### PR TITLE
return relevant history from 'run' and 'validate'

### DIFF
--- a/ignite/trainer/trainer.py
+++ b/ignite/trainer/trainer.py
@@ -160,6 +160,8 @@ class Trainer(object):
 
         self._fire_event(TrainingEvents.VALIDATION_COMPLETED)
 
+        return self.validation_history
+
     def terminate(self):
         """
         Sends terminate signal to trainer, so that training terminates after the current iteration
@@ -184,7 +186,7 @@ class Trainer(object):
 
         Returns
         -------
-        None
+        History: the training history
         """
 
         try:
@@ -209,6 +211,7 @@ class Trainer(object):
             mins, secs = divmod(time_taken, 60)
             hours, mins = divmod(mins, 60)
             self._logger.info("Training complete. Time taken %02d:%02d:%02d" % (hours, mins, secs))
+            return self.training_history
         except BaseException as e:
             self._logger.error("Training is terminating due to exception: %s", str(e))
             self._fire_event(TrainingEvents.EXCEPTION_RAISED)

--- a/tests/ignite/trainer/test_trainer.py
+++ b/tests/ignite/trainer/test_trainer.py
@@ -393,8 +393,8 @@ def test_create_supervised():
     y = torch.FloatTensor([[3.0], [5.0]])
     data = [(x, y)]
 
-    trainer.validate(data)
-    y_pred, y = trainer.validation_history[0]
+    validation_history = trainer.validate(data)
+    y_pred, y = validation_history[0]
 
     assert y_pred[0, 0] == approx(0.0)
     assert y_pred[1, 0] == approx(0.0)
@@ -404,9 +404,8 @@ def test_create_supervised():
     assert model.weight.data[0, 0] == approx(0.0)
     assert model.bias.data[0] == approx(0.0)
 
-    trainer.run(data)
-    loss = trainer.training_history[0]
+    training_history = trainer.run(data)
 
-    assert loss == approx(17.0)
+    assert training_history[0] == approx(17.0)
     assert model.weight.data[0, 0] == approx(1.3)
     assert model.bias.data[0] == approx(0.8)


### PR DESCRIPTION
This is purely for convenience but I think it is quite common that people will want to access the history right after. I'm already finding this in my own work.