### PR TITLE
Update metrics docs, added example of usage of `output_transform`

### DIFF
--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -4,8 +4,8 @@ ignite.metrics
 Metrics provide a way to compute various quantities of interest in an online
 fashion without having to store the entire output history of a model.
 
-In practice user needs to attach metric instance to engine. Metric value is
-computed using engine's output:
+In practice a user needs to attach the metric instance to an engine. The metric
+value is then computed using the output of the engine's `process_function`:
 
     .. code-block:: python
 
@@ -17,7 +17,8 @@ computed using engine's output:
         metric = CategoricalAccuracy()
         metric.attach(engine, "accuracy")
 
-If engine's output is not in the format `y_pred, y`, user can use `output_transform`:
+If the engine's output is not in the format `y_pred, y`, the user can
+use the `output_transform` argument to transform it:
 
     .. code-block:: python
 

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -1,6 +1,42 @@
 ignite.metrics
 ==============
 
+Metrics provide a way to compute various quantities of interest in an online
+fashion without having to store the entire output history of a model.
+
+In practice user needs to attach metric instance to engine. Metric value is
+computed using engine's output:
+
+    .. code-block:: python
+
+        def process_function(engine, batch):
+            # ...
+            return y_pred, y
+
+        engine = Engine(process_function)
+        metric = CategoricalAccuracy()
+        metric.attach(engine, "accuracy")
+
+If engine's output is not in the format `y_pred, y`, user can use `output_transform`:
+
+    .. code-block:: python
+
+        def process_function(engine, batch):
+            # ...
+            return {'y_pred': y_pred, 'y_true': y, ...}
+
+        engine = Engine(process_function)
+
+        def output_transform(output):
+            # `output` variable is returned by above `process_function`
+            y_pred = output['y_pred']
+            y = output['y_true']
+            return y_pred, y  # output format is according to `CategoricalAccuracy` docs
+
+        metric = CategoricalAccuracy(output_transform=output_transform)
+        metric.attach(engine, "accuracy")
+
+
 .. currentmodule:: ignite.metrics
 
 .. autoclass:: BinaryAccuracy

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -4,8 +4,6 @@ from ignite.engine import Events
 
 
 class Metric(object):
-    __metaclass__ = ABCMeta
-
     """
     Base class for all Metrics.
 
@@ -14,10 +12,29 @@ class Metric(object):
 
     Args:
         output_transform (callable): a callable that is used to transform the
-            model's output into the form expected by the metric. This can be
-            useful if, for example, you have a multi-output model and you want to
-            compute the metric with respect to one of the outputs.
+            :class:`ignite.engine.Engine` `process_function`'s output into the
+            form expected by the metric.
+            This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+
+    Example with `output_transform`:
+
+        .. code-block:: python
+
+            def process_function(engine, batch):
+                # ...
+                return {'y_pred': y_pred, 'y_true': y, ...}
+
+            def output_transform(output):
+                # `output` variable is returned by above `process_function`
+                y_pred = output['y_pred']
+                y = output['y_true']
+                return y_pred, y  # output format is according to `CategoricalAccuracy` docs
+
+            metric = CategoricalAccuracy(output_transform=output_transform)
     """
+    __metaclass__ = ABCMeta
+
     def __init__(self, output_transform=lambda x: x):
         self._output_transform = output_transform
         self.reset()

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -9,7 +9,7 @@ class Metric(object):
 
     Args:
         output_transform (callable): a callable that is used to transform the
-            :class:`ignite.engine.Engine` `process_function`'s output into the
+            :class:`ignite.engine.Engine`'s `process_function`'s output into the
             form expected by the metric.
             This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -7,9 +7,6 @@ class Metric(object):
     """
     Base class for all Metrics.
 
-    Metrics provide a way to compute various quantities of interest in an online
-    fashion without having to store the entire output history of a model.
-
     Args:
         output_transform (callable): a callable that is used to transform the
             :class:`ignite.engine.Engine` `process_function`'s output into the
@@ -17,21 +14,6 @@ class Metric(object):
             This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
 
-    Example with `output_transform`:
-
-        .. code-block:: python
-
-            def process_function(engine, batch):
-                # ...
-                return {'y_pred': y_pred, 'y_true': y, ...}
-
-            def output_transform(output):
-                # `output` variable is returned by above `process_function`
-                y_pred = output['y_pred']
-                y = output['y_true']
-                return y_pred, y  # output format is according to `CategoricalAccuracy` docs
-
-            metric = CategoricalAccuracy(output_transform=output_transform)
     """
     __metaclass__ = ABCMeta
 


### PR DESCRIPTION
Addresses #213 

- Needed to move below ` __metaclass__ = ABCMeta` as it disables docs generation.
- Added example with `output_transform`

cc @jasonkriss 