### PR TITLE
introduce Supervised wrapper

### DIFF
--- a/ignite/wrappers/__init__.py
+++ b/ignite/wrappers/__init__.py
@@ -1,0 +1,1 @@
+from .supervised import Supervised

--- a/ignite/wrappers/supervised.py
+++ b/ignite/wrappers/supervised.py
@@ -1,5 +1,6 @@
 from torch.autograd import Variable
 
+
 class Supervised(object):
     """
     Provides training and validation update functions for standard supervised models.

--- a/ignite/wrappers/supervised.py
+++ b/ignite/wrappers/supervised.py
@@ -50,7 +50,7 @@ class Supervised(object):
         self._model.eval()
         x, y = self._prepare_batch(batch)
         y_pred = self._model(x)
-        return y_pred, y
+        return y_pred.data.cpu(), y.data.cpu()
 
     def _prepare_batch(self, batch):
         x, y = batch

--- a/ignite/wrappers/supervised.py
+++ b/ignite/wrappers/supervised.py
@@ -1,0 +1,58 @@
+from torch.autograd import Variable
+
+class Supervised(object):
+    """
+    Provides training and validation update functions for standard supervised models.
+
+    Args:
+        model (torch.nn.Module): the model to train
+        optimizer (torch.optim.Optimizer): the optimizer to use
+        loss_fn (torch.nn loss function): the loss function to use
+        cuda (bool, optional): whether or not to transfer batch to GPU (default: False)
+
+    """
+    def __init__(self, model, optimizer, loss_fn, cuda=False):
+        self._model = model
+        self._optimizer = optimizer
+        self._loss_fn = loss_fn
+        self._cuda = cuda
+
+    def update(self, batch):
+        """
+        Training update function.
+
+        Args:
+            batch (tuple): the model input and target
+
+        Returns:
+            float: the batch loss
+        """
+        self._model.train()
+        self._optimizer.zero_grad()
+        x, y = self._prepare_batch(batch)
+        y_pred = self._model(x)
+        loss = self._loss_fn(y_pred, y)
+        loss.backward()
+        self._optimizer.step()
+        return loss.data[0]
+
+    def predict(self, batch):
+        """
+        Validation update function.
+
+        Args:
+            batch (tuple): the model input and target
+
+        Returns:
+            tuple: the prediction and the target
+        """
+        self._model.eval()
+        x, y = self._prepare_batch(batch)
+        y_pred = self._model(x)
+        return y_pred, y
+
+    def _prepare_batch(self, batch):
+        x, y = batch
+        if self._cuda:
+            x, y = x.cuda(), y.cuda()
+        return Variable(x), Variable(y)

--- a/ignite/wrappers/supervised.py
+++ b/ignite/wrappers/supervised.py
@@ -35,7 +35,7 @@ class Supervised(object):
         loss = self._loss_fn(y_pred, y)
         loss.backward()
         self._optimizer.step()
-        return loss.data[0]
+        return loss.data.cpu()[0]
 
     def predict(self, batch):
         """

--- a/ignite/wrappers/supervised.py
+++ b/ignite/wrappers/supervised.py
@@ -39,7 +39,7 @@ class Supervised(object):
 
     def predict(self, batch):
         """
-        Validation update function.
+        Validation inference function.
 
         Args:
             batch (tuple): the model input and target

--- a/tests/ignite/wrappers/test_supervised.py
+++ b/tests/ignite/wrappers/test_supervised.py
@@ -45,7 +45,7 @@ def test_predict():
     batch = _build_batch()
     y_pred, y = wrapper.predict(batch)
 
-    _assert_almost_equal(y_pred.data[0, 0], 0.0)
-    _assert_almost_equal(y_pred.data[1, 0], 0.0)
-    _assert_almost_equal(y.data[0, 0], 3.0)
-    _assert_almost_equal(y.data[1, 0], 5.0)
+    _assert_almost_equal(y_pred[0, 0], 0.0)
+    _assert_almost_equal(y_pred[1, 0], 0.0)
+    _assert_almost_equal(y[0, 0], 3.0)
+    _assert_almost_equal(y[1, 0], 5.0)

--- a/tests/ignite/wrappers/test_supervised.py
+++ b/tests/ignite/wrappers/test_supervised.py
@@ -6,13 +6,16 @@ from torch.nn.functional import mse_loss
 
 from ignite.wrappers import Supervised
 
+
 def _build_batch():
     x = torch.FloatTensor([[1.0], [2.0]])
     y = torch.FloatTensor([[3.0], [5.0]])
     return x, y
 
+
 def _assert_almost_equal(a, b):
     assert round(a - b, 5) == 0
+
 
 def test_update():
     model = Linear(1, 1)
@@ -30,6 +33,7 @@ def test_update():
     _assert_almost_equal(loss, 17.0)
     _assert_almost_equal(model.weight.data[0, 0], 1.3)
     _assert_almost_equal(model.bias.data[0], 0.8)
+
 
 def test_predict():
     model = Linear(1, 1)

--- a/tests/ignite/wrappers/test_supervised.py
+++ b/tests/ignite/wrappers/test_supervised.py
@@ -1,0 +1,47 @@
+import torch
+from torch.nn import Linear
+from torch.optim import SGD
+from torch.autograd import Variable
+from torch.nn.functional import mse_loss
+
+from ignite.wrappers import Supervised
+
+def _build_batch():
+    x = torch.FloatTensor([[1.0], [2.0]])
+    y = torch.FloatTensor([[3.0], [5.0]])
+    return x, y
+
+def _assert_almost_equal(a, b):
+    assert round(a - b, 5) == 0
+
+def test_update():
+    model = Linear(1, 1)
+    model.weight.data.zero_()
+    model.bias.data.zero_()
+    optimizer = SGD(model.parameters(), 0.1)
+    wrapper = Supervised(model, optimizer, mse_loss)
+
+    _assert_almost_equal(model.weight.data[0, 0], 0.0)
+    _assert_almost_equal(model.bias.data[0], 0.0)
+
+    batch = _build_batch()
+    loss = wrapper.update(batch)
+
+    _assert_almost_equal(loss, 17.0)
+    _assert_almost_equal(model.weight.data[0, 0], 1.3)
+    _assert_almost_equal(model.bias.data[0], 0.8)
+
+def test_predict():
+    model = Linear(1, 1)
+    model.weight.data.zero_()
+    model.bias.data.zero_()
+    optimizer = SGD(model.parameters(), 0.1)
+    wrapper = Supervised(model, optimizer, mse_loss)
+
+    batch = _build_batch()
+    y_pred, y = wrapper.predict(batch)
+
+    _assert_almost_equal(y_pred.data[0, 0], 0.0)
+    _assert_almost_equal(y_pred.data[1, 0], 0.0)
+    _assert_almost_equal(y.data[0, 0], 3.0)
+    _assert_almost_equal(y.data[1, 0], 5.0)

--- a/tests/ignite/wrappers/test_supervised.py
+++ b/tests/ignite/wrappers/test_supervised.py
@@ -3,6 +3,7 @@ from torch.nn import Linear
 from torch.optim import SGD
 from torch.autograd import Variable
 from torch.nn.functional import mse_loss
+from pytest import approx
 
 from ignite.wrappers import Supervised
 
@@ -13,10 +14,6 @@ def _build_batch():
     return x, y
 
 
-def _assert_almost_equal(a, b):
-    assert round(a - b, 5) == 0
-
-
 def test_update():
     model = Linear(1, 1)
     model.weight.data.zero_()
@@ -24,15 +21,15 @@ def test_update():
     optimizer = SGD(model.parameters(), 0.1)
     wrapper = Supervised(model, optimizer, mse_loss)
 
-    _assert_almost_equal(model.weight.data[0, 0], 0.0)
-    _assert_almost_equal(model.bias.data[0], 0.0)
+    assert model.weight.data[0, 0] == approx(0.0)
+    assert model.bias.data[0] == approx(0.0)
 
     batch = _build_batch()
     loss = wrapper.update(batch)
 
-    _assert_almost_equal(loss, 17.0)
-    _assert_almost_equal(model.weight.data[0, 0], 1.3)
-    _assert_almost_equal(model.bias.data[0], 0.8)
+    assert loss == approx(17.0)
+    assert model.weight.data[0, 0] == approx(1.3)
+    assert model.bias.data[0] == approx(0.8)
 
 
 def test_predict():
@@ -45,7 +42,7 @@ def test_predict():
     batch = _build_batch()
     y_pred, y = wrapper.predict(batch)
 
-    _assert_almost_equal(y_pred[0, 0], 0.0)
-    _assert_almost_equal(y_pred[1, 0], 0.0)
-    _assert_almost_equal(y[0, 0], 3.0)
-    _assert_almost_equal(y[1, 0], 5.0)
+    assert y_pred[0, 0] == approx(0.0)
+    assert y_pred[1, 0] == approx(0.0)
+    assert y[0, 0] == approx(3.0)
+    assert y[1, 0] == approx(5.0)


### PR DESCRIPTION
Resolves #38 

@alykhantejani couple things to sort out before this can be merged...

- do you have a strong preference on docstring format? I used google style here to be consistent with pytorch itself
- how do you feel about the "wrapper" name? Is it too generic or is it alright?
- I swapped the order of y, y_pred in the return of `predict` to be consistent with loss functions in pytorch
- I haven't updated the readme or examples but i figured it might be best to do that once we wrap up the other remaining issues. Is that alright with you?

Let me know if you have any other feedback on this.