### PR TITLE
attach current batch to trainer

### DIFF
--- a/ignite/trainer/trainer.py
+++ b/ignite/trainer/trainer.py
@@ -61,6 +61,8 @@ class Trainer(object):
 
         self.training_history = History()
         self.validation_history = History()
+        self.current_batch = None
+        self.current_validation_batch = None
         self.current_iteration = 0
         self.current_validation_iteration = 0
         self.current_epoch = 0
@@ -138,6 +140,7 @@ class Trainer(object):
 
         self.epoch_losses = []
         for _, batch in enumerate(training_data, 1):
+            self.current_batch = batch
             self._fire_event(TrainingEvents.TRAINING_ITERATION_STARTED)
 
             training_step_result = self._training_update_function(batch)
@@ -167,6 +170,7 @@ class Trainer(object):
         start_time = time.time()
 
         for _, batch in enumerate(validation_data, 1):
+            self.current_validation_batch = batch
             self._fire_event(TrainingEvents.VALIDATION_ITERATION_STARTED)
             validation_step_result = self._validation_inference_function(batch)
             if validation_step_result is not None:

--- a/tests/ignite/trainer/test_trainer.py
+++ b/tests/ignite/trainer/test_trainer.py
@@ -96,6 +96,34 @@ def test_args_and_kwargs_are_passed_to_event():
         assert handler_kwargs == kwargs
 
 
+def test_current_batch_is_set_every_iteration():
+    training_batches = [1, 2, 3]
+    trainer = Trainer(MagicMock(), MagicMock())
+
+    def batch_accumulator(trainer, acc):
+        acc.append(trainer.current_batch)
+
+    accumulated = []
+    trainer.add_event_handler(TrainingEvents.TRAINING_ITERATION_STARTED, batch_accumulator, accumulated)
+    trainer.run(training_batches)
+
+    assert accumulated == training_batches
+
+
+def test_current_validation_batch_is_set_every_iteration():
+    validation_batches = [1, 2, 3]
+    trainer = Trainer(MagicMock(), MagicMock())
+
+    def batch_accumulator(trainer, acc):
+        acc.append(trainer.current_validation_batch)
+
+    accumulated = []
+    trainer.add_event_handler(TrainingEvents.VALIDATION_ITERATION_STARTED, batch_accumulator, accumulated)
+    trainer.validate(validation_batches)
+
+    assert accumulated == validation_batches
+
+
 def test_current_epoch_counter_increases_every_epoch():
     trainer = Trainer(MagicMock(return_value=1), MagicMock())
     max_epochs = 5


### PR DESCRIPTION
This is necessary in order to support rendering input samples during training (hat tip @eifuentes).

We talked about it a bit in #37, but I wonder if we should more seriously consider introducing a `state` dict/object that gets passed to each handler. With this PR, we now have several `current_*` attributes that might make more sense in `state`.

What do you think @alykhantejani?