### PR TITLE
PyTorch 0.4.0 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment -c pytorch python=$TRAVIS_PYTHON_VERSION numpy mock pytorch==0.3.1
+  - conda create -q -n test-environment -c pytorch python=$TRAVIS_PYTHON_VERSION numpy mock pytorch
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install enum34; fi
   - source activate test-environment
   - python setup.py install

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -89,7 +89,7 @@ And update functions of the trainer and evaluator are simply:
     def _update(engine, batch):
         model.train()
         optimizer.zero_grad()
-        x, y = _prepare_batch(batch, requires_grad=False, device=device)
+        x, y = _prepare_batch(batch, device=device)
         y_pred = model(x)
         loss = loss_fn(y_pred, y)
         loss.backward()
@@ -98,7 +98,7 @@ And update functions of the trainer and evaluator are simply:
 
     def _inference(engine, batch):
         model.eval()
-        x, y = _prepare_batch(batch, requires_grad=False, device=device)
+        x, y = _prepare_batch(batch, device=device)
         y_pred = model(x)
         return y_pred, y
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -89,18 +89,18 @@ And update functions of the trainer and evaluator are simply:
     def _update(engine, batch):
         model.train()
         optimizer.zero_grad()
-        x, y = _prepare_batch(batch, cuda)
+        x, y = _prepare_batch(batch, requires_grad=False, device=device)
         y_pred = model(x)
         loss = loss_fn(y_pred, y)
         loss.backward()
         optimizer.step()
-        return loss.data.cpu()[0]
+        return loss.item()
 
     def _inference(engine, batch):
         model.eval()
-        x, y = _prepare_batch(batch, cuda, volatile=True)
+        x, y = _prepare_batch(batch, requires_grad=False, device=device)
         y_pred = model(x)
-        return to_tensor(y_pred, cpu=not cuda), to_tensor(y, cpu=not cuda)
+        return y_pred, y
 
 Note that the helper function :meth:`create_supervised_evaluator` to create an evaluator accepts an
 argument `metrics`:

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -44,12 +44,11 @@ def get_data_loaders(train_batch_size, val_batch_size):
 
 
 def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
-    cuda = torch.cuda.is_available()
     train_loader, val_loader = get_data_loaders(train_batch_size, val_batch_size)
-
     model = Net()
-    device = None
-    if cuda:
+    device = 'cpu'
+
+    if torch.cuda.is_available():
         device = 'cuda'
         model = model.to(device)
 

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -48,14 +48,17 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     train_loader, val_loader = get_data_loaders(train_batch_size, val_batch_size)
 
     model = Net()
+    device = None
     if cuda:
-        model = model.cuda()
+        device = 'cuda'
+        model = model.to(device)
+
     optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
-    trainer = create_supervised_trainer(model, optimizer, F.nll_loss, cuda=cuda)
+    trainer = create_supervised_trainer(model, optimizer, F.nll_loss, device=device)
     evaluator = create_supervised_evaluator(model,
                                             metrics={'accuracy': CategoricalAccuracy(),
                                                      'nll': Loss(F.nll_loss)},
-                                            cuda=cuda)
+                                            device=device)
 
     @trainer.on(Events.ITERATION_COMPLETED)
     def log_training_loss(engine):

--- a/examples/mnist_with_tensorboardx.py
+++ b/examples/mnist_with_tensorboardx.py
@@ -81,14 +81,17 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval, lo
 
     model = Net()
     writer = create_summary_writer(model, log_dir)
+    device = None
     if cuda:
-        model = model.cuda()
+        device = 'cuda'
+        model = model.to(device)
+
     optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
-    trainer = create_supervised_trainer(model, optimizer, F.nll_loss, cuda=cuda)
+    trainer = create_supervised_trainer(model, optimizer, F.nll_loss, device=device)
     evaluator = create_supervised_evaluator(model,
                                             metrics={'accuracy': CategoricalAccuracy(),
                                                      'nll': Loss(F.nll_loss)},
-                                            cuda=cuda)
+                                            device=device)
 
     @trainer.on(Events.ITERATION_COMPLETED)
     def log_training_loss(engine):

--- a/examples/mnist_with_tensorboardx.py
+++ b/examples/mnist_with_tensorboardx.py
@@ -76,13 +76,12 @@ def create_summary_writer(model, log_dir):
 
 
 def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval, log_dir):
-    cuda = torch.cuda.is_available()
     train_loader, val_loader = get_data_loaders(train_batch_size, val_batch_size)
-
     model = Net()
     writer = create_summary_writer(model, log_dir)
-    device = None
-    if cuda:
+    device = 'cpu'
+
+    if torch.cuda.is_available():
         device = 'cuda'
         model = model.to(device)
 

--- a/examples/mnist_with_visdom.py
+++ b/examples/mnist_with_visdom.py
@@ -57,12 +57,11 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     if not vis.check_connection():
         raise RuntimeError("Visdom server not running. Please run python -m visdom.server")
 
-    cuda = torch.cuda.is_available()
     train_loader, val_loader = get_data_loaders(train_batch_size, val_batch_size)
-
     model = Net()
-    device = None
-    if cuda:
+    device = 'cpu'
+
+    if torch.cuda.is_available():
         device = 'cuda'
         model = model.to(device)
 

--- a/examples/mnist_with_visdom.py
+++ b/examples/mnist_with_visdom.py
@@ -61,14 +61,17 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     train_loader, val_loader = get_data_loaders(train_batch_size, val_batch_size)
 
     model = Net()
+    device = None
     if cuda:
-        model = model.cuda()
+        device = 'cuda'
+        model = model.to(device)
+
     optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
-    trainer = create_supervised_trainer(model, optimizer, F.nll_loss, cuda=cuda)
+    trainer = create_supervised_trainer(model, optimizer, F.nll_loss, device=device)
     evaluator = create_supervised_evaluator(model,
                                             metrics={'accuracy': CategoricalAccuracy(),
                                                      'nll': Loss(F.nll_loss)},
-                                            cuda=cuda)
+                                            device=device)
 
     train_loss_window = create_plot_window(vis, '#Iterations', 'Loss', 'Training Loss')
     val_accuracy_window = create_plot_window(vis, '#Epochs', 'Accuracy', 'Validation Accuracy')

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -15,7 +15,8 @@ def to_variable(batch, cuda=False, volatile=False):
     if torch.is_tensor(batch):
         if cuda:
             batch = batch.cuda()
-        return Variable(batch, volatile=volatile)
+        with torch.set_grad_enabled(not volatile):
+            return batch
     elif isinstance(batch, string_classes):
         return batch
     elif isinstance(batch, collections.Mapping):

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -20,7 +20,5 @@ def convert_tensor(tensor, requires_grad=False, device=None):
 
 
 def to_onehot(indices, num_classes):
-    onehot = torch.zeros(indices.size(0), num_classes)
-    if indices.is_cuda:
-        onehot = onehot.to('cuda')
+    onehot = torch.zeros(indices.size(0), num_classes, device=indices.device)
     return onehot.scatter_(1, indices.unsqueeze(1), 1)

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -11,19 +11,17 @@ def _to_hours_mins_secs(time_taken):
     return hours, mins, secs
 
 
-def convert_tensor(input_, requires_grad=False, device=None):
+def convert_tensor(input_, device=None):
     if torch.is_tensor(input_):
         if device:
             input_ = input_.to(device=device)
-        if requires_grad != input_.requires_grad:
-            input_.requires_grad_(requires_grad)
         return input_
     elif isinstance(input_, string_classes):
         return input_
     elif isinstance(input_, collections.Mapping):
-        return {k: convert_tensor(sample, requires_grad=requires_grad, device=device) for k, sample in input_.items()}
+        return {k: convert_tensor(sample, device=device) for k, sample in input_.items()}
     elif isinstance(input_, collections.Sequence):
-        return [convert_tensor(sample, requires_grad=requires_grad, device=device) for sample in input_]
+        return [convert_tensor(sample, device=device) for sample in input_]
     else:
         raise TypeError(("input must contain tensors, numbers, dicts or lists; found {}"
                          .format(type(input_[0]))))

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -11,35 +11,19 @@ def _to_hours_mins_secs(time_taken):
     return hours, mins, secs
 
 
-def to_variable(batch, cuda=False, volatile=False):
-    if torch.is_tensor(batch):
+def to_tensor(variable, cuda=False, requires_grad=False):
+    if torch.is_tensor(variable):
         if cuda:
-            batch = batch.cuda()
-        with torch.set_grad_enabled(not volatile):
-            return batch
-    elif isinstance(batch, string_classes):
-        return batch
-    elif isinstance(batch, collections.Mapping):
-        return {k: to_variable(sample, cuda=cuda, volatile=volatile) for k, sample in batch.items()}
-    elif isinstance(batch, collections.Sequence):
-        return [to_variable(sample, cuda=cuda, volatile=volatile) for sample in batch]
-    else:
-        raise TypeError(("batch must contain tensors, numbers, dicts or lists; found {}"
-                         .format(type(batch[0]))))
-
-
-def to_tensor(variable, cpu=False):
-    if isinstance(variable, Variable):
-        t = variable.data
-        if cpu:
-            t = t.cpu()
-        return t
+            variable = variable.cuda()
+        if not requires_grad:
+            variable = variable.detach()
+        return variable
     elif isinstance(variable, string_classes):
         return variable
     elif isinstance(variable, collections.Mapping):
-        return {k: to_tensor(sample, cpu=cpu) for k, sample in variable.items()}
+        return {k: to_tensor(sample, cuda=cuda, requires_grad=requires_grad) for k, sample in variable.items()}
     elif isinstance(variable, collections.Sequence):
-        return [to_tensor(sample, cpu=cpu) for sample in variable]
+        return [to_tensor(sample, cuda=cuda, requires_grad=requires_grad) for sample in variable]
     else:
         raise TypeError(("Argument variable must contain torch.autograd.Variable, numbers, dicts or lists; found {}"
                          .format(type(variable))))

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -11,12 +11,22 @@ def _to_hours_mins_secs(time_taken):
     return hours, mins, secs
 
 
-def convert_tensor(tensor, requires_grad=False, device=None):
-    if device:
-        tensor = tensor.to(device=device)
-    if requires_grad != tensor.requires_grad:
-        tensor.requires_grad_(requires_grad)
-    return tensor
+def convert_tensor(input_, requires_grad=False, device=None):
+    if torch.is_tensor(input_):
+        if device:
+            input_ = input_.to(device=device)
+        if requires_grad != input_.requires_grad:
+            input_.requires_grad_(requires_grad)
+        return input_
+    elif isinstance(input_, string_classes):
+        return input_
+    elif isinstance(input_, collections.Mapping):
+        return {k: convert_tensor(sample, requires_grad=requires_grad, device=device) for k, sample in input_.items()}
+    elif isinstance(input_, collections.Sequence):
+        return [convert_tensor(sample, requires_grad=requires_grad, device=device) for sample in input_]
+    else:
+        raise TypeError(("input must contain tensors, numbers, dicts or lists; found {}"
+                         .format(type(input_[0]))))
 
 
 def to_onehot(indices, num_classes):

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -11,26 +11,16 @@ def _to_hours_mins_secs(time_taken):
     return hours, mins, secs
 
 
-def to_tensor(variable, cuda=False, requires_grad=False):
-    if torch.is_tensor(variable):
-        if cuda:
-            variable = variable.cuda()
-        if not requires_grad:
-            variable = variable.detach()
-        return variable
-    elif isinstance(variable, string_classes):
-        return variable
-    elif isinstance(variable, collections.Mapping):
-        return {k: to_tensor(sample, cuda=cuda, requires_grad=requires_grad) for k, sample in variable.items()}
-    elif isinstance(variable, collections.Sequence):
-        return [to_tensor(sample, cuda=cuda, requires_grad=requires_grad) for sample in variable]
-    else:
-        raise TypeError(("Argument variable must contain torch.autograd.Variable, numbers, dicts or lists; found {}"
-                         .format(type(variable))))
+def convert_tensor(tensor, requires_grad=False, device=None):
+    if device:
+        tensor = tensor.to(device=device)
+    if requires_grad != tensor.requires_grad:
+        tensor.requires_grad_(requires_grad)
+    return tensor
 
 
 def to_onehot(indices, num_classes):
     onehot = torch.zeros(indices.size(0), num_classes)
     if indices.is_cuda:
-        onehot = onehot.cuda()
+        onehot = onehot.to('cuda')
     return onehot.scatter_(1, indices.unsqueeze(1), 1)

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -2,7 +2,6 @@ import collections
 
 import torch
 from torch._six import string_classes
-from torch.autograd import Variable
 
 
 def _to_hours_mins_secs(time_taken):

--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -24,7 +24,7 @@ def convert_tensor(input_, device=None):
         return [convert_tensor(sample, device=device) for sample in input_]
     else:
         raise TypeError(("input must contain tensors, numbers, dicts or lists; found {}"
-                         .format(type(input_[0]))))
+                         .format(type(input_))))
 
 
 def to_onehot(indices, num_classes):

--- a/ignite/engines/__init__.py
+++ b/ignite/engines/__init__.py
@@ -30,7 +30,7 @@ def create_supervised_trainer(model, optimizer, loss_fn, cuda=False):
         loss = loss_fn(y_pred, y)
         loss.backward()
         optimizer.step()
-        return loss.data.cpu()[0]
+        return loss.data.cpu().item()
 
     return Engine(_update)
 

--- a/ignite/engines/__init__.py
+++ b/ignite/engines/__init__.py
@@ -50,7 +50,7 @@ def create_supervised_evaluator(model, metrics={}, device=None):
         model.eval()
         x, y = _prepare_batch(batch, requires_grad=False, device=device)
         y_pred = model(x)
-        return (y_pred, y)
+        return y_pred, y
 
     engine = Engine(_inference)
 

--- a/ignite/engines/__init__.py
+++ b/ignite/engines/__init__.py
@@ -1,11 +1,11 @@
 from ignite.engines.engine import Engine, Events, State
-from ignite._utils import to_variable, to_tensor
+from ignite._utils import to_tensor
 
 
-def _prepare_batch(batch, cuda, volatile=False):
+def _prepare_batch(batch, cuda, requires_grad=True):
     x, y = batch
-    x = to_variable(x, cuda=cuda, volatile=volatile)
-    y = to_variable(y, cuda=cuda, volatile=volatile)
+    x = to_tensor(x, cuda=cuda, requires_grad=requires_grad)
+    y = to_tensor(y, cuda=cuda, requires_grad=requires_grad)
     return x, y
 
 
@@ -49,9 +49,9 @@ def create_supervised_evaluator(model, metrics={}, cuda=False):
     """
     def _inference(engine, batch):
         model.eval()
-        x, y = _prepare_batch(batch, cuda, volatile=True)
+        x, y = _prepare_batch(batch, cuda, requires_grad=False)
         y_pred = model(x)
-        return to_tensor(y_pred, cpu=not cuda), to_tensor(y, cpu=not cuda)
+        return to_tensor(y_pred, cuda=cuda), to_tensor(y, cuda=cuda)
 
     engine = Engine(_inference)
 

--- a/ignite/engines/__init__.py
+++ b/ignite/engines/__init__.py
@@ -30,7 +30,7 @@ def create_supervised_trainer(model, optimizer, loss_fn, cuda=False):
         loss = loss_fn(y_pred, y)
         loss.backward()
         optimizer.step()
-        return loss.data.cpu().item()
+        return loss.item()
 
     return Engine(_update)
 

--- a/ignite/metrics/binary_accuracy.py
+++ b/ignite/metrics/binary_accuracy.py
@@ -22,7 +22,7 @@ class BinaryAccuracy(Metric):
     def update(self, output):
         y_pred, y = output
         correct = torch.eq(torch.round(y_pred).type(y.type()), y).view(-1)
-        self._num_correct += torch.sum(correct)
+        self._num_correct += torch.sum(correct).item()
         self._num_examples += correct.shape[0]
 
     def compute(self):

--- a/ignite/metrics/categorical_accuracy.py
+++ b/ignite/metrics/categorical_accuracy.py
@@ -22,7 +22,7 @@ class CategoricalAccuracy(Metric):
         y_pred, y = output
         indices = torch.max(y_pred, 1)[1]
         correct = torch.eq(indices, y).view(-1)
-        self._num_correct += torch.sum(correct)
+        self._num_correct += torch.sum(correct).item()
         self._num_examples += correct.shape[0]
 
     def compute(self):

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -24,9 +24,9 @@ class Loss(Metric):
 
     def update(self, output):
         y_pred, y = output
-        average_loss = self._loss_fn(Variable(y_pred, volatile=True), Variable(y, volatile=True))
-        assert average_loss.shape == (1,), '`loss_fn` did not return the average loss'
-        self._sum += average_loss.data[0] * y.shape[0]
+        average_loss = self._loss_fn(y_pred, y)
+        assert len(average_loss.shape) == 0, '`loss_fn` did not return the average loss'
+        self._sum += average_loss.item() * y.shape[0]
         self._num_examples += y.shape[0]
 
     def compute(self):

--- a/ignite/metrics/mean_pairwise_distance.py
+++ b/ignite/metrics/mean_pairwise_distance.py
@@ -25,7 +25,7 @@ class MeanPairwiseDistance(Metric):
     def update(self, output):
         y_pred, y = output
         distances = pairwise_distance(y_pred, y, p=self._p, eps=self._eps)
-        self._sum_of_distances += torch.sum(distances)
+        self._sum_of_distances += torch.sum(distances).item()
         self._num_examples += y.shape[0]
 
     def compute(self):

--- a/ignite/metrics/mean_squared_error.py
+++ b/ignite/metrics/mean_squared_error.py
@@ -19,7 +19,7 @@ class MeanSquaredError(Metric):
     def update(self, output):
         y_pred, y = output
         squared_errors = torch.pow(y_pred - y.view_as(y_pred), 2)
-        self._sum_of_squared_errors += torch.sum(squared_errors)
+        self._sum_of_squared_errors += torch.sum(squared_errors).item()
         self._num_examples += y.shape[0]
 
     def compute(self):

--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -49,6 +49,6 @@ class Precision(Metric):
         result = self._true_positives / self._all_positives
         result[result != result] = 0.0
         if self._average:
-            return result.mean()
+            return result.mean().item()
         else:
             return result

--- a/ignite/metrics/recall.py
+++ b/ignite/metrics/recall.py
@@ -49,6 +49,6 @@ class Recall(Metric):
         result = self._true_positives / self._actual
         result[result != result] = 0.0
         if self._average:
-            return result.mean()
+            return result.mean().item()
         else:
             return result

--- a/ignite/metrics/top_k_categorical_accuracy.py
+++ b/ignite/metrics/top_k_categorical_accuracy.py
@@ -25,7 +25,7 @@ class TopKCategoricalAccuracy(Metric):
         sorted_indices = torch.topk(y_pred, self._k, dim=1)[1]
         expanded_y = y.view(-1, 1).expand(-1, self._k)
         correct = torch.sum(torch.eq(sorted_indices, expanded_y), dim=1)
-        self._num_correct += torch.sum(correct)
+        self._num_correct += torch.sum(correct).item()
         self._num_examples += correct.shape[0]
 
     def compute(self):

--- a/tests/ignite/engines/test_engine.py
+++ b/tests/ignite/engines/test_engine.py
@@ -333,14 +333,14 @@ def test_create_supervised_trainer():
     y = torch.FloatTensor([[3.0], [5.0]])
     data = [(x, y)]
 
-    assert model.weight.data[0, 0] == approx(0.0)
-    assert model.bias.data[0] == approx(0.0)
+    assert model.weight.data[0, 0].item() == approx(0.0)
+    assert model.bias.item() == approx(0.0)
 
     state = trainer.run(data)
 
     assert state.output == approx(17.0)
-    assert model.weight.data[0, 0] == approx(1.3)
-    assert model.bias.data[0] == approx(0.8)
+    assert model.weight.data[0, 0].item() == approx(1.3)
+    assert model.bias.item() == approx(0.8)
 
 
 def test_create_supervised():
@@ -357,13 +357,13 @@ def test_create_supervised():
     state = evaluator.run(data)
     y_pred, y = state.output
 
-    assert y_pred[0, 0] == approx(0.0)
-    assert y_pred[1, 0] == approx(0.0)
-    assert y[0, 0] == approx(3.0)
-    assert y[1, 0] == approx(5.0)
+    assert y_pred[0, 0].item() == approx(0.0)
+    assert y_pred[1, 0].item() == approx(0.0)
+    assert y[0, 0].item() == approx(3.0)
+    assert y[1, 0].item() == approx(5.0)
 
-    assert model.weight.data[0, 0] == approx(0.0)
-    assert model.bias.data[0] == approx(0.0)
+    assert model.weight.data[0, 0].item() == approx(0.0)
+    assert model.bias.item() == approx(0.0)
 
 
 def test_create_supervised_with_metrics():

--- a/tests/ignite/metrics/test_binary_accuracy.py
+++ b/tests/ignite/metrics/test_binary_accuracy.py
@@ -16,12 +16,14 @@ def test_compute():
     y_pred = torch.FloatTensor([0.2, 0.4, 0.6, 0.8])
     y = torch.ones(4).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.5
 
     acc.reset()
     y_pred = torch.FloatTensor([0.2, 0.7, 0.8, 0.9])
     y = torch.ones(4).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.75
 
 
@@ -34,6 +36,7 @@ def test_compute_batch_images():
                                  [0.2, 0.6]]])
     y = torch.ones(1, 2, 2).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.5
 
     acc.reset()
@@ -43,4 +46,5 @@ def test_compute_batch_images():
                                  [0.9, 0.6]]])
     y = torch.ones(2, 2, 2).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.75

--- a/tests/ignite/metrics/test_categorical_accuracy.py
+++ b/tests/ignite/metrics/test_categorical_accuracy.py
@@ -16,12 +16,14 @@ def test_compute():
     y_pred = torch.eye(4)
     y = torch.ones(4).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.25
 
     acc.reset()
     y_pred = torch.eye(2)
     y = torch.ones(2).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.5
 
 
@@ -38,6 +40,7 @@ def test_compute_batch_images():
 
     acc.update((y_pred, y))
 
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.5
 
     acc.reset()
@@ -51,4 +54,5 @@ def test_compute_batch_images():
                            [0, 2]]])
 
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.75

--- a/tests/ignite/metrics/test_mean_pairwise_distance.py
+++ b/tests/ignite/metrics/test_mean_pairwise_distance.py
@@ -17,10 +17,12 @@ def test_compute():
     y_pred = torch.Tensor([[3.0, 4.0], [-3.0, -4.0]])
     y = torch.zeros(2, 2)
     mpd.update((y_pred, y))
+    assert isinstance(mpd.compute(), float)
     assert mpd.compute() == approx(5.0)
 
     mpd.reset()
     y_pred = torch.Tensor([[4.0, 4.0, 4.0, 4.0], [-4.0, -4.0, -4.0, -4.0]])
     y = torch.zeros(2, 4)
     mpd.update((y_pred, y))
+    assert isinstance(mpd.compute(), float)
     assert mpd.compute() == approx(8.0)

--- a/tests/ignite/metrics/test_mean_squared_error.py
+++ b/tests/ignite/metrics/test_mean_squared_error.py
@@ -16,10 +16,12 @@ def test_compute():
     y_pred = torch.Tensor([[2.0], [-2.0]])
     y = torch.zeros(2)
     mse.update((y_pred, y))
+    assert isinstance(mse.compute(), float)
     assert mse.compute() == 4.0
 
     mse.reset()
     y_pred = torch.Tensor([[3.0], [-3.0]])
     y = torch.zeros(2)
     mse.update((y_pred, y))
+    assert isinstance(mse.compute(), float)
     assert mse.compute() == 9.0

--- a/tests/ignite/metrics/test_precision.py
+++ b/tests/ignite/metrics/test_precision.py
@@ -41,6 +41,7 @@ def test_compute_average():
     y_pred = torch.eye(4)
     y = torch.ones(4).type(torch.LongTensor)
     precision.update((y_pred, y))
+    assert isinstance(precision.compute(), float)
     assert precision.compute() == 0.25
 
 

--- a/tests/ignite/metrics/test_recall.py
+++ b/tests/ignite/metrics/test_recall.py
@@ -44,6 +44,7 @@ def test_compute_average():
     y = torch.ones(4).type(torch.LongTensor)
     recall.update((y_pred, y))
 
+    assert isinstance(recall.compute(), float)
     assert recall.compute() == 0.0625
 
 

--- a/tests/ignite/metrics/test_root_mean_squared_error.py
+++ b/tests/ignite/metrics/test_root_mean_squared_error.py
@@ -16,10 +16,12 @@ def test_compute():
     y_pred = torch.Tensor([[2.0], [-2.0]])
     y = torch.zeros(2)
     rmse.update((y_pred, y))
+    assert isinstance(rmse.compute(), float)
     assert rmse.compute() == 2.0
 
     rmse.reset()
     y_pred = torch.Tensor([[3.0], [-3.0]])
     y = torch.zeros(2)
     rmse.update((y_pred, y))
+    assert isinstance(rmse.compute(), float)
     assert rmse.compute() == 3.0

--- a/tests/ignite/metrics/test_top_k_categorical_accuracy.py
+++ b/tests/ignite/metrics/test_top_k_categorical_accuracy.py
@@ -16,10 +16,12 @@ def test_compute():
     y_pred = torch.FloatTensor([[0.2, 0.4, 0.6, 0.8], [0.8, 0.6, 0.4, 0.2]])
     y = torch.ones(2).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 0.5
 
     acc.reset()
     y_pred = torch.FloatTensor([[0.4, 0.8, 0.2, 0.6], [0.8, 0.6, 0.4, 0.2]])
     y = torch.ones(2).type(torch.LongTensor)
     acc.update((y_pred, y))
+    assert isinstance(acc.compute(), float)
     assert acc.compute() == 1.0

--- a/tests/ignite/test__utils.py
+++ b/tests/ignite/test__utils.py
@@ -5,6 +5,27 @@ from ignite._utils import convert_tensor, to_onehot
 
 
 def test_convert_tensor():
+    x = torch.Tensor([0.0])
+    tensor = convert_tensor(x)
+    assert torch.is_tensor(tensor)
+
+    x = (torch.Tensor([0.0]), torch.Tensor([0.0]))
+    list_ = convert_tensor(x)
+    assert isinstance(list_, list)
+    assert torch.is_tensor(list_[0])
+    assert torch.is_tensor(list_[1])
+
+    x = {'a': torch.Tensor([0.0]), 'b': torch.Tensor([0.0])}
+    dict_ = convert_tensor(x)
+    assert isinstance(dict_, dict)
+    assert torch.is_tensor(dict_['a'])
+    assert torch.is_tensor(dict_['b'])
+
+    assert convert_tensor('a') == 'a'
+
+    with pytest.raises(TypeError):
+        convert_tensor(12345)
+
     tensor = torch.Tensor([1])
     assert not tensor.requires_grad
     tensor = convert_tensor(tensor, requires_grad=True)

--- a/tests/ignite/test__utils.py
+++ b/tests/ignite/test__utils.py
@@ -1,24 +1,7 @@
 import pytest
 import torch
 from torch.autograd import Variable
-from ignite._utils import to_variable, to_tensor, to_onehot
-
-
-def test_to_variable():
-    x = torch.Tensor([0.0])
-    var_x = to_variable(x)
-    assert isinstance(var_x, Variable)
-
-    x = (torch.Tensor([0.0]), torch.Tensor([0.0]))
-    var_x = to_variable(x)
-    assert isinstance(var_x, list) and isinstance(var_x[0], Variable) and isinstance(var_x[1], Variable)
-
-    x = {'a': torch.Tensor([0.0]), 'b': torch.Tensor([0.0])}
-    var_x = to_variable(x)
-    assert isinstance(var_x, dict) and isinstance(var_x['a'], Variable) and isinstance(var_x['b'], Variable)
-
-    with pytest.raises(TypeError):
-        to_variable(12345)
+from ignite._utils import to_tensor, to_onehot
 
 
 def test_to_tensor():
@@ -36,6 +19,12 @@ def test_to_tensor():
 
     with pytest.raises(TypeError):
         to_tensor(12345)
+
+    x = torch.ones(1, requires_grad=True)
+    y = to_tensor(x + 2, requires_grad=False)
+    z = y + 2
+    assert not y.requires_grad
+    assert not z.requires_grad
 
 
 def test_to_onehot():

--- a/tests/ignite/test__utils.py
+++ b/tests/ignite/test__utils.py
@@ -1,30 +1,21 @@
 import pytest
 import torch
 from torch.autograd import Variable
-from ignite._utils import to_tensor, to_onehot
+from ignite._utils import convert_tensor, to_onehot
 
 
-def test_to_tensor():
-    var_x = Variable(torch.Tensor([0.0]))
-    x = to_tensor(var_x)
-    assert torch.is_tensor(x)
+def test_convert_tensor():
+    tensor = torch.Tensor([1])
+    assert not tensor.requires_grad
+    tensor = convert_tensor(tensor, requires_grad=True)
+    assert tensor.requires_grad
 
-    var_x = (Variable(torch.Tensor([0.0])), Variable(torch.Tensor([0.0])))
-    x = to_tensor(var_x)
-    assert isinstance(x, list) and torch.is_tensor(x[0]) and torch.is_tensor(x[1])
-
-    var_x = {'a': Variable(torch.Tensor([0.0])), 'b': Variable(torch.Tensor([0.0]))}
-    x = to_tensor(var_x)
-    assert isinstance(x, dict) and torch.is_tensor(x['a']) and torch.is_tensor(x['b'])
-
-    with pytest.raises(TypeError):
-        to_tensor(12345)
-
-    x = torch.ones(1, requires_grad=True)
-    y = to_tensor(x + 2, requires_grad=False)
-    z = y + 2
-    assert not y.requires_grad
-    assert not z.requires_grad
+    # 'convert_tensor' will not catch exceptions raised by pytorch.
+    leaf = torch.Tensor([1])
+    leaf.requires_grad_(True)
+    not_leaf = leaf + 2
+    with pytest.raises(RuntimeError):
+        convert_tensor(not_leaf, requires_grad=False)
 
 
 def test_to_onehot():

--- a/tests/ignite/test__utils.py
+++ b/tests/ignite/test__utils.py
@@ -26,18 +26,6 @@ def test_convert_tensor():
     with pytest.raises(TypeError):
         convert_tensor(12345)
 
-    tensor = torch.Tensor([1])
-    assert not tensor.requires_grad
-    tensor = convert_tensor(tensor, requires_grad=True)
-    assert tensor.requires_grad
-
-    # 'convert_tensor' will not catch exceptions raised by pytorch.
-    leaf = torch.Tensor([1])
-    leaf.requires_grad_(True)
-    not_leaf = leaf + 2
-    with pytest.raises(RuntimeError):
-        convert_tensor(not_leaf, requires_grad=False)
-
 
 def test_to_onehot():
     indices = torch.LongTensor([0, 1, 2, 3])


### PR DESCRIPTION
Addresses #154.

I _think_ I hit everything necessary, but it's totally possible that I missed something. (I'm also not 100% sure yet of the use of `torch.set_grad_enabled` to replace `volatile`.) In any case, hopefully this will be a helpful start.

One really pernicious thing to note is that `Metric.compute() == <some_value>` will always be true unless that method extracts the scalar value from the new `torch.tensor` scalar. In other words, because `Tensor.data.__getindex__` returns a tensor now, `torch.Tensor.__eq__` will return another tensor like this:

```
In [1]: import torch

In [2]: not_a_float = torch.Tensor([0.0]).data[0]

In [3]: not_a_float == 0.5
Out[3]: tensor(0, dtype=torch.uint8)
```

Which is truthy in the unit tests. Kinda tricky! I added `assert isinstance(<val>, float)` checks to try and catch that (in addition to using `.item()` in the metric methods themselves), but maybe there is a better way.