### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
       install:
         # Minimal install : ignite and dependencies just to build the docs
         - pip install -r docs/requirements.txt
-        - pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl
+        - pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp35-cp35m-linux_x86_64.whl
         # `pip install .` vs `python setup.py install` : 1st works better to produce _module/ignite with source links
         - pip install .
       script:


### PR DESCRIPTION
Try to fix the warning on travis : https://travis-ci.org/pytorch/ignite/jobs/418584925#L525
```
WARNING: autodoc: failed to import class 'BinaryAccuracy' from module 'ignite.metrics'; the following exception was raised:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/sphinx/ext/autodoc/importer.py", line 152, in import_module
    __import__(modname)
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/ignite/metrics/__init__.py", line 1, in <module>
    from ignite.metrics.binary_accuracy import BinaryAccuracy
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/ignite/metrics/binary_accuracy.py", line 5, in <module>
    from ignite.metrics.metric import Metric
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/ignite/metrics/metric.py", line 8, in <module>
    class Metric(object):
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/ignite/metrics/metric.py", line 65, in Metric
    @torch.no_grad()
TypeError: 'no_grad' object is not callable
```