### PR TITLE
Add ModelCheckpoint to ignite/contrib

### DIFF
--- a/ignite/contrib/checkpoint.py
+++ b/ignite/contrib/checkpoint.py
@@ -1,0 +1,118 @@
+import os
+import tempfile
+from collections import namedtuple
+
+import torch
+
+
+class ModelCheckpoint:
+    """ Foo bar
+
+    Parameters
+    ----------
+    dirname : str
+    filename_prefix : str
+    iteration_interval : int, optional
+    epoch_interval : int, optional
+    score_function : Callable, optional
+    n_saved : int, optional
+    atomic : bool, optional
+    require_empty : bool, optional
+    create_dir : bool, optional
+    exist_ok : bool, optional
+    """
+
+    def __init__(self, dirname, filename_prefix,
+                 iteration_interval=None, epoch_interval=None,
+                 score_function=None,
+                 n_saved=1,
+                 atomic=True, require_empty=True,
+                 create_dir=True, exist_ok=True):
+
+        self._dirname            = dirname
+        self._fname_prefix       = filename_prefix
+        self._n_saved            = n_saved
+        self._iteration_interval = iteration_interval
+        self._epoch_interval     = epoch_interval
+        self._score_function     = score_function
+        self._atomic             = atomic
+        self._item_T             = namedtuple('item_T', ('priority', 'data'))
+
+        self._saved = []
+
+        if not (iteration_interval or epoch_interval or score_function):
+            raise ValueError("One of 'iteration_interval', 'epoch_interval' or "
+                             "'score_function' arguments must be provided.")
+
+        if create_dir:
+            os.makedirs(dirname, exist_ok=exist_ok)
+
+        if require_empty:
+            n_matched = [fname
+                         for fname in os.listdir(dirname)
+                         if fname.startswith(self._fname_prefix)]
+
+            if len(n_matched) > 0:
+                raise ValueError("Files prefixed with {} are already present "
+                                 "in the directory {}. If you want to use this "
+                                 "directory anyway, pass require_empty=False. "
+                                 "".format(filename_prefix, dirname))
+
+    def _save(self, obj, path):
+        if not self._atomic:
+            torch.save(obj, path)
+
+        else:
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+
+            try:
+                torch.save(obj, tmp.file)
+
+            except:
+                tmp.close()
+                os.remove(tmp.name)
+                raise
+
+            else:
+                tmp.close()
+                os.rename(tmp.name, path)
+
+    def __call__(self, engine, **kwargs):
+
+        if len(kwargs) == 0:
+            raise RuntimeError("No objects to checkpoint found.")
+
+        if self._score_function is not None:
+            index    = engine.current_iteration
+            priority = self._score_function(engine)
+
+        elif self._iteration_interval is not None:
+            if engine.current_iteration % self._iteration_interval != 0:
+                return
+            index    = engine.current_iteration
+            priority = engine.current_iteration
+
+        else:
+            if engine.current_epoch % self._epoch_interval != 0:
+                return
+            index    = engine.current_epoch
+            priority = engine.current_epoch
+
+        if (len(self._saved) < self._n_saved) or (self._saved[0].priority < priority):
+            saved = []
+
+            for name, obj in kwargs.items():
+                fname = '{}_{}_{}.pth'.format(self._fname_prefix, name, index)
+                path  = os.path.join(self._dirname, fname)
+
+                self._save(obj=obj, path=path)
+                saved.append(fname)
+
+            saved = self._item_T(priority, saved)
+            self._saved.append(saved)
+            self._saved.sort(key=lambda item: item.priority)
+
+        if len(self._saved) > self._n_saved:
+            _, paths = self._saved.pop(0)
+            for p in paths:
+                os.remove(p)

--- a/ignite/handlers/__init__.py
+++ b/ignite/handlers/__init__.py
@@ -1,1 +1,3 @@
+from .checkpoint import ModelCheckpoint
+from .evaluate import Evaluate
 from .timing import Timer

--- a/ignite/handlers/__init__.py
+++ b/ignite/handlers/__init__.py
@@ -1,3 +1,2 @@
 from .checkpoint import ModelCheckpoint
-from .evaluate import Evaluate
 from .timing import Timer

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -6,34 +6,34 @@ import torch
 
 
 class ModelCheckpoint:
-    """ Foo bar
+    """ ModelCheckpoint handler can be used to save objects to disk.
 
-    Parameters
-    ----------
-    dirname : str
-        Directory path where objects will be saved
-    filename_prefix : str
-        Prefix for the filenames to which objects will be saved.
-        Each object is saved under '{filename_prefix}_{name}_{step_number}.pth'
-        where {step_number} is epoch or iteration number.
-    iteration_interval : int, optional
-        if not None, model will be saved to disk every 'iteration_interval' iterations
-    epoch_interval : int, optional
-        if not None, model will be saved to disk every 'epoch_interval' epochs
-    score_function : Callable, optional
-        if not None, it should be a function taking a single argument, an `ignite.engine.Engine` object,
-        and return a score (float / int). Objects with highest scores will be retained.
-    n_saved : int, optional
-        Number of objects that should be kept on disk. Older files will be removed.
-    atomic : bool, optional
-        If True, objects are serialized to a temporary file, and then moved to final destination, so that
-        files are guaranteed to not be damaged (for example if exception occures during saving).
-    require_empty : bool, optional
-        If True, will raise exception if there are any files starting with `filename_prefix` in the directory 'dirname'
-    create_dir : bool, optional
-        If True, will create directory 'dirname' if it doesnt exist.
-    exist_ok : bool, optional
-        Passed to 'os.makedirs' call. Ignored if 'create_dir' is False.
+    Args:
+        dirname (str):
+            Directory path where objects will be saved
+        filename_prefix (str):
+            Prefix for the filenames to which objects will be saved.
+            Each object is saved under '{filename_prefix}_{name}_{step_number}.pth'
+            where {step_number} is epoch or iteration number.
+        iteration_interval (int, optional):
+            if not None, model will be saved to disk every 'iteration_interval' iterations
+        epoch_interval (int, optional):
+            if not None, model will be saved to disk every 'epoch_interval' epochs
+        score_function (Callable, optional):
+            if not None, it should be a function taking a single argument, an `ignite.engine.Engine` object,
+            and return a score (float / int). Objects with highest scores will be retained.
+        n_saved (int, optional):
+            Number of objects that should be kept on disk. Older files will be removed.
+        atomic (bool, optional):
+            If True, objects are serialized to a temporary file, and then moved to final destination, so that
+            files are guaranteed to not be damaged (for example if exception occures during saving).
+        require_empty (bool, optional):
+            If True, will raise exception if there are any files starting with `filename_prefix`
+            in the directory 'dirname'
+        create_dir (bool, optional):
+            If True, will create directory 'dirname' if it doesnt exist.
+        exist_ok (bool, optional):
+            Passed to 'os.makedirs' call. Ignored if 'create_dir' is False.
     """
 
     def __init__(self, dirname, filename_prefix,
@@ -50,9 +50,7 @@ class ModelCheckpoint:
         self._epoch_interval     = epoch_interval
         self._score_function     = score_function
         self._atomic             = atomic
-
-        self._item_T  = namedtuple('_item_T', ('priority', 'data'))
-        self._saved   = []
+        self._saved              = []
 
         if not (iteration_interval or epoch_interval or score_function):
             raise ValueError("One of 'iteration_interval', 'epoch_interval' or "
@@ -121,9 +119,8 @@ class ModelCheckpoint:
                 self._save(obj=obj, path=path)
                 saved_objs.append(path)
 
-            item = self._item_T(priority, saved_objs)
-            self._saved.append(item)
-            self._saved.sort(key=lambda item: item.priority)
+            self._saved.append((priority, saved_objs))
+            self._saved.sort(key=lambda item: item[0])
 
         if len(self._saved) > self._n_saved:
             _, paths = self._saved.pop(0)

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -7,8 +7,9 @@ import torch
 class ModelCheckpoint(object):
     """ ModelCheckpoint handler can be used to periodically save objects to disk.
 
-    This handler accepts two arguments:
-        - an `ignite.engine.Engine` object, which will be passed to the
+    This handler accepts three arguments:
+        - an `ignite.engine.Engine` object
+        - an `ignite.engine.State` object, which will be passed to the
             `score_function` (if it is provided)
         - a `dict` mapping names (`str`) to objects that should be saved to disk.
             See Notes and Examples for further details.
@@ -24,7 +25,7 @@ class ModelCheckpoint(object):
             Exactly one of (`save_interval`, `score_function`) arguments must be provided.
         score_function (Callable, optional):
             if not None, it should be a function taking a 1single argument,
-            an `ignite.engine.Engine` object,
+            an `ignite.engine.State` object,
             and return a score (`float`). Objects with highest scores will be retained.
             Exactly one of (`save_interval`, `score_function`) arguments must be provided.
         n_saved (int, optional):
@@ -42,9 +43,11 @@ class ModelCheckpoint(object):
             Passed to 'os.makedirs' call. Ignored if 'create_dir' is False.
 
     Notes:
-          This handler expects two arguments: an `Engine` object, and a `dict`
-          mapping names to objects. These names are used to specify filenames
-          for saved objects. Each filename has the following structure:
+          This handler expects three arguments: an `Engine` object, 
+          a `State` object, and a `dict` mapping names to objects that should
+          be saved. 
+          These names are used to specify filenames for saved objects. 
+          Each filename has the following structure:
           `{filename_prefix}_{name}_{step_number}.pth`.
           Here, `filename_prefix` is the argument passed to the constructor,
           `name` is the key in the aforementioned `dict`, and `step_number`
@@ -121,14 +124,14 @@ class ModelCheckpoint(object):
                 tmp.close()
                 os.rename(tmp.name, path)
 
-    def __call__(self, engine, to_save):
+    def __call__(self, engine, state, to_save):
         if len(to_save) == 0:
             raise RuntimeError("No objects to checkpoint found.")
 
         self._iteration += 1
 
         if self._score_function is not None:
-            priority = self._score_function(engine)
+            priority = self._score_function(state)
 
         else:
             priority = self._iteration

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -85,7 +85,11 @@ class ModelCheckpoint(object):
                              "arguments must be provided.")
 
         if create_dir:
-            os.makedirs(dirname, exist_ok=exist_ok)
+            exists = os.path.exists(dirname)
+            if exists and not exist_ok:
+                raise OSError("Directory {} already exists. Pass exist_ok=True to ignore this error.")
+            elif not exists:
+                os.makedirs(dirname)
 
         if require_empty:
             matched = [fname

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -43,10 +43,10 @@ class ModelCheckpoint(object):
             Passed to 'os.makedirs' call. Ignored if 'create_dir' is False.
 
     Notes:
-          This handler expects three arguments: an `Engine` object, 
+          This handler expects three arguments: an `Engine` object,
           a `State` object, and a `dict` mapping names to objects that should
-          be saved. 
-          These names are used to specify filenames for saved objects. 
+          be saved.
+          These names are used to specify filenames for saved objects.
           Each filename has the following structure:
           `{filename_prefix}_{name}_{step_number}.pth`.
           Here, `filename_prefix` is the argument passed to the constructor,

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -1,12 +1,11 @@
 import os
 import tempfile
-from collections import namedtuple
 
 import torch
 
 
-class ModelCheckpoint:
-    """ ModelCheckpoint handler can be used to save objects to disk.
+class ModelCheckpoint(object):
+    """ ModelCheckpoint handler can be used to periodically save objects to disk.
 
     Args:
         dirname (str):
@@ -14,19 +13,21 @@ class ModelCheckpoint:
         filename_prefix (str):
             Prefix for the filenames to which objects will be saved.
             Each object is saved under '{filename_prefix}_{name}_{step_number}.pth'
-            where {step_number} is epoch or iteration number.
-        iteration_interval (int, optional):
-            if not None, model will be saved to disk every 'iteration_interval' iterations
-        epoch_interval (int, optional):
-            if not None, model will be saved to disk every 'epoch_interval' epochs
+            `step_number` is incremented by `1` with every call to the handler.
+        save_interval (int, optional):
+            if not None, objects will be saved to disk every `save_interval` calls to the handler.
+            Exactly one of (`save_interval`, `score_function`) arguments must be provided.
         score_function (Callable, optional):
-            if not None, it should be a function taking a single argument, an `ignite.engine.Engine` object,
-            and return a score (float / int). Objects with highest scores will be retained.
+            if not None, it should be a function taking a 1single argument,
+            an `ignite.engine.Engine` object,
+            and return a score (`float`). Objects with highest scores will be retained.
+            Exactly one of (`save_interval`, `score_function`) arguments must be provided.
         n_saved (int, optional):
             Number of objects that should be kept on disk. Older files will be removed.
         atomic (bool, optional):
-            If True, objects are serialized to a temporary file, and then moved to final destination, so that
-            files are guaranteed to not be damaged (for example if exception occures during saving).
+            If True, objects are serialized to a temporary file,
+            and then moved to final destination, so that files are
+            guaranteed to not be damaged (for example if exception occures during saving).
         require_empty (bool, optional):
             If True, will raise exception if there are any files starting with `filename_prefix`
             in the directory 'dirname'
@@ -37,37 +38,36 @@ class ModelCheckpoint:
     """
 
     def __init__(self, dirname, filename_prefix,
-                 iteration_interval=None, epoch_interval=None,
-                 score_function=None,
+                 save_interval=None, score_function=None,
                  n_saved=1,
                  atomic=True, require_empty=True,
                  create_dir=True, exist_ok=True):
 
-        self._dirname            = dirname
-        self._fname_prefix       = filename_prefix
-        self._n_saved            = n_saved
-        self._iteration_interval = iteration_interval
-        self._epoch_interval     = epoch_interval
-        self._score_function     = score_function
-        self._atomic             = atomic
-        self._saved              = []
+        self._dirname = dirname
+        self._fname_prefix = filename_prefix
+        self._n_saved = n_saved
+        self._save_interval = save_interval
+        self._score_function = score_function
+        self._atomic = atomic
+        self._saved = []  # list of tuples (priority, saved_objects)
+        self._iteration = 1
 
-        if not (iteration_interval or epoch_interval or score_function):
-            raise ValueError("One of 'iteration_interval', 'epoch_interval' or "
-                             "'score_function' arguments must be provided.")
+        if (save_interval and score_function) or (not save_interval and not score_function):
+            raise ValueError("Exactly one of `save_interval`, or `score_function` "
+                             "arguments must be provided.")
 
         if create_dir:
             os.makedirs(dirname, exist_ok=exist_ok)
 
         if require_empty:
-            n_matched = [fname
-                         for fname in os.listdir(dirname)
-                         if fname.startswith(self._fname_prefix)]
+            matched = [fname
+                       for fname in os.listdir(dirname)
+                       if fname.startswith(self._fname_prefix)]
 
-            if len(n_matched) > 0:
+            if len(matched) > 0:
                 raise ValueError("Files prefixed with {} are already present "
                                  "in the directory {}. If you want to use this "
-                                 "directory anyway, pass require_empty=False. "
+                                 "directory anyway, pass `require_empty=False`. "
                                  "".format(filename_prefix, dirname))
 
     def _save(self, obj, path):
@@ -94,27 +94,19 @@ class ModelCheckpoint:
             raise RuntimeError("No objects to checkpoint found.")
 
         if self._score_function is not None:
-            index    = engine.current_iteration
             priority = self._score_function(engine)
 
-        elif self._iteration_interval is not None:
-            if engine.current_iteration % self._iteration_interval != 0:
-                return
-            index    = engine.current_iteration
-            priority = engine.current_iteration
-
         else:
-            if engine.current_epoch % self._epoch_interval != 0:
+            priority = self._iteration
+            if (self._iteration % self._save_interval) != 0:
                 return
-            index    = engine.current_epoch
-            priority = engine.current_epoch
 
-        if (len(self._saved) < self._n_saved) or (self._saved[0].priority < priority):
+        if (len(self._saved) < self._n_saved) or (self._saved[0][0] < priority):
             saved_objs = []
 
             for name, obj in kwargs.items():
-                fname = '{}_{}_{}.pth'.format(self._fname_prefix, name, index)
-                path  = os.path.join(self._dirname, fname)
+                fname = '{}_{}_{}.pth'.format(self._fname_prefix, name, self._iteration)
+                path = os.path.join(self._dirname, fname)
 
                 self._save(obj=obj, path=path)
                 saved_objs.append(path)
@@ -126,3 +118,5 @@ class ModelCheckpoint:
             _, paths = self._saved.pop(0)
             for p in paths:
                 os.remove(p)
+
+        self._iteration += 1

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -34,7 +34,7 @@ def test_args_validation(dirname):
         h = ModelCheckpoint(existing, _PREFIX,
                             create_dir=False)
 
-    with pytest.raises(FileExistsError):
+    with pytest.raises(OSError):
         h = ModelCheckpoint(existing, _PREFIX, create_dir=True,
                             save_interval=42)
 
@@ -64,7 +64,7 @@ def test_atomic(dirname):
 
         try:
             h(None, {name: obj})
-        except AttributeError:
+        except:
             pass
 
         fname = os.path.join(dirname, '{}_{}_{}.pth'.format(_PREFIX, name, 1))

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -45,7 +45,7 @@ def test_args_validation(dirname):
 
 def test_simple_recovery(dirname):
     h = ModelCheckpoint(dirname, _PREFIX, create_dir=False, save_interval=1)
-    h(None, {'obj': 42})
+    h(None, None, {'obj': 42})
 
     fname = os.path.join(dirname, '{}_{}_{}.pth'.format(_PREFIX, 'obj', 1))
     assert torch.load(fname) == 42
@@ -63,7 +63,7 @@ def test_atomic(dirname):
                             save_interval=1)
 
         try:
-            h(None, {name: obj})
+            h(None, None, {name: obj})
         except:
             pass
 
@@ -78,14 +78,14 @@ def test_atomic(dirname):
 
 
 def test_last_k(dirname):
-    h = ModelCheckpoint(dirname, _PREFIX, create_dir=False, n_saved=2, save_interval=1)
+    h = ModelCheckpoint(dirname, _PREFIX, create_dir=False, n_saved=2, save_interval=2)
     to_save = {'name': 42}
 
-    for _ in range(4):
-        h(None, to_save)
+    for _ in range(8):
+        h(None, None, to_save)
 
     expected = ['{}_{}_{}.pth'.format(_PREFIX, 'name', i)
-                for i in [3, 4]]
+                for i in [6, 8]]
 
     assert sorted(os.listdir(dirname)) == expected
 
@@ -101,7 +101,7 @@ def test_best_k(dirname):
 
     to_save = {'name': 42}
     for _ in range(4):
-        h(None, to_save)
+        h(None, None, to_save)
 
     expected = ['{}_{}_{}.pth'.format(_PREFIX, 'name', i)
                 for i in [1, 3]]

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -3,6 +3,7 @@ import tempfile
 
 import pytest
 import torch
+import shutil
 
 from ignite.engine import Events
 from ignite.handlers import ModelCheckpoint
@@ -13,10 +14,9 @@ _PREFIX = 'PREFIX'
 
 @pytest.fixture
 def dirname():
-    directory = tempfile.TemporaryDirectory()
-    dirname = directory.name
-
-    yield dirname
+    path = tempfile.mkdtemp()
+    yield path
+    shutil.rmtree(path)
 
 
 def test_args_validation(dirname):

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -70,10 +70,10 @@ def test_atomic(dirname):
         fname = os.path.join(dirname, '{}_{}_{}.pth'.format(_PREFIX, name, 1))
         assert os.path.exists(fname) == expected
 
-    _test_existance(atomic=False, name='nonatomic_OK',   obj=serializable,     expected=True)
+    _test_existance(atomic=False, name='nonatomic_OK', obj=serializable, expected=True)
     _test_existance(atomic=False, name='nonatomic_FAIL', obj=non_serializable, expected=True)
 
-    _test_existance(atomic=True, name='atomic_OK',      obj=serializable,  expected=True)
+    _test_existance(atomic=True, name='atomic_OK', obj=serializable, expected=True)
     _test_existance(atomic=True, name='atomic_FAIL', obj=non_serializable, expected=False)
 
 

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -1,0 +1,128 @@
+import os
+import tempfile
+
+import pytest
+import torch
+
+from ignite.engine import Events
+from ignite.handlers import ModelCheckpoint
+from ignite.trainer import Trainer
+
+_PREFIX = 'PREFIX'
+
+
+@pytest.fixture
+def dirname():
+    directory = tempfile.TemporaryDirectory()
+    dirname = directory.name
+
+    yield dirname
+
+
+def test_args_validation(dirname):
+    existing = os.path.join(dirname, 'existing_dir')
+    nonempty = os.path.join(dirname, 'nonempty')
+
+    os.makedirs(existing)
+    os.makedirs(nonempty)
+
+    with open(os.path.join(nonempty, '{}_name_0.pth'.format(_PREFIX)), 'w'):
+        pass
+
+    # save_interval & score_func
+    with pytest.raises(ValueError):
+        h = ModelCheckpoint(existing, _PREFIX,
+                            create_dir=False)
+
+    with pytest.raises(FileExistsError):
+        h = ModelCheckpoint(existing, _PREFIX, create_dir=True,
+                            save_interval=42)
+
+    with pytest.raises(ValueError):
+        h = ModelCheckpoint(nonempty, _PREFIX, exist_ok=True,
+                            save_interval=42)
+
+
+def test_simple_recovery(dirname):
+    h = ModelCheckpoint(dirname, _PREFIX, create_dir=False, save_interval=1)
+    h(None, {'obj': 42})
+
+    fname = os.path.join(dirname, '{}_{}_{}.pth'.format(_PREFIX, 'obj', 1))
+    assert torch.load(fname) == 42
+
+
+def test_atomic(dirname):
+    serializable = 42
+    non_serializable = (42, lambda _: 42)
+
+    def _test_existance(atomic, name, obj, expected):
+        h = ModelCheckpoint(dirname, _PREFIX,
+                            atomic=atomic,
+                            create_dir=False,
+                            require_empty=False,
+                            save_interval=1)
+
+        try:
+            h(None, {name: obj})
+        except AttributeError:
+            pass
+
+        fname = os.path.join(dirname, '{}_{}_{}.pth'.format(_PREFIX, name, 1))
+        assert os.path.exists(fname) == expected
+
+    _test_existance(atomic=False, name='nonatomic_OK',   obj=serializable,     expected=True)
+    _test_existance(atomic=False, name='nonatomic_FAIL', obj=non_serializable, expected=True)
+
+    _test_existance(atomic=True, name='atomic_OK',      obj=serializable,  expected=True)
+    _test_existance(atomic=True, name='atomic_FAIL', obj=non_serializable, expected=False)
+
+
+def test_last_k(dirname):
+    h = ModelCheckpoint(dirname, _PREFIX, create_dir=False, n_saved=2, save_interval=1)
+    to_save = {'name': 42}
+
+    for _ in range(4):
+        h(None, to_save)
+
+    expected = ['{}_{}_{}.pth'.format(_PREFIX, 'name', i)
+                for i in [3, 4]]
+
+    assert sorted(os.listdir(dirname)) == expected
+
+
+def test_best_k(dirname):
+    scores = iter([1.0, -2., 3.0, -4.0])
+
+    def score_function(engine):
+        return next(scores)
+
+    h = ModelCheckpoint(dirname, _PREFIX, create_dir=False,
+                        n_saved=2, score_function=score_function)
+
+    to_save = {'name': 42}
+    for _ in range(4):
+        h(None, to_save)
+
+    expected = ['{}_{}_{}.pth'.format(_PREFIX, 'name', i)
+                for i in [1, 3]]
+
+    assert sorted(os.listdir(dirname)) == expected
+
+
+def test_with_trainer(dirname):
+
+    def update_fn(batch):
+        pass
+
+    name = 'model'
+    trainer = Trainer(update_fn)
+    handler = ModelCheckpoint(dirname, _PREFIX, create_dir=False,
+                              n_saved=2, save_interval=1)
+
+    trainer.add_event_handler(Events.EPOCH_COMPLETED, handler, {name: 42})
+    trainer.run([0], max_epochs=4)
+
+    expected = ['{}_{}_{}.pth'.format(_PREFIX, name, i)
+                for i in [3, 4]]
+
+    assert sorted(os.listdir(dirname)) == expected


### PR DESCRIPTION
I think this partially solves #62 . Ultimately I agree with @alykhantejani that something more elaborate would be desirable (see https://github.com/pytorch/ignite/issues/62#issuecomment-364078176).

This is a simple handler that can be used to periodically save objects to disk. It supports saving `n` last / best models. Attach with something like
```python
trainer.add_event_handler(Events.ITERATION_COMPLETED,
                          ModelCheckpoint('/tmp/models', 
                                           'gan', 
                                           iteration_interval=1000, n_saved=5),
                          trainer, 
                          model=model)
```

If you'd decide this is something you'd like to merge, I'd add docs, tests, and example.