### PR TITLE
Avoid to install tests with the package, add condition to install enum34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ readme = read('README.rst')
 
 VERSION = find_version('ignite', '__init__.py')
 
-requirements = ['enum34', 'torch']
+requirements = ['enum34;python_version<"3.4"', 'torch']
 
 setup(
     # Metadata
@@ -36,7 +36,7 @@ setup(
     license='BSD',
 
     # Package info
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=('tests', 'tests.*',)),
 
     zip_safe=True,
     install_requires=requirements,


### PR DESCRIPTION
This should avoid the copy of `tests` folder into `/usr/local/lib/pythonX.Y/dist-packages/tests/`
Can be tested with `pip uninstall pytorch-ignite -y` and `pip install .` with manual checking of `/usr/local/lib/pythonX.Y/dist-packages/tests/`