### PR TITLE
[issue #139] Check event handler's signature before registering

### DIFF
--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -63,8 +63,8 @@ class Engine(object):
         if self._process_function is None:
             raise ValueError("Engine must be given a processing function in order to run")
 
-        BATCH_PLACEHOLDER = None
-        self._check_signature(process_function, 'process_function', BATCH_PLACEHOLDER)
+        batch_placeholder = None
+        self._check_signature(process_function, 'process_function', batch_placeholder)
 
     def add_event_handler(self, event_name, handler, *args, **kwargs):
         """Add an event handler to be executed when the specified event is fired

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -70,6 +70,21 @@ class Engine(object):
             *args: optional args to be passed to `handler`
             **kwargs: optional keyword args to be passed to `handler`
 
+        Notes:
+              The handler function's first argument will be `self`, the `Engine` object it was bound to.
+
+              Note that other arguments can be passed to the handler in addition to the `*args` and `**kwargs`
+              passed here, for example during `Events.EXCEPTION_RAISED`.
+
+        Example usage:
+        ```python
+        engine = Engine(process_function)
+
+        def print_epoch(engine):
+            print("Epoch: {}".format(engine.state.epoch))
+
+        engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch)
+        ```
         """
         if event_name not in Events.__members__.values():
             self._logger.error("attempt to add event handler to an invalid event %s ", event_name)

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -63,8 +63,7 @@ class Engine(object):
         if self._process_function is None:
             raise ValueError("Engine must be given a processing function in order to run")
 
-        batch_placeholder = None
-        self._check_signature(process_function, 'process_function', batch_placeholder)
+        self._check_signature(process_function, 'process_function', None)
 
     def add_event_handler(self, event_name, handler, *args, **kwargs):
         """Add an event handler to be executed when the specified event is fired

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import time
 from enum import Enum
@@ -56,6 +57,16 @@ class Engine(object):
         if event_name not in Events.__members__.values():
             self._logger.error("attempt to add event handler to an invalid event %s ", event_name)
             raise ValueError("Event {} is not a valid event for this Engine".format(event_name))
+
+        signature = inspect.signature(handler)
+        try:
+            signature.bind(self, *args, **kwargs)
+        except TypeError as exc:
+            parameters = signature.parameters
+            raise ValueError("Error adding handler '{}': "
+                             "takes parameters {} but will be called with {} "
+                             "({})".format(
+                                 handler, list(parameters), [self] + list(args) + list(kwargs), exc))
 
         if event_name not in self._event_handlers:
             self._event_handlers[event_name] = []

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -33,8 +33,22 @@ class Engine(object):
 
     Args:
         process_function (Callable): A function receiving a handle to the engine and the current batch
-            in each iteration, outputing data to be stored in the state
+            in each iteration, and returns data to be stored in the engine's state
 
+    Example usage:
+    ```python
+    def process_function(engine, batch):
+        inputs, targets = batch
+        optimizer.zero_grad()
+        y_pred = model(inputs)
+        loss = loss_fn(y_pred, targets)
+        loss.backward()
+        optimizer.step()
+        return loss.item()
+
+    engine = Engine(process_function)
+    engine.run(data_loader)
+    ```
     """
     def __init__(self, process_function):
         self._event_handlers = {}

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -63,14 +63,10 @@ class Engine(object):
             inspect.getcallargs(callable_, self, *args, **kwargs)
         except TypeError as exc:
             spec = inspect.getargspec(callable_)
-            arg_names = (spec.args +
-                         list(spec.varargs or {}) +
-                         list(spec.keywords or {}) +
-                         list(spec.defaults or {}))
             raise ValueError("Error adding handler '{}': "
                              "takes parameters {} but will be called with {} "
                              "({})".format(
-                                 handler, arg_names, [self] + list(args) + list(kwargs), exc))
+                                 handler, spec.args, [self] + list(args) + list(kwargs), exc))
 
         if event_name not in self._event_handlers:
             self._event_handlers[event_name] = []

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -6,6 +6,8 @@ from enum import Enum
 
 from ignite._utils import _to_hours_mins_secs
 
+IS_PYTHON2 = sys.version_info[0] < 3
+
 
 class Events(Enum):
     EPOCH_STARTED = "epoch_started"
@@ -70,7 +72,7 @@ class Engine(object):
     def _check_handler_signature(self, handler, *args, **kwargs):
         exception_msg = None
 
-        if sys.version_info[0] < 3:
+        if IS_PYTHON2:
             try:
                 callable_ = handler if hasattr(handler, '__name__') else handler.__call__
                 inspect.getcallargs(callable_, self, *args, **kwargs)

--- a/ignite/engines/engine.py
+++ b/ignite/engines/engine.py
@@ -37,17 +37,19 @@ class Engine(object):
 
     Example usage:
     ```python
-    def process_function(engine, batch):
+    def train_and_store_loss(engine, batch):
         inputs, targets = batch
         optimizer.zero_grad()
-        y_pred = model(inputs)
-        loss = loss_fn(y_pred, targets)
+        outputs = model(inputs)
+        loss = loss_fn(outputs, targets)
         loss.backward()
         optimizer.step()
         return loss.item()
 
-    engine = Engine(process_function)
+    engine = Engine(train_and_store_loss)
     engine.run(data_loader)
+
+    # Loss value is now stored in `engine.state.output`.
     ```
     """
     def __init__(self, process_function):

--- a/tests/ignite/engines/test_engine.py
+++ b/tests/ignite/engines/test_engine.py
@@ -44,6 +44,42 @@ def test_add_event_handler_raises_with_invalid_event():
         engine.add_event_handler("incorrect", lambda engine: None)
 
 
+def test_add_event_handler_raises_with_invalid_signature():
+    engine = Engine(MagicMock())
+
+    def handler(engine):
+        pass
+
+    engine.add_event_handler(Events.STARTED, handler)
+    with pytest.raises(ValueError):
+        engine.add_event_handler(Events.STARTED, handler, 1)
+
+    def handler_with_args(engine, a):
+        pass
+
+    engine.add_event_handler(Events.STARTED, handler_with_args, 1)
+    with pytest.raises(ValueError):
+        engine.add_event_handler(Events.STARTED, handler_with_args)
+
+    def handler_with_kwargs(engine, b=42):
+        pass
+
+    engine.add_event_handler(Events.STARTED, handler_with_kwargs, b=2)
+    with pytest.raises(ValueError):
+        engine.add_event_handler(Events.STARTED, handler_with_kwargs, c=3)
+    with pytest.raises(ValueError):
+        engine.add_event_handler(Events.STARTED, handler_with_kwargs, 1, b=2)
+
+    def handler_with_args_and_kwargs(engine, a, b=42):
+        pass
+
+    engine.add_event_handler(Events.STARTED, handler_with_args_and_kwargs, 1, b=2)
+    with pytest.raises(ValueError):
+        engine.add_event_handler(Events.STARTED, handler_with_args_and_kwargs, 1, 2, b=2)
+    with pytest.raises(ValueError):
+        engine.add_event_handler(Events.STARTED, handler_with_args_and_kwargs, 1, b=2, c=3)
+
+
 def test_add_event_handler():
     engine = DummyEngine()
 

--- a/tests/ignite/engines/test_engine.py
+++ b/tests/ignite/engines/test_engine.py
@@ -14,7 +14,7 @@ from ignite.engines import Engine, Events, State, create_supervised_trainer, cre
 from ignite.metrics import MeanSquaredError
 
 
-def process_func(batch):
+def process_func(engine, batch):
     return 1
 
 
@@ -35,6 +35,19 @@ def test_terminate():
     assert not engine.should_terminate
     engine.terminate()
     assert engine.should_terminate
+
+
+def test_invalid_process_raises_with_invalid_signature():
+    engine = Engine(lambda engine, batch: None)
+
+    with pytest.raises(ValueError):
+        Engine(lambda: None)
+
+    with pytest.raises(ValueError):
+        Engine(lambda batch: None)
+
+    with pytest.raises(ValueError):
+        Engine(lambda engine, batch, extra_arg: None)
 
 
 def test_add_event_handler_raises_with_invalid_event():


### PR DESCRIPTION
Addresses #139.

This adds a check to `Engine.add_event_handler()` that the handler's signature matches what it will actually be called with inside `_fire_event()`.

Adding a handler like this:
```
def handler(engine):
    pass

engine.add_event_handler(Events.STARTED, handler, 42)
```

Results in a traceback like this:
```
ValueError: Error adding handler '<function handler at 0x105323950>': takes parameters ['engine'] but will be called with [<ignite.engines.engine.Engine object at 0x107a0a8d0>, 42] (too many positional arguments)
```

Open to any and all feedback!