### PR TITLE
Add ignore_exceptions flag to Trainer.run

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,7 @@ The following example shows how to register a handler which will save the model 
         raise exception
 
     trainer.add_event_handler(Events.EXCEPTION_RAISED,
+                              save_and_raise,
                               my_model,
                               '/tmp/my_model.pth')
 

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ The :code:`Trainer` emits events during the training loop, which the user can at
 - TRAINING_ITERATION_COMPLETED
 - VALIDATION_ITERATION_STARTED
 - VALIDATION_ITERATION_COMPLETED
-- EXCEPTION_RAISED
+- EXCEPTION_RAISED (see `Note on EXCEPTION_RAISED`_ below)
 
 Users can attach multiple handlers to each of these events, which allows them to control aspects of training such as 
 early stopping, or reducing the learning rate as well as things such as logging or updating external dashboards like
@@ -118,6 +118,28 @@ Event handlers are any callable where the first argument is an instance of the :
                               early_stopping_handler,
                               min_iterations,
                               lookback=5)
+
+Note on EXCEPTION_RAISED
+^^^^^^^^^^^^^^^^^^^^^^^^
+By default :code:`Ignite` will re-raise any exception caught during training. If you would like to change this
+behaviour, you have to register an handler for the :code:`EXCEPTION_RAISED` event. This handler will be called with
+the :code:`Engine` object and the caught :code:`Exception` as two first arguments, followed by any :code:`*args` and
+:code:`**kwargs` passed to :code:`add_event_handler` call. If this handler is registered, :code:`Ignite` will not
+re-raise the exception.
+
+The following example shows how to register a handler which will save the model before re-rasing the exception.
+
+.. code-block:: python
+
+    from ignite.engine import Events
+
+    def save_and_raise(engine, exception, model, path):
+        torch.save(model, path)
+        raise exception
+
+    trainer.add_event_handler(Events.EXCEPTION_RAISED,
+                              my_model,
+                              '/tmp/my_model.pth')
 
 Logging
 +++++++

--- a/ignite/engine.py
+++ b/ignite/engine.py
@@ -93,11 +93,11 @@ class Engine(object):
             return f
         return decorator
 
-    def _fire_event(self, event_name):
+    def _fire_event(self, event_name, *event_args):
         if event_name in self._event_handlers.keys():
             self._logger.debug("firing handlers for event %s ", event_name)
             for func, args, kwargs in self._event_handlers[event_name]:
-                func(self, *args, **kwargs)
+                func(self, *(event_args + args), **kwargs)
 
     def terminate(self):
         """
@@ -126,7 +126,12 @@ class Engine(object):
             return hours, mins, secs
         except BaseException as e:
             self._logger.error("Current run is terminating due to exception: %s", str(e))
-            self._fire_event(Events.EXCEPTION_RAISED)
+            self._handle_exception(e)
+
+    def _handle_exception(self, e):
+        if Events.EXCEPTION_RAISED in self._event_handlers:
+            self._fire_event(Events.EXCEPTION_RAISED, e)
+        else:
             raise e
 
     @abstractmethod

--- a/ignite/trainer.py
+++ b/ignite/trainer.py
@@ -29,14 +29,13 @@ class Trainer(Engine):
         super(Trainer, self).__init__(training_update_function)
         self.current_epoch = 0
         self.max_epochs = 0
-        self.exception = None
 
     def _train_one_epoch(self, training_data):
         hours, mins, secs = self._run_once_on_dataset(training_data)
         self._logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.current_epoch, hours,
                           mins, secs)
 
-    def run(self, training_data, max_epochs=1, ignore_exceptions=False):
+    def run(self, training_data, max_epochs=1):
         """
         Train the model, evaluate the validation set and update best parameters if the validation loss
         improves.
@@ -49,9 +48,6 @@ class Trainer(Engine):
             Collection of training batches allowing repeated iteration (e.g., list or DataLoader)
         max_epochs: int, optional
             max epochs to train for [default=1]
-        ignore_exceptions: bool, optional
-            if `True`, then exceptions raised inside the training loop will not be re-raised, and
-            you should handle them in the appropriate handler (for `Events.EXCEPTION_RAISED` event)
 
         Notes
         -----
@@ -88,13 +84,8 @@ class Trainer(Engine):
             self._logger.info("Training complete. Time taken %02d:%02d:%02d" % (hours, mins, secs))
 
         except BaseException as e:
-            self.exception = e
-
             self._logger.error("Training is terminating due to exception: %s", str(e))
-            self._fire_event(Events.EXCEPTION_RAISED)
-
-            if ignore_exceptions is False:
-                raise e
+            self._handle_exception(e)
 
 
 def create_supervised_trainer(model, optimizer, loss_fn, cuda=False):

--- a/ignite/trainer.py
+++ b/ignite/trainer.py
@@ -49,11 +49,6 @@ class Trainer(Engine):
         max_epochs: int, optional
             max epochs to train for [default=1]
 
-        Notes
-        -----
-        Caught exception is stored in the `exception` attribute so that it can be easily
-        accessed from the handler function via `trainer.exception`
-
         Returns
         -------
         None

--- a/tests/ignite/test_trainer.py
+++ b/tests/ignite/test_trainer.py
@@ -40,18 +40,25 @@ class _PicklableMagicMock(object):
         return self.uuid
 
 
-def test_exception_handler_called_on_error():
+def test_default_exception_handler():
     training_update_function = MagicMock(side_effect=ValueError())
-
     trainer = Trainer(training_update_function)
-    exception_handler = MagicMock()
-    trainer.add_event_handler(Events.EXCEPTION_RAISED, exception_handler)
 
     with raises(ValueError):
         trainer.run([1])
 
-    # one call from _run_once_over_data and one from the run function in the trainer
-    exception_handler.assert_has_calls([call(trainer), call(trainer)])
+
+def test_custom_exception_handler():
+    value_error = ValueError()
+    training_update_function = MagicMock(side_effect=value_error)
+
+    trainer = Trainer(training_update_function)
+    exception_handler = MagicMock()
+    trainer.add_event_handler(Events.EXCEPTION_RAISED, exception_handler)
+    trainer.run([1])
+
+    # only one call from _run_once_over_data, since the exception is swallowed
+    exception_handler.assert_has_calls([call(trainer, value_error)])
 
 
 def test_current_epoch_counter_increases_every_epoch():


### PR DESCRIPTION
`Ignite` provides a way to define a handler in case of an `Exception`, yet we still have to wrap the `run` method in a `try` / `except` because you can't really do anything inside that handler.
