### PR TITLE
Feature 117 state access

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -58,18 +58,18 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
                                             cuda=cuda)
 
     @trainer.on(Events.ITERATION_COMPLETED)
-    def log_training_loss(trainer, state):
-        iter = (state.iteration - 1) % len(train_loader) + 1
+    def log_training_loss(engine):
+        iter = (engine.state.iteration - 1) % len(train_loader) + 1
         if iter % log_interval == 0:
-            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(state.epoch, iter, len(train_loader), state.output))
+            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
 
     @trainer.on(Events.EPOCH_COMPLETED)
-    def log_validation_results(trainer, state):
+    def log_validation_results(engine):
         metrics = evaluator.run(val_loader).metrics
         avg_accuracy = metrics['accuracy']
         avg_nll = metrics['nll']
         print("Validation Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"
-              .format(state.epoch, avg_accuracy, avg_nll))
+              .format(engine.state.epoch, avg_accuracy, avg_nll))
 
     trainer.run(train_loader, max_epochs=epochs)
 

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -61,7 +61,8 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     def log_training_loss(engine):
         iter = (engine.state.iteration - 1) % len(train_loader) + 1
         if iter % log_interval == 0:
-            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
+            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}"
+                  "".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(engine):

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -66,7 +66,8 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(engine):
-        metrics = evaluator.run(val_loader).metrics
+        evaluator.run(val_loader)
+        metrics = evaluator.state.metrics
         avg_accuracy = metrics['accuracy']
         avg_nll = metrics['nll']
         print("Validation Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"

--- a/examples/mnist_with_tensorboardx.py
+++ b/examples/mnist_with_tensorboardx.py
@@ -91,21 +91,21 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval, lo
                                             cuda=cuda)
 
     @trainer.on(Events.ITERATION_COMPLETED)
-    def log_training_loss(trainer, state):
-        iter = (state.iteration - 1) % len(train_loader) + 1
+    def log_training_loss(engine):
+        iter = (engine.state.iteration - 1) % len(train_loader) + 1
         if iter % log_interval == 0:
-            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(state.epoch, iter, len(train_loader), state.output))
-            writer.add_scalar("training/loss", state.output, state.iteration)
+            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
+            writer.add_scalar("training/loss", engine.state.output, engine.state.iteration)
 
     @trainer.on(Events.EPOCH_COMPLETED)
-    def log_validation_results(trainer, state):
+    def log_validation_results(engine):
         metrics = evaluator.run(val_loader).metrics
         avg_accuracy = metrics['accuracy']
         avg_nll = metrics['nll']
         print("Validation Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"
-              .format(state.epoch, avg_accuracy, avg_nll))
-        writer.add_scalar("valdation/loss", avg_nll, state.epoch)
-        writer.add_scalar("valdation/accuracy", avg_accuracy, state.epoch)
+              .format(engine.state.epoch, avg_accuracy, avg_nll))
+        writer.add_scalar("valdation/loss", avg_nll, engine.state.epoch)
+        writer.add_scalar("valdation/accuracy", avg_accuracy, engine.state.epoch)
 
     # kick everything off
     trainer.run(train_loader, max_epochs=epochs)

--- a/examples/mnist_with_tensorboardx.py
+++ b/examples/mnist_with_tensorboardx.py
@@ -100,7 +100,8 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval, lo
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(engine):
-        metrics = evaluator.run(val_loader).metrics
+        evaluator.run(val_loader)
+        metrics = evaluator.state.metrics
         avg_accuracy = metrics['accuracy']
         avg_nll = metrics['nll']
         print("Validation Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"

--- a/examples/mnist_with_tensorboardx.py
+++ b/examples/mnist_with_tensorboardx.py
@@ -94,7 +94,8 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval, lo
     def log_training_loss(engine):
         iter = (engine.state.iteration - 1) % len(train_loader) + 1
         if iter % log_interval == 0:
-            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
+            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}"
+                  "".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
             writer.add_scalar("training/loss", engine.state.output, engine.state.iteration)
 
     @trainer.on(Events.EPOCH_COMPLETED)

--- a/examples/mnist_with_visdom.py
+++ b/examples/mnist_with_visdom.py
@@ -75,21 +75,21 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     val_loss_window = create_plot_window(vis, '#Epochs', 'Loss', 'Validation Loss')
 
     @trainer.on(Events.ITERATION_COMPLETED)
-    def log_training_loss(trainer, state):
-        iter = (state.iteration - 1) % len(train_loader) + 1
+    def log_training_loss(engine):
+        iter = (engine.state.iteration - 1) % len(train_loader) + 1
         if iter % log_interval == 0:
-            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(state.epoch, iter, len(train_loader), state.output))
-            vis.line(X=np.array([state.iteration]), Y=np.array([state.output]), update='append', win=train_loss_window)
+            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
+            vis.line(X=np.array([engine.state.iteration]), Y=np.array([engine.state.output]), update='append', win=train_loss_window)
 
     @trainer.on(Events.EPOCH_COMPLETED)
-    def log_validation_results(trainer, state):
+    def log_validation_results(engine):
         metrics = evaluator.run(val_loader).metrics
         avg_accuracy = metrics['accuracy']
         avg_nll = metrics['nll']
         print("Validation Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"
-              .format(state.epoch, avg_accuracy, avg_nll))
-        vis.line(X=np.array([state.epoch]), Y=np.array([avg_accuracy]), win=val_accuracy_window, update='append')
-        vis.line(X=np.array([state.epoch]), Y=np.array([avg_nll]), win=val_loss_window, update='append')
+              .format(engine.state.epoch, avg_accuracy, avg_nll))
+        vis.line(X=np.array([engine.state.epoch]), Y=np.array([avg_accuracy]), win=val_accuracy_window, update='append')
+        vis.line(X=np.array([engine.state.epoch]), Y=np.array([avg_nll]), win=val_loss_window, update='append')
 
     # kick everything off
     trainer.run(train_loader, max_epochs=epochs)

--- a/examples/mnist_with_visdom.py
+++ b/examples/mnist_with_visdom.py
@@ -78,8 +78,11 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     def log_training_loss(engine):
         iter = (engine.state.iteration - 1) % len(train_loader) + 1
         if iter % log_interval == 0:
-            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
-            vis.line(X=np.array([engine.state.iteration]), Y=np.array([engine.state.output]), update='append', win=train_loss_window)
+            print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}"
+                  "".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
+            vis.line(X=np.array([engine.state.iteration]),
+                     Y=np.array([engine.state.output]),
+                     update='append', win=train_loss_window)
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(engine):

--- a/examples/mnist_with_visdom.py
+++ b/examples/mnist_with_visdom.py
@@ -86,7 +86,8 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(engine):
-        metrics = evaluator.run(val_loader).metrics
+        evaluator.run(val_loader)
+        metrics = evaluator.state.metrics
         avg_accuracy = metrics['accuracy']
         avg_nll = metrics['nll']
         print("Validation Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -120,7 +120,7 @@ class Engine(object):
                 self.state.batch = batch
                 self.state.iteration += 1
                 self._fire_event(Events.ITERATION_STARTED)
-                self.state.output = self._process_function(batch)
+                self.state.output = self._process_function(self, batch)
                 self._fire_event(Events.ITERATION_COMPLETED)
                 if self.should_terminate:
                     break

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -34,7 +34,8 @@ class Engine(object):
     Parameters
     ----------
     process_function : callable
-        A function receiving the current training batch in each iteration, outputing data to be stored in the state
+        A function receiving a handle to the engine and the current training
+        batch in each iteration, outputing data to be stored in the state
 
     """
     def __init__(self, process_function):

--- a/ignite/engines/evaluator.py
+++ b/ignite/engines/evaluator.py
@@ -37,7 +37,7 @@ def create_supervised_evaluator(model, metrics={}, cuda=False):
         y = to_variable(y, cuda=cuda, volatile=True)
         return x, y
 
-    def _inference(batch):
+    def _inference(engine, batch):
         model.eval()
         x, y = _prepare_batch(batch)
         y_pred = model(x)

--- a/ignite/engines/evaluator.py
+++ b/ignite/engines/evaluator.py
@@ -12,12 +12,11 @@ class Evaluator(Engine):
         super(Evaluator, self).add_event_handler(event_name, handler, *args, **kwargs)
 
     def run(self, data):
-        state = State(dataloader=data, metrics={})
-        self._fire_event(Events.STARTED, state)
-        hours, mins, secs = self._run_once_on_dataset(state)
+        self.state = State(dataloader=data, metrics={})
+        self._fire_event(Events.STARTED)
+        hours, mins, secs = self._run_once_on_dataset()
         self._logger.info("Evaluation Complete. Time taken: %02d:%02d:%02d", hours, mins, secs)
-        self._fire_event(Events.COMPLETED, state)
-        return state
+        self._fire_event(Events.COMPLETED)
 
 
 def create_supervised_evaluator(model, metrics={}, cuda=False):

--- a/ignite/engines/trainer.py
+++ b/ignite/engines/trainer.py
@@ -28,31 +28,29 @@ class Trainer(Engine):
         -------
         None
         """
-        state = State(dataloader=data, epoch=0, max_epochs=max_epochs)
+        self.state = State(dataloader=data, epoch=0, max_epochs=max_epochs)
 
         try:
             self._logger.info("Training starting with max_epochs={}".format(max_epochs))
             start_time = time.time()
-            self._fire_event(Events.STARTED, state)
-            while state.epoch < max_epochs and not self.should_terminate:
-                state.epoch += 1
-                self._fire_event(Events.EPOCH_STARTED, state)
-                hours, mins, secs = self._run_once_on_dataset(state)
-                self._logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", state.epoch, hours, mins, secs)
+            self._fire_event(Events.STARTED)
+            while self.state.epoch < max_epochs and not self.should_terminate:
+                self.state.epoch += 1
+                self._fire_event(Events.EPOCH_STARTED)
+                hours, mins, secs = self._run_once_on_dataset()
+                self._logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.state.epoch, hours, mins, secs)
                 if self.should_terminate:
                     break
-                self._fire_event(Events.EPOCH_COMPLETED, state)
+                self._fire_event(Events.EPOCH_COMPLETED)
 
-            self._fire_event(Events.COMPLETED, state)
+            self._fire_event(Events.COMPLETED)
             time_taken = time.time() - start_time
             hours, mins, secs = _to_hours_mins_secs(time_taken)
             self._logger.info("Training complete. Time taken %02d:%02d:%02d" % (hours, mins, secs))
 
         except BaseException as e:
             self._logger.error("Training is terminating due to exception: %s", str(e))
-            self._handle_exception(state, e)
-
-        return state
+            self._handle_exception(e)
 
 
 def create_supervised_trainer(model, optimizer, loss_fn, cuda=False):

--- a/ignite/engines/trainer.py
+++ b/ignite/engines/trainer.py
@@ -73,7 +73,7 @@ def create_supervised_trainer(model, optimizer, loss_fn, cuda=False):
         y = to_variable(y, cuda=cuda)
         return x, y
 
-    def _update(batch):
+    def _update(engine, batch):
         model.train()
         optimizer.zero_grad()
         x, y = _prepare_batch(batch)

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -7,10 +7,8 @@ import torch
 class ModelCheckpoint(object):
     """ ModelCheckpoint handler can be used to periodically save objects to disk.
 
-    This handler accepts three arguments:
+    This handler accepts two arguments:
         - an `ignite.engines.Engine` object
-        - an `ignite.engines.State` object, which will be passed to the
-            `score_function` (if it is provided)
         - a `dict` mapping names (`str`) to objects that should be saved to disk.
             See Notes and Examples for further details.
 
@@ -24,8 +22,8 @@ class ModelCheckpoint(object):
             if not None, objects will be saved to disk every `save_interval` calls to the handler.
             Exactly one of (`save_interval`, `score_function`) arguments must be provided.
         score_function (Callable, optional):
-            if not None, it should be a function taking a 1single argument,
-            an `ignite.engines.State` object,
+            if not None, it should be a function taking a single argument,
+            an `ignite.engines.Engine` object,
             and return a score (`float`). Objects with highest scores will be retained.
             Exactly one of (`save_interval`, `score_function`) arguments must be provided.
         n_saved (int, optional):
@@ -43,9 +41,9 @@ class ModelCheckpoint(object):
             Passed to 'os.makedirs' call. Ignored if 'create_dir' is False.
 
     Notes:
-          This handler expects three arguments: an `Engine` object,
-          a `State` object, and a `dict` mapping names to objects that should
-          be saved.
+          This handler expects two arguments: an `Engine` object and a `dict`
+          mapping names to objects that should be saved.
+          
           These names are used to specify filenames for saved objects.
           Each filename has the following structure:
           `{filename_prefix}_{name}_{step_number}.pth`.
@@ -123,14 +121,14 @@ class ModelCheckpoint(object):
                 tmp.close()
                 os.rename(tmp.name, path)
 
-    def __call__(self, engine, state, to_save):
+    def __call__(self, engine, to_save):
         if len(to_save) == 0:
             raise RuntimeError("No objects to checkpoint found.")
 
         self._iteration += 1
 
         if self._score_function is not None:
-            priority = self._score_function(state)
+            priority = self._score_function(engine)
 
         else:
             priority = self._iteration

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -43,7 +43,7 @@ class ModelCheckpoint(object):
     Notes:
           This handler expects two arguments: an `Engine` object and a `dict`
           mapping names to objects that should be saved.
-          
+
           These names are used to specify filenames for saved objects.
           Each filename has the following structure:
           `{filename_prefix}_{name}_{step_number}.pth`.

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -58,7 +58,7 @@ class Metric(object):
         self.update(engine.state.output)
 
     def completed(self, engine, name):
-        state.metrics[name] = self.compute()
+        engine.state.metrics[name] = self.compute()
 
     def attach(self, engine, name):
         engine.add_event_handler(Events.STARTED, self.started)

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -51,13 +51,13 @@ class Metric(object):
         """
         pass
 
-    def started(self, engine, state):
+    def started(self, engine):
         self.reset()
 
-    def iteration_completed(self, engine, state):
-        self.update(state.output)
+    def iteration_completed(self, engine):
+        self.update(engine.state.output)
 
-    def completed(self, engine, state, name):
+    def completed(self, engine, name):
         state.metrics[name] = self.compute()
 
     def attach(self, engine, name):

--- a/tests/ignite/engines/test_engine.py
+++ b/tests/ignite/engines/test_engine.py
@@ -15,11 +15,10 @@ class DummyEngine(Engine):
         super(DummyEngine, self).__init__(process_func)
 
     def run(self, num_times):
-        state = State()
+        self.state = State()
         for _ in range(num_times):
-            self._fire_event(Events.STARTED, state)
-            self._fire_event(Events.COMPLETED, state)
-        return state
+            self._fire_event(Events.STARTED)
+            self._fire_event(Events.COMPLETED)
 
 
 def test_terminate():
@@ -33,7 +32,7 @@ def test_add_event_handler_raises_with_invalid_event():
     engine = DummyEngine()
 
     with pytest.raises(ValueError):
-        engine.add_event_handler("incorrect", lambda engine, state: None)
+        engine.add_event_handler("incorrect", lambda engine: None)
 
 
 def test_add_event_handler():
@@ -45,13 +44,13 @@ def test_add_event_handler():
 
     started_counter = Counter()
 
-    def handle_training_iteration_started(engine, state, counter):
+    def handle_training_iteration_started(engine, counter):
         counter.count += 1
     engine.add_event_handler(Events.STARTED, handle_training_iteration_started, started_counter)
 
     completed_counter = Counter()
 
-    def handle_training_iteration_completed(engine, state, counter):
+    def handle_training_iteration_completed(engine, counter):
         counter.count += 1
     engine.add_event_handler(Events.COMPLETED, handle_training_iteration_completed, completed_counter)
 
@@ -67,9 +66,9 @@ def test_adding_multiple_event_handlers():
     for handler in handlers:
         engine.add_event_handler(Events.STARTED, handler)
 
-    state = engine.run(1)
+    engine.run(1)
     for handler in handlers:
-        handler.assert_called_once_with(engine, state)
+        handler.assert_called_once_with(engine)
 
 
 def test_args_and_kwargs_are_passed_to_event():
@@ -82,15 +81,14 @@ def test_args_and_kwargs_are_passed_to_event():
         engine.add_event_handler(event, handler, *args, **kwargs)
         handlers.append(handler)
 
-    state = engine.run(1)
+    engine.run(1)
     called_handlers = [handle for handle in handlers if handle.called]
     assert len(called_handlers) == 2
 
     for handler in called_handlers:
         handler_args, handler_kwargs = handler.call_args
         assert handler_args[0] == engine
-        assert handler_args[1] == state
-        assert handler_args[2::] == args
+        assert handler_args[1::] == args
         assert handler_kwargs == kwargs
 
 
@@ -98,7 +96,7 @@ def test_on_decorator_raises_with_invalid_event():
     engine = DummyEngine()
     with pytest.raises(ValueError):
         @engine.on("incorrect")
-        def f(engine, state):
+        def f(engine):
             pass
 
 
@@ -112,13 +110,13 @@ def test_on_decorator():
     started_counter = Counter()
 
     @engine.on(Events.STARTED, started_counter)
-    def handle_training_iteration_started(engine, state, started_counter):
+    def handle_training_iteration_started(engine, started_counter):
         started_counter.count += 1
 
     completed_counter = Counter()
 
     @engine.on(Events.COMPLETED, completed_counter)
-    def handle_training_iteration_completed(engine, state, completed_counter):
+    def handle_training_iteration_completed(engine, completed_counter):
         completed_counter.count += 1
 
     engine.run(15)

--- a/tests/ignite/engines/test_evaluator.py
+++ b/tests/ignite/engines/test_evaluator.py
@@ -9,20 +9,20 @@ from ignite.metrics import MeanSquaredError
 
 def test_returns_state():
     evaluator = Evaluator(MagicMock(return_value=1))
-    state = evaluator.run([])
+    evaluator.run([])
 
-    assert isinstance(state, State)
+    assert isinstance(evaluator.state, State)
 
 
 def test_state_attributes():
     dataloader = [1, 2, 3]
     evaluator = Evaluator(MagicMock(return_value=1))
-    state = evaluator.run(dataloader)
+    evaluator.run(dataloader)
 
-    assert state.iteration == 3
-    assert state.output == 1
-    assert state.batch == 3
-    assert state.dataloader == dataloader
+    assert evaluator.state.iteration == 3
+    assert evaluator.state.output == 1
+    assert evaluator.state.batch == 3
+    assert evaluator.state.dataloader == dataloader
 
 
 def test_current_validation_iteration_counter_increases_every_iteration():
@@ -35,8 +35,8 @@ def test_current_validation_iteration_counter_increases_every_iteration():
             self.current_iteration_count = 1
             self.total_count = 0
 
-        def __call__(self, evaluator, state):
-            assert state.iteration == self.current_iteration_count
+        def __call__(self, evaluator):
+            assert evaluator.state.iteration == self.current_iteration_count
             self.current_iteration_count += 1
             self.total_count += 1
 
@@ -45,7 +45,7 @@ def test_current_validation_iteration_counter_increases_every_iteration():
 
     iteration_counter = IterationCounter()
 
-    def clear_counter(evaluator, state, counter):
+    def clear_counter(evaluator, counter):
         counter.clear()
 
     evaluator.add_event_handler(Events.STARTED, clear_counter, iteration_counter)
@@ -72,14 +72,14 @@ def test_evaluation_iteration_events_are_fired():
     mock_manager.attach_mock(iteration_complete, 'iteration_complete')
 
     batches = [(1, 2), (3, 4), (5, 6)]
-    state = evaluator.run(batches)
+    evaluator.run(batches)
     assert iteration_started.call_count == len(batches)
     assert iteration_complete.call_count == len(batches)
 
     expected_calls = []
     for i in range(len(batches)):
-        expected_calls.append(call.iteration_started(evaluator, state))
-        expected_calls.append(call.iteration_complete(evaluator, state))
+        expected_calls.append(call.iteration_started(evaluator))
+        expected_calls.append(call.iteration_complete(evaluator))
 
     assert mock_manager.mock_calls == expected_calls
 
@@ -89,15 +89,15 @@ def test_terminate_stops_evaluator_when_called_during_iteration():
     iteration_to_stop = 3  # i.e. part way through the 3rd validation run
     evaluator = Evaluator(MagicMock(return_value=1))
 
-    def start_of_iteration_handler(evaluator, state):
-        if state.iteration == iteration_to_stop:
+    def start_of_iteration_handler(evaluator):
+        if evaluator.state.iteration == iteration_to_stop:
             evaluator.terminate()
 
     evaluator.add_event_handler(Events.ITERATION_STARTED, start_of_iteration_handler)
-    state = evaluator.run([None] * num_iterations)
+    evaluator.run([None] * num_iterations)
 
     # should complete the iteration when terminate called but not increment counter
-    assert state.iteration == iteration_to_stop
+    assert evaluator.state.iteration == iteration_to_stop
 
 
 def test_create_supervised():
@@ -111,8 +111,8 @@ def test_create_supervised():
     y = torch.FloatTensor([[3.0], [5.0]])
     data = [(x, y)]
 
-    state = evaluator.run(data)
-    y_pred, y = state.output
+    evaluator.run(data)
+    y_pred, y = evaluator.state.output
 
     assert y_pred[0, 0] == approx(0.0)
     assert y_pred[1, 0] == approx(0.0)
@@ -134,5 +134,5 @@ def test_create_supervised_with_metrics():
     y = torch.FloatTensor([[3.0], [4.0]])
     data = [(x, y)]
 
-    state = evaluator.run(data)
-    assert state.metrics['mse'] == 12.5
+    evaluator.run(data)
+    assert evaluator.state.metrics['mse'] == 12.5

--- a/tests/ignite/engines/test_evaluator.py
+++ b/tests/ignite/engines/test_evaluator.py
@@ -7,7 +7,7 @@ from ignite.engines import Evaluator, Events, State, create_supervised_evaluator
 from ignite.metrics import MeanSquaredError
 
 
-def test_returns_state():
+def test_creates_state():
     evaluator = Evaluator(MagicMock(return_value=1))
     evaluator.run([])
 

--- a/tests/ignite/engines/test_trainer.py
+++ b/tests/ignite/engines/test_trainer.py
@@ -39,7 +39,7 @@ class _PicklableMagicMock(object):
         return self.uuid
 
 
-def test_returns_state():
+def test_creates_state():
     trainer = Trainer(MagicMock(return_value=1))
     trainer.run([])
 
@@ -77,7 +77,7 @@ def test_custom_exception_handler():
     trainer.run([1])
 
     # only one call from _run_once_over_data, since the exception is swallowed
-    exception_handler.assert_has_calls([call(trainer, trainer.state, value_error)])
+    exception_handler.assert_has_calls([call(trainer, value_error)])
 
 
 def test_current_epoch_counter_increases_every_epoch():
@@ -132,8 +132,8 @@ def test_terminate_at_end_of_epoch_stops_training():
 
     trainer = Trainer(MagicMock(return_value=1))
 
-    def end_of_epoch_handler(trainer, state):
-        if state.epoch == last_epoch_to_run:
+    def end_of_epoch_handler(trainer):
+        if trainer.state.epoch == last_epoch_to_run:
             trainer.terminate()
 
     trainer.add_event_handler(Events.EPOCH_COMPLETED, end_of_epoch_handler)

--- a/tests/ignite/engines/test_trainer.py
+++ b/tests/ignite/engines/test_trainer.py
@@ -41,22 +41,22 @@ class _PicklableMagicMock(object):
 
 def test_returns_state():
     trainer = Trainer(MagicMock(return_value=1))
-    state = trainer.run([])
+    trainer.run([])
 
-    assert isinstance(state, State)
+    assert isinstance(trainer.state, State)
 
 
 def test_state_attributes():
     dataloader = [1, 2, 3]
     trainer = Trainer(MagicMock(return_value=1))
-    state = trainer.run(dataloader, max_epochs=3)
+    trainer.run(dataloader, max_epochs=3)
 
-    assert state.iteration == 9
-    assert state.output == 1
-    assert state.batch == 3
-    assert state.dataloader == dataloader
-    assert state.epoch == 3
-    assert state.max_epochs == 3
+    assert trainer.state.iteration == 9
+    assert trainer.state.output == 1
+    assert trainer.state.batch == 3
+    assert trainer.state.dataloader == dataloader
+    assert trainer.state.epoch == 3
+    assert trainer.state.max_epochs == 3
 
 
 def test_default_exception_handler():
@@ -74,10 +74,10 @@ def test_custom_exception_handler():
     trainer = Trainer(training_update_function)
     exception_handler = MagicMock()
     trainer.add_event_handler(Events.EXCEPTION_RAISED, exception_handler)
-    state = trainer.run([1])
+    trainer.run([1])
 
     # only one call from _run_once_over_data, since the exception is swallowed
-    exception_handler.assert_has_calls([call(trainer, state, value_error)])
+    exception_handler.assert_has_calls([call(trainer, trainer.state, value_error)])
 
 
 def test_current_epoch_counter_increases_every_epoch():
@@ -88,15 +88,15 @@ def test_current_epoch_counter_increases_every_epoch():
         def __init__(self):
             self.current_epoch_count = 1
 
-        def __call__(self, trainer, state):
-            assert state.epoch == self.current_epoch_count
+        def __call__(self, trainer):
+            assert trainer.state.epoch == self.current_epoch_count
             self.current_epoch_count += 1
 
     trainer.add_event_handler(Events.EPOCH_STARTED, EpochCounter())
 
-    state = trainer.run([1], max_epochs=max_epochs)
+    trainer.run([1], max_epochs=max_epochs)
 
-    assert state.epoch == max_epochs
+    assert trainer.state.epoch == max_epochs
 
 
 def test_current_iteration_counter_increases_every_iteration():
@@ -108,22 +108,22 @@ def test_current_iteration_counter_increases_every_iteration():
         def __init__(self):
             self.current_iteration_count = 1
 
-        def __call__(self, trainer, state):
-            assert state.iteration == self.current_iteration_count
+        def __call__(self, trainer):
+            assert trainer.state.iteration == self.current_iteration_count
             self.current_iteration_count += 1
 
     trainer.add_event_handler(Events.ITERATION_STARTED, IterationCounter())
 
-    state = trainer.run(training_batches, max_epochs=max_epochs)
+    trainer.run(training_batches, max_epochs=max_epochs)
 
-    assert state.iteration == max_epochs * len(training_batches)
+    assert trainer.state.iteration == max_epochs * len(training_batches)
 
 
 def test_stopping_criterion_is_max_epochs():
     trainer = Trainer(MagicMock(return_value=1))
     max_epochs = 5
-    state = trainer.run([1], max_epochs=max_epochs)
-    assert state.epoch == max_epochs
+    trainer.run([1], max_epochs=max_epochs)
+    assert trainer.state.epoch == max_epochs
 
 
 def test_terminate_at_end_of_epoch_stops_training():
@@ -140,9 +140,9 @@ def test_terminate_at_end_of_epoch_stops_training():
 
     assert not trainer.should_terminate
 
-    state = trainer.run([1], max_epochs=max_epochs)
+    trainer.run([1], max_epochs=max_epochs)
 
-    assert state.epoch == last_epoch_to_run
+    assert trainer.state.epoch == last_epoch_to_run
     assert trainer.should_terminate
 
 
@@ -153,21 +153,21 @@ def test_terminate_at_start_of_epoch_stops_training_after_completing_iteration()
 
     trainer = Trainer(MagicMock(return_value=1))
 
-    def start_of_epoch_handler(trainer, state):
-        if state.epoch == epoch_to_terminate_on:
+    def start_of_epoch_handler(trainer):
+        if trainer.state.epoch == epoch_to_terminate_on:
             trainer.terminate()
 
     trainer.add_event_handler(Events.EPOCH_STARTED, start_of_epoch_handler)
 
     assert not trainer.should_terminate
 
-    state = trainer.run(batches_per_epoch, max_epochs=max_epochs)
+    trainer.run(batches_per_epoch, max_epochs=max_epochs)
 
     # epoch is not completed so counter is not incremented
-    assert state.epoch == epoch_to_terminate_on
+    assert trainer.state.epoch == epoch_to_terminate_on
     assert trainer.should_terminate
     # completes first iteration
-    assert state.iteration == ((epoch_to_terminate_on - 1) * len(batches_per_epoch)) + 1
+    assert trainer.state.iteration == ((epoch_to_terminate_on - 1) * len(batches_per_epoch)) + 1
 
 
 def test_terminate_stops_training_mid_epoch():
@@ -175,15 +175,15 @@ def test_terminate_stops_training_mid_epoch():
     iteration_to_stop = num_iterations_per_epoch + 3  # i.e. part way through the 3rd epoch
     trainer = Trainer(MagicMock(return_value=1))
 
-    def start_of_iteration_handler(trainer, state):
-        if state.iteration == iteration_to_stop:
+    def start_of_iteration_handler(trainer):
+        if trainer.state.iteration == iteration_to_stop:
             trainer.terminate()
 
     trainer.add_event_handler(Events.ITERATION_STARTED, start_of_iteration_handler)
-    state = trainer.run(data=[None] * num_iterations_per_epoch, max_epochs=3)
+    trainer.run(data=[None] * num_iterations_per_epoch, max_epochs=3)
     # completes the iteration but doesn't increment counter (this happens just before a new iteration starts)
-    assert (state.iteration == iteration_to_stop)
-    assert state.epoch == np.ceil(iteration_to_stop / num_iterations_per_epoch)  # it starts from 0
+    assert (trainer.state.iteration == iteration_to_stop)
+    assert trainer.state.epoch == np.ceil(iteration_to_stop / num_iterations_per_epoch)  # it starts from 0
 
 
 def _create_mock_data_loader(epochs, batches_per_epoch):
@@ -213,15 +213,15 @@ def test_training_iteration_events_are_fired():
     mock_manager.attach_mock(iteration_started, 'iteration_started')
     mock_manager.attach_mock(iteration_complete, 'iteration_complete')
 
-    state = trainer.run(data, max_epochs=max_epochs)
+    trainer.run(data, max_epochs=max_epochs)
 
     assert iteration_started.call_count == num_batches * max_epochs
     assert iteration_complete.call_count == num_batches * max_epochs
 
     expected_calls = []
     for i in range(max_epochs * num_batches):
-        expected_calls.append(call.iteration_started(trainer, state))
-        expected_calls.append(call.iteration_complete(trainer, state))
+        expected_calls.append(call.iteration_started(trainer, trainer.state))
+        expected_calls.append(call.iteration_complete(trainer, trainer.state))
 
     assert mock_manager.mock_calls == expected_calls
 
@@ -240,8 +240,8 @@ def test_create_supervised_trainer():
     assert model.weight.data[0, 0] == approx(0.0)
     assert model.bias.data[0] == approx(0.0)
 
-    state = trainer.run(data)
+    trainer.run(data)
 
-    assert state.output == approx(17.0)
+    assert trainer.state.output == approx(17.0)
     assert model.weight.data[0, 0] == approx(1.3)
     assert model.bias.data[0] == approx(0.8)

--- a/tests/ignite/engines/test_trainer.py
+++ b/tests/ignite/engines/test_trainer.py
@@ -220,8 +220,8 @@ def test_training_iteration_events_are_fired():
 
     expected_calls = []
     for i in range(max_epochs * num_batches):
-        expected_calls.append(call.iteration_started(trainer, trainer.state))
-        expected_calls.append(call.iteration_complete(trainer, trainer.state))
+        expected_calls.append(call.iteration_started(trainer))
+        expected_calls.append(call.iteration_complete(trainer))
 
     assert mock_manager.mock_calls == expected_calls
 

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -44,7 +44,7 @@ def test_args_validation(dirname):
 
 def test_simple_recovery(dirname):
     h = ModelCheckpoint(dirname, _PREFIX, create_dir=False, save_interval=1)
-    h(None, None, {'obj': 42})
+    h(None, {'obj': 42})
 
     fname = os.path.join(dirname, '{}_{}_{}.pth'.format(_PREFIX, 'obj', 1))
     assert torch.load(fname) == 42
@@ -62,7 +62,7 @@ def test_atomic(dirname):
                             save_interval=1)
 
         try:
-            h(None, None, {name: obj})
+            h(None, {name: obj})
         except:
             pass
 
@@ -81,7 +81,7 @@ def test_last_k(dirname):
     to_save = {'name': 42}
 
     for _ in range(8):
-        h(None, None, to_save)
+        h(None, to_save)
 
     expected = ['{}_{}_{}.pth'.format(_PREFIX, 'name', i)
                 for i in [6, 8]]
@@ -92,7 +92,7 @@ def test_last_k(dirname):
 def test_best_k(dirname):
     scores = iter([1.0, -2., 3.0, -4.0])
 
-    def score_function(state):
+    def score_function(engine):
         return next(scores)
 
     h = ModelCheckpoint(dirname, _PREFIX, create_dir=False,
@@ -100,7 +100,7 @@ def test_best_k(dirname):
 
     to_save = {'name': 42}
     for _ in range(4):
-        h(None, None, to_save)
+        h(None, to_save)
 
     expected = ['{}_{}_{}.pth'.format(_PREFIX, 'name', i)
                 for i in [1, 3]]

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -110,7 +110,7 @@ def test_best_k(dirname):
 
 def test_with_trainer(dirname):
 
-    def update_fn(batch):
+    def update_fn(engine, batch):
         pass
 
     name = 'model'

--- a/tests/ignite/handlers/test_timing.py
+++ b/tests/ignite/handlers/test_timing.py
@@ -31,7 +31,7 @@ def test_timer():
                    resume=Events.EPOCH_STARTED)
 
     @trainer.on(Events.EPOCH_COMPLETED)
-    def run_validation(trainer, state):
+    def run_validation(trainer):
         tester.run(range(n_iter))
 
     # Run "training"

--- a/tests/ignite/handlers/test_timing.py
+++ b/tests/ignite/handlers/test_timing.py
@@ -11,7 +11,7 @@ def test_timer():
     def _train_func(engine, batch):
         time.sleep(sleep_t)
 
-    def _test_func(batch):
+    def _test_func(engine, batch):
         time.sleep(sleep_t)
 
     trainer = Trainer(_train_func)

--- a/tests/ignite/handlers/test_timing.py
+++ b/tests/ignite/handlers/test_timing.py
@@ -8,7 +8,7 @@ def test_timer():
     sleep_t = 0.2
     n_iter = 3
 
-    def _train_func(batch):
+    def _train_func(engine, batch):
         time.sleep(sleep_t)
 
     def _test_func(batch):


### PR DESCRIPTION
Addressing #117:

- Attached `state` to `Engine`
- `Trainer` and `Evaluator` `run()` methods no longer return anything
- `Engine` is the only argument now passed by default to event handlers (not `engine, state`)
- `engine, batch` is now passed to update functions, rather than just `batch`