### PR TITLE
Split into two steps: download and visdom server launch in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   # mnist.py
   - python examples/mnist.py --epochs=1
   # mnist_with_visdom.py
+  - python -c "from visdom.server import download_scripts; download_scripts()" # download scripts : https://github.com/facebookresearch/visdom/blob/master/py/server.py#L929
   - python -m visdom.server &
   - sleep 10
   - python examples/mnist_with_visdom.py --epochs=1


### PR DESCRIPTION
Split test of the preparation part to launch mnist with visdom. Sometimes visdom server starting time depassed 10 seconds (sleep time) before starting the example and thus tests fail.

Looking closely to the source of [visdom.server](https://github.com/facebookresearch/visdom/blob/master/py/server.py#L929)
```
if __name__ == "__main__":
    download_scripts()
    main()
```
the first part can be called separately before starting the server.

Observing travis [logs](https://travis-ci.org/vfdev-5/ignite/jobs/358951087), we can see that downloading part takes ~3,4 seconds.
Probably, this can solve the previous problems of failed test.

