### PR TITLE
Metric Loss should be agnostic to number of outputs

### DIFF
--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -21,8 +21,7 @@ class Loss(Metric):
         self._num_examples = 0
 
     def update(self, output):
-        y_pred, y = output
-        average_loss = self._loss_fn(y_pred, y)
+        average_loss = self._loss_fn(*output)
         assert len(average_loss.shape) == 0, '`loss_fn` did not return the average loss'
         self._sum += average_loss.item() * y.shape[0]
         self._num_examples += y.shape[0]


### PR DESCRIPTION
The responsibility of feed them correctly should lie on `output_transform` function. This would enable working with losses that require more than 2 outputs (e.g., CTC loss)