### PR TITLE
Remove avg loss logic from trainer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+
+install:
+  - sudo apt-get update
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION enum34 numpy mock
+  - source activate test-environment
+  - python setup.py install
+  - pip install --upgrade pytest
+
+script:
+  - pytest test/
+
+matrix:
+  include:
+    - env: LINT_CHECK
+      python: "2.7"
+      install: pip install flake8
+      script: flake8

--- a/ignite/trainer.py
+++ b/ignite/trainer.py
@@ -35,15 +35,16 @@ class Trainer(object):
     """
     Generic trainer class.
 
-    Training update and validation functions receive batches of data and return loss values.
-    Each function may return several losses (e.g., cross-entropy and classification accuracy).
-    This class will keep track of the best parameter setting achieved during training, but will only
-    consider the first loss if multiple losses are returned by training or validation functions.
+    Training update and validation functions receive batches of data and return values which will
+    be stored in the `training_history` and `validation_history`. The trainer defines multiple
+    events in `TrainingEvents` for which the user can attach event handlers to. The events get
+    passed the trainer, so they can access the training/validation history
+
 
     Parameters
     ----------
     training_data : Iterable
-        Collection of training batches allowing repeated iteration (e.g., list or DataLoaderManager)
+        Collection of training batches allowing repeated iteration (e.g., list or DataLoader)
 
     training_update_function : callable
         Update function receiving the current training batch in each iteration
@@ -71,11 +72,8 @@ class Trainer(object):
         self._validation_inference_function = validation_inference_function
         self._event_listeners = {}
 
-        self.training_losses = []
-        self.avg_training_loss_per_epoch = []
-        self.best_training_loss = [np.inf]
-        self.avg_validation_loss = []
-        self.best_validation_loss = [np.inf]
+        self.training_history = []
+        self.validation_history = []
         self.current_iteration = 0
         self.current_validation_iteration = 0
         self.current_epoch = 0
@@ -128,131 +126,58 @@ class Trainer(object):
         start_time = time.time()
 
         self.epoch_losses = []
-        for _, batch in enumerate(self._training_data,
-                                  1):  # enumerate used to support PyTorch DataLoader
+        for _, batch in enumerate(self._training_data, 1):
             self._fire_event(TrainingEvents.TRAINING_ITERATION_STARTED)
-            loss = self._training_update_function(batch)
 
-            if not isinstance(loss, Iterable):
-                loss = [loss]
+            training_step_result = self._training_update_function(batch)
+            if training_step_result is not None:
+                self.training_history.append(training_step_result)
 
-            if np.any(np.equal(loss, None)):
-                raise ValueError("The loss contains None values.")
-
-            self.epoch_losses.append(loss)
-            self.training_losses.append(loss)
             self.current_iteration += 1
 
             self._fire_event(TrainingEvents.TRAINING_ITERATION_COMPLETED)
             if self.should_terminate:
                 return
 
-        if len(self.epoch_losses) == 0:
-            raise ValueError("There are no iteration losses. \
-            Likely this was caused by an empty training data iterable.")
-        else:
-            avg_loss = np.mean(self.epoch_losses, 0)
-
-        if not isinstance(avg_loss, Iterable):
-            avg_loss = [avg_loss]
-
-        self.avg_training_loss_per_epoch.append(avg_loss)
-        if avg_loss[0] < self.best_training_loss[0]:
-            self.best_training_loss = avg_loss
-
         time_taken = time.time() - start_time
         hours, mins, secs = _to_hours_mins_secs(time_taken)
-        self._logger.info("Epoch[%s]: Avg. Loss: %s \t Best Loss: %s \t Time Taken: %d:%d:%d",
-                          self.current_epoch,
-                          avg_loss, self.best_training_loss, hours, mins, secs)
+        self._logger.info("Epoch[%s] Complete. Time taken: %d:%d:%d", self.current_epoch, hours,
+                          mins, secs)
 
         self._fire_event(TrainingEvents.TRAINING_EPOCH_COMPLETED)
 
-        # don't serialize epoch-wise losses
-        del self.epoch_losses
-
-        return avg_loss
-
     def validate(self):
-        """ Evaluates the validation set and updates the best model loss """
+        """ Evaluates the validation set"""
         if self._validation_data is None:
-            self._update_best_model_loss()
             return
 
         self.current_validation_iteration = 0
         self._fire_event(TrainingEvents.VALIDATION_STARTING)
         start_time = time.time()
-        losses = []
-        for _, batch in enumerate(self._validation_data,
-                                  1):  # enumerate used to support PyTorch DataLoader
+
+        for _, batch in enumerate(self._validation_data, 1):
             self._fire_event(TrainingEvents.VALIDATION_ITERATION_STARTED)
-            loss = self._validation_inference_function(batch)
+            validation_step_result = self._validation_inference_function(batch)
+            if validation_step_result is not None:
+                self.validation_history.append(validation_step_result)
 
-            if not isinstance(loss, Iterable):
-                loss = [loss]
-
-            if np.any(np.equal(loss, None)):
-                raise ValueError("The loss contains None values.")
-
-            losses.append(loss)
             self.current_validation_iteration += 1
             self._fire_event(TrainingEvents.VALIDATION_ITERATION_COMPLETED)
             if self.should_terminate:
                 break
 
-        if len(losses) == 0:
-            raise ValueError("There are no iteration losses. \
-            Likely this was caused by an empty validation data iterable.")
-        else:
-            avg_loss = np.mean(losses, 0)
-
-        if not isinstance(avg_loss, Iterable):
-            avg_loss = [avg_loss]
-
-        self.avg_validation_loss.append(avg_loss)
-        if avg_loss[0] < self.best_validation_loss[0]:
-            self.best_validation_loss = avg_loss
-
         time_taken = time.time() - start_time
         hours, mins, secs = _to_hours_mins_secs(time_taken)
-        self._logger.info("Validation: Avg. Loss: %s \t Best Loss: %s \t Time Taken: %d:%d:%d",
-                          avg_loss,
-                          self.best_validation_loss, hours, mins, secs)
+        self._logger.info("Validation Complete. Time taken: %d:%d:%d", hours, mins, secs)
 
-        self._update_best_model_loss()
         self._fire_event(TrainingEvents.VALIDATION_COMPLETED)
-
-        return avg_loss
-
-    def _update_best_model_loss(self):
-        """
-        If the loss has improved, stores the current best loss.
-
-        Uses the validation loss if validation data is available, otherwise uses the training loss.
-        """
-
-        # obtain best guess of loss corresponding to current set of parameters
-        current_loss = np.inf
-        if self._validation_data:
-            if self.avg_validation_loss:
-                current_loss = self.avg_validation_loss[-1]
-        elif self.avg_training_loss_per_epoch:
-            current_loss = self.avg_training_loss_per_epoch[-1]
-        # use first loss when multiple losses present
-        if isinstance(current_loss, Iterable):
-            current_loss = current_loss[0]
-
-        if current_loss < self._best_model_parameter_loss:
-            self._logger.info("Updating best model loss")
-            self._fire_event(TrainingEvents.BEST_LOSS_UPDATED)
-            self._best_model_parameter_loss = current_loss
 
     def terminate(self):
         """
-        Sends terminate signal to trainer, so that training terminates after the current epoch finishes
+        Sends terminate signal to trainer, so that training terminates after the current iteration
         """
-        self._logger.info(
-            "Terminate signaled to trainer. Training will stop after current epoch is finished")
+        self._logger.info("Terminate signaled to trainer. " +
+                          "Training will stop after current iteration is finished")
         self.should_terminate = True
 
     def run(self, max_epochs=1, validate_every_epoch=True):
@@ -289,8 +214,7 @@ class Trainer(object):
                     self.validate()
                     if self.should_terminate:
                         break
-                else:
-                    self._update_best_model_loss()
+
                 self._fire_event(TrainingEvents.EPOCH_COMPLETED)
                 self.current_epoch += 1
 
@@ -303,10 +227,3 @@ class Trainer(object):
             self._logger.error("Training is terminating due to exception: %s", str(e))
             self._fire_event(TrainingEvents.EXCEPTION_RAISED)
             raise e
-
-    def __getstate__(self):
-        return {key: self.__dict__[key] for key in self.__dict__.keys() if key != "_logger"}
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self._logger = self._get_logger()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -50,36 +50,10 @@ def test_adding_handler_for_non_existent_event_throws_error():
     trainer.add_event_listener(event_name, lambda x: x)
 
 
-def test_update_function_returning_none_throws_error():
-  trainer = Trainer([1], MagicMock(return_value=None), MagicMock(), MagicMock())
-
-  with raises(ValueError):
-    trainer.run()
-
-
-def test_validation_function_returning_none_throws_error():
-  trainer = Trainer([1], MagicMock(return_value=1), [1], MagicMock(return_value=None))
-
-  with raises(ValueError):
-    trainer.run()
-
-
-def test_empty_trainingdata_iterable_throws_error():
-  trainer = Trainer(MagicMock(), MagicMock(return_value=1), MagicMock(), MagicMock())
-
-  with raises(ValueError):
-    trainer.run()
-
-
-def test_empty_validationdata_iterable_throws_error():
-  trainer = Trainer([1], MagicMock(return_value=1), MagicMock(), MagicMock())
-
-  with raises(ValueError):
-    trainer.run()
-
-
 def test_exception_handler_called_on_error():
-  trainer = Trainer([1], MagicMock(return_value=None), MagicMock(), MagicMock())
+  training_update_function = MagicMock(side_effect=ValueError())
+
+  trainer = Trainer([1], training_update_function, MagicMock(), MagicMock())
   exception_handler = MagicMock()
   trainer.add_event_listener(TrainingEvents.EXCEPTION_RAISED, exception_handler)
 
@@ -321,19 +295,20 @@ def test_terminate_after_training_iteration_skips_validation_run():
   assert trainer.validate.call_count == 0
 
 
-def _create_mock_data_loader_manager(epochs, batches_per_epoch):
+def _create_mock_data_loader(epochs, batches_per_epoch):
   batches = [MagicMock()] * batches_per_epoch
   data_loader_manager = MagicMock()
   batch_iterators = [iter(batches) for _ in range(epochs)]
 
   data_loader_manager.__iter__.side_effect = batch_iterators
+
   return data_loader_manager
 
 
 def test_training_iteration_events_are_fired():
   max_epochs = 5
   num_batches = 3
-  training_data = _create_mock_data_loader_manager(max_epochs, num_batches)
+  training_data = _create_mock_data_loader(max_epochs, num_batches)
 
   trainer = Trainer(training_data=training_data,
                     validation_data=MagicMock(),
@@ -366,7 +341,7 @@ def test_training_iteration_events_are_fired():
 def test_validation_iteration_events_are_fired():
   max_epochs = 5
   num_batches = 3
-  validation_data = _create_mock_data_loader_manager(max_epochs, num_batches)
+  validation_data = _create_mock_data_loader(max_epochs, num_batches)
 
   trainer = Trainer(training_data=[None],
                     validation_data=validation_data,
@@ -399,7 +374,7 @@ def test_validation_iteration_events_are_fired():
 def test_validation_iteration_events_are_fired_when_validate_is_called_explicitly():
   max_epochs = 5
   num_batches = 3
-  validation_data = _create_mock_data_loader_manager(max_epochs, num_batches)
+  validation_data = _create_mock_data_loader(max_epochs, num_batches)
 
   trainer = Trainer(training_data=[None],
                     validation_data=validation_data,
@@ -423,150 +398,3 @@ def test_validation_iteration_events_are_fired_when_validate_is_called_explicitl
 
   assert iteration_started.call_count == num_batches
   assert iteration_complete.call_count == num_batches
-
-
-@mark.parametrize("training_update_losses_per_batch, avg_loss_per_epoch, batches_per_epoch",
-                  [([1, 2, 3, 4], [np.array([1.5]), np.array([3.5])], 2),
-                   ([(1, 5), (2, 6), (3, 7), (4, 8)], [np.array([1.5, 5.5]), np.array([3.5, 7.5])],
-                    2)])
-def test_avg_training_loss_per_epoch_updates_correctly(training_update_losses_per_batch,
-                                                       avg_loss_per_epoch,
-                                                       batches_per_epoch):
-  max_epochs = len(training_update_losses_per_batch) // batches_per_epoch
-  training_data = _create_mock_data_loader_manager(max_epochs, batches_per_epoch)
-
-  trainer = Trainer(training_data=training_data,
-                    validation_data=MagicMock(),
-                    training_update_function=MagicMock(
-                        side_effect=training_update_losses_per_batch),
-                    validation_inference_function=MagicMock())
-
-  trainer.run(max_epochs=max_epochs, validate_every_epoch=False)
-
-  assert np.array_equal(trainer.avg_training_loss_per_epoch, avg_loss_per_epoch)
-  assert np.array_equal(trainer.best_training_loss, np.min(avg_loss_per_epoch, axis=0))
-
-
-@mark.parametrize("validation_update_losses_per_batch, avg_loss_per_epoch, batches_per_epoch",
-                  [([1, 2, 3, 4], [np.array([1.5]), np.array([3.5])], 2),
-                   ([(1, 2), (2, 1), (3, 4), (4, 5)], [(1.5, 1.5), (3.5, 4.5)], 2)])
-def test_avg_validation_loss_per_epoch_updates_correctly(validation_update_losses_per_batch,
-                                                         avg_loss_per_epoch,
-                                                         batches_per_epoch):
-  max_epochs = len(validation_update_losses_per_batch) // batches_per_epoch
-
-  validation_data_loader_manager = _create_mock_data_loader_manager(max_epochs, batches_per_epoch)
-
-  trainer = Trainer(training_data=[1],
-                    validation_data=validation_data_loader_manager,
-                    training_update_function=MagicMock(return_value=1),
-                    validation_inference_function=MagicMock(
-      side_effect=validation_update_losses_per_batch))
-
-  trainer.run(max_epochs=max_epochs)
-
-  assert np.array_equal(trainer.avg_validation_loss, avg_loss_per_epoch)
-  assert np.array_equal(trainer.best_validation_loss, min(avg_loss_per_epoch, key=lambda a: a[0]))
-
-
-@mark.parametrize(
-    "validation_update_losses_per_batch, batches_per_epoch, expected_number_of_updates",
-    [([7, 6, 6, 6, 6, 7, 5, 5], 2, 3),
-     ([(7, 2), (6, 1), (6, 1), (6, 0), (6, 0), (7, 1), (5, 0), (5, 0)], 2, 3),
-        (
-        [(7, 3, 2), (6, 2, 1), (6, 2, 1), (6, 2, 0), (6, 1, 0), (7, 0, 1), (5, 1, 0), (5, 0, 0)], 2,
-        3)])
-def test_best_loss_updates_if_validation_loss_reduces(validation_update_losses_per_batch,
-                                                      batches_per_epoch,
-                                                      expected_number_of_updates):
-  max_epochs = len(validation_update_losses_per_batch) // batches_per_epoch
-
-  validation_data_loader_manager = _create_mock_data_loader_manager(max_epochs, batches_per_epoch)
-
-  training_data = [1]
-  training_update_function = MagicMock()
-  training_data = _create_mock_data_loader_manager(max_epochs, batches_per_epoch)
-  training_update_function = MagicMock(side_effect=validation_update_losses_per_batch)
-
-  def check_loss_update(trainer):
-    best_validation_loss = trainer.best_validation_loss
-    last_validation_loss = trainer.avg_validation_loss[-1]
-    assert (best_validation_loss == last_validation_loss).all()
-
-  trainer = Trainer(training_data=training_data,
-                    validation_data=validation_data_loader_manager,
-                    training_update_function=training_update_function,
-                    validation_inference_function=MagicMock(
-                        side_effect=validation_update_losses_per_batch))
-
-  trainer.add_event_listener(TrainingEvents.BEST_LOSS_UPDATED, check_loss_update)
-
-  counter = MagicMock()
-  trainer.add_event_listener(TrainingEvents.BEST_LOSS_UPDATED, counter)
-
-  trainer.run(max_epochs=max_epochs)
-
-  assert counter.call_count == expected_number_of_updates
-
-
-@mark.parametrize("validate_every_epoch", [True, False])
-@mark.parametrize("training_update_loss_per_batch, batches_per_epoch, expected_number_of_updates",
-                  [([7, 6, 6, 6, 6, 7, 5, 5], 2, 3),
-                   ([(7, 2), (6, 1), (6, 1), (6, 0), (6, 0), (7, 1), (5, 0), (5, 0)], 2, 3),
-                   ([(7, 3, 2), (6, 2, 1), (6, 2, 1), (6, 2, 0), (6, 1, 0), (7, 0, 1), (5, 1, 0),
-                     (5, 0, 0)], 2, 3)])
-def test_best_loss_updates_if_no_validation_loss_and_training_loss_reduces(
-        training_update_loss_per_batch,
-        batches_per_epoch,
-        expected_number_of_updates,
-        validate_every_epoch):
-  max_epochs = len(training_update_loss_per_batch) // batches_per_epoch
-
-  training_data = _create_mock_data_loader_manager(max_epochs, batches_per_epoch)
-
-  def check_loss_update(trainer):
-    best_training_loss = trainer.best_training_loss
-    last_training_loss = trainer.avg_training_loss_per_epoch[-1]
-    assert (best_training_loss == last_training_loss).all()
-
-  trainer = Trainer(training_data=training_data,
-                    training_update_function=MagicMock(side_effect=training_update_loss_per_batch))
-
-  trainer.add_event_listener(TrainingEvents.BEST_LOSS_UPDATED, check_loss_update)
-
-  counter = MagicMock()
-  trainer.add_event_listener(TrainingEvents.BEST_LOSS_UPDATED, counter)
-
-  trainer.run(max_epochs=max_epochs, validate_every_epoch=validate_every_epoch)
-
-  assert counter.call_count == expected_number_of_updates
-
-
-@mark.parametrize("validate_every_epoch", [True, False])
-@mark.parametrize("num_training_batches", [1, 5])
-def test_best_loss_updates_if_validate_is_called_irregularly(num_training_batches,
-                                                             validate_every_epoch):
-  max_epochs = 10
-  num_validation_batches = 2
-
-  def update(*args):
-    return np.random.randn()
-
-  def validate(*args):
-    return np.random.randn()
-
-  def validate_or_not(trainer):
-    if trainer.current_iteration % 3 == 0:
-      trainer.validate()
-
-  trainer = Trainer(
-      training_data=[None] * num_training_batches,
-      training_update_function=update,
-      validation_data=[None] * num_validation_batches,
-      validation_inference_function=validate)
-
-  trainer.add_event_listener(TrainingEvents.TRAINING_ITERATION_COMPLETED, validate_or_not)
-
-  trainer.run(max_epochs=max_epochs, validate_every_epoch=validate_every_epoch)
-
-  assert np.isclose(np.min(trainer.avg_training_loss_per_epoch), trainer.best_training_loss)


### PR DESCRIPTION
As discussed with @fmassa we should remove the logic that tracks best loss and average loss from the trainer. This can prove troublesome if you want to do the following:

1) minimise NLL
2) snapshot the model with the highest accuracy returned from validate

The current logic assumes you are always minimizing some loss and stores the "best" validation loss as the minimum. You can make the above scenario work but its a bit hacky.

This PR just saves the results of the `training_update_function` and the `validation_update_function` to `training_history` and `validation_history` which are accessible to the event handlers (so averages can be computed and models can be snaphsotted).

We may want to swap the `training_history` and `validation_history` from a list to a `History` object which provides convenience methods to calculate rolling averages etc, but this can be done in another PR once we settle on the design.  


I also removed the associated tests, and changed some of the docstrings.