### PR TITLE
remove unnecessary init in NegativeLogLikelihood

### DIFF
--- a/ignite/metrics/negative_log_likelihood.py
+++ b/ignite/metrics/negative_log_likelihood.py
@@ -8,10 +8,6 @@ from ignite.exceptions import NotComputableError
 
 
 class NegativeLogLikelihood(Metric):
-    def __init__(self):
-        self._sum = 0
-        self._num_examples = 0
-
     def reset(self):
         self._sum = 0
         self._num_examples = 0


### PR DESCRIPTION
The `Metric` base class calls reset in the initializer.