### PR TITLE
Trainer with metrics

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -29,6 +29,13 @@ Code
         print("Epoch[{}] Loss: {:.2f}".format(trainer.state.epoch, len(train_loader), trainer.state.output))
 
     @trainer.on(Events.EPOCH_COMPLETED)
+    def log_training_results(trainer):
+        evaluator.run(train_loader)
+        metrics = evaluator.state.metrics
+        print("Training Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"
+              .format(trainer.state.epoch, metrics['accuracy'], metrics['nll']))
+
+    @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(trainer):
         evaluator.run(val_loader)
         metrics = evaluator.state.metrics
@@ -136,10 +143,18 @@ or equivalently without the decorator
 
     trainer.add_event_handler(Events.ITERATION_COMPLETED, log_training_loss)
 
-When an epoch ends we want to run model validation, therefore we attach another handler to the trainer on epoch complete
-event:
+When an epoch ends we want compute training and validation metrics [#f1]_. For that purpose we can run previously defined
+`evaluator` on `train_loader` and `val_loader`. Therefore we attach two additional handlers to the trainer on epoch
+complete event:
 
 .. code-block:: python
+
+    @trainer.on(Events.EPOCH_COMPLETED)
+    def log_training_results(trainer):
+        evaluator.run(train_loader)
+        metrics = evaluator.state.metrics
+        print("Training Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"
+              .format(trainer.state.epoch, metrics['accuracy'], metrics['nll']))
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(engine):
@@ -164,3 +179,40 @@ Finally, we start the engine on the training dataset and run it during 100 epoch
 .. code-block:: python
 
     trainer.run(train_loader, max_epochs=100)
+
+
+.. rubric:: Footnotes
+
+.. [#f1]
+
+   In this example we follow a pattern that requires a second pass through the training set. This
+   could be expensive on large datasets (even taking a subset). Another more common pattern is to accumulate
+   measures online over an epoch in the training loop. In this case metrics are aggregated on a moving model,
+   and thus, we do not want to encourage this pattern. However, if user still would like to implement the
+   last pattern, it can be easily done redefining trainer's update function and attaching metrics as following:
+
+   .. code-block:: python
+
+       def create_supervised_trainer(model, optimizer, loss_fn, metrics={}, device=None):
+
+           def _update(engine, batch):
+               model.train()
+               optimizer.zero_grad()
+               x, y = _prepare_batch(batch, device=device)
+               y_pred = model(x)
+               loss = loss_fn(y_pred, y)
+               loss.backward()
+               optimizer.step()
+               return loss.item(), y_pred, y
+
+           def _metrics_transform(output):
+               return output[1], output[2]
+
+           engine = Engine(_update)
+
+           for name, metric in metrics.items():
+               metric._output_transform = _metrics_transform
+               metric.attach(engine, name)
+
+           return engine
+

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -29,7 +29,7 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
-        return F.log_softmax(x)
+        return F.log_softmax(x, dim=-1)
 
 
 def get_data_loaders(train_batch_size, val_batch_size):
@@ -65,6 +65,15 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
         if iter % log_interval == 0:
             print("Epoch[{}] Iteration[{}/{}] Loss: {:.2f}"
                   "".format(engine.state.epoch, iter, len(train_loader), engine.state.output))
+
+    @trainer.on(Events.EPOCH_COMPLETED)
+    def log_training_results(engine):
+        evaluator.run(train_loader)
+        metrics = evaluator.state.metrics
+        avg_accuracy = metrics['accuracy']
+        avg_nll = metrics['nll']
+        print("Training Results - Epoch: {}  Avg accuracy: {:.2f} Avg loss: {:.2f}"
+              .format(engine.state.epoch, avg_accuracy, avg_nll))
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_validation_results(engine):


### PR DESCRIPTION
A proposition to update `create_supervised_trainer` to accept metrics similarly to `create_supervised_evaluator`. A log can be updated as the following
```
Epoch[1] Iteration[910/938] Loss: 0.48
Epoch[1] Iteration[920/938] Loss: 0.56
Epoch[1] Iteration[930/938] Loss: 0.34
Training Results - Epoch: 1  Avg accuracy: 0.67 Avg loss: 0.97
Validation Results - Epoch: 1  Avg accuracy: 0.94 Avg loss: 0.21
```
What do you guys think ?

In addition, added minor changes:
- Remove `Variable`
- replace tensorboardx graph creation method
- fix `F.log_softmax` warnings on unspecified dimension
