### PR TITLE
fix deprecation warning Python 3.7

### DIFF
--- a/ignite/_utils.py
+++ b/ignite/_utils.py
@@ -1,7 +1,14 @@
-import collections
+import sys
 
 import torch
 from torch._six import string_classes
+
+IS_PYTHON2 = sys.version_info[0] < 3
+
+if IS_PYTHON2:
+    import collections
+else:
+    import collections.abc as collections
 
 
 def _to_hours_mins_secs(time_taken):


### PR DESCRIPTION
```
.../ignite/ignite/_utils.py:37: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  elif isinstance(input_, collections.Sequence):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```