### PR TITLE
During atomic save in checkpoint, save temporary file to target directory rather than to default TMPDIR.

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -109,7 +109,7 @@ class ModelCheckpoint(object):
             torch.save(obj, path)
 
         else:
-            tmp = tempfile.NamedTemporaryFile(delete=False)
+            tmp = tempfile.NamedTemporaryFile(delete=False, dir=self._dirname)
 
             try:
                 torch.save(obj, tmp.file)


### PR DESCRIPTION
Addresses bug #114.

> Currently, ModelCheckpoint uses the default destination in tempfile when saving a temporary file for an atomic checkpoint write. This is potentially problematic: it assumes that the default tempfile.tempdir is on the same volume as the user-specified destination directory (dirname); it also causes the issue described above. It should create the temporary file in the user-specified destination directory prior to renaming it (NamedTemporaryFile should take dir=dirname).