### PR TITLE
Update loss argument, fix warning

### DIFF
--- a/tests/ignite/metrics/test_loss.py
+++ b/tests/ignite/metrics/test_loss.py
@@ -42,7 +42,7 @@ def test_compute_on_criterion():
 
 
 def test_non_averaging_loss():
-    loss = Loss(nn.NLLLoss(reduce=False))
+    loss = Loss(nn.NLLLoss(reduction='none'))
 
     y_pred = torch.Tensor([[0.1, 0.4, 0.5], [0.1, 0.7, 0.2]]).log()
     y = torch.LongTensor([2, 2])


### PR DESCRIPTION
Small warning fix at test time:
```
tests/ignite/metrics/test_loss.py::test_non_averaging_loss
  /usr/local/lib/python3.5/dist-packages/torch/nn/functional.py:52: UserWarning: size_average and reduce args will be deprecated, please use reduction='elementwise_mean' instead.
    warnings.warn(warning.format(ret))
```