### PR TITLE
Fix issue #173

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -100,7 +100,8 @@ class Engine(object):
             self._logger.error("attempt to add event handler to an invalid event %s ", event_name)
             raise ValueError("Event {} is not a valid event for this Engine".format(event_name))
 
-        self._check_signature(handler, 'handler', *args, **kwargs)
+        event_args = (Exception(), ) if event_name == Events.EXCEPTION_RAISED else ()
+        self._check_signature(handler, 'handler', *(event_args + args), **kwargs)
 
         if event_name not in self._event_handlers:
             self._event_handlers[event_name] = []

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -217,12 +217,20 @@ def test_custom_exception_handler():
     update_function = MagicMock(side_effect=value_error)
 
     engine = Engine(update_function)
-    exception_handler = MagicMock()
-    engine.add_event_handler(Events.EXCEPTION_RAISED, exception_handler)
+
+    class ExceptionCounter(object):
+        def __init__(self):
+            self.exceptions = []
+
+        def __call__(self, engine, e):
+            self.exceptions.append(e)
+
+    counter = ExceptionCounter()
+    engine.add_event_handler(Events.EXCEPTION_RAISED, counter)
     state = engine.run([1])
 
     # only one call from _run_once_over_data, since the exception is swallowed
-    exception_handler.assert_has_calls([call(engine, value_error)])
+    assert len(counter.exceptions) == 1 and counter.exceptions[0] == value_error
 
 
 def test_current_epoch_counter_increases_every_epoch():


### PR DESCRIPTION
CI will fail in the fixed test because of another bug discussed [here](https://github.com/pytorch/ignite/pull/162#discussion_r186746525):

when test exception is raised the method `Engine._run_once_on_dataset` handles the exception and returns None but `hours, mins, secs = self._run_once_on_dataset()` fails with error.
This second exception make current test fail. 

cc @elanmart, this PR should wait until your PR to fix above bug with `hours, mins, secs = self._run_once_on_dataset()`

@alykhantejani if you know a proper manner to use `MagicMock` I'd be happy to fix my code. 

