### PR TITLE
close #218

### DIFF
--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -11,6 +11,7 @@ class Loss(Metric):
     - `loss_fn` must return the average loss over all observations in the batch.
     - `update` must receive output of the form `(y_pred, y)`.
     """
+
     def __init__(self, loss_fn, output_transform=lambda x: x):
         super(Loss, self).__init__(output_transform)
         self._loss_fn = loss_fn
@@ -20,8 +21,12 @@ class Loss(Metric):
         self._num_examples = 0
 
     def update(self, output):
-        y_pred, y = output
-        average_loss = self._loss_fn(y_pred, y)
+        if len(output) == 2:
+            y_pred, y = output
+            kwargs = {}
+        else:
+            y_pred, y, kwargs = output
+        average_loss = self._loss_fn(y_pred, y, **kwargs)
         assert len(average_loss.shape) == 0, '`loss_fn` did not return the average loss'
         self._sum += average_loss.item() * y.shape[0]
         self._num_examples += y.shape[0]

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -8,8 +8,19 @@ class Loss(Metric):
     """
     Calculates the average loss according to the passed loss_fn.
 
-    - `loss_fn` must return the average loss over all observations in the batch.
-    - `update` must receive output of the form `(y_pred, y)`.
+    Args:
+        loss_fn (callable): a callble taking a prediction tensor, a target
+            tensor, eventually other arguments, and returns the average loss
+            over all observations in the batch.
+        output_transform (callable): a callable that is used to transform the
+            :class:`ignite.engine.Engine`'s `process_function`'s output into the
+            form expected by the metric.
+            This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+            The output is is expected to be a tuple (prediction, target) or
+            (prediction, target, kwargs) where kwargs is a dictionary of extra
+            keywords arguments.
+
     """
 
     def __init__(self, loss_fn, output_transform=lambda x: x):

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -9,8 +9,8 @@ class Loss(Metric):
     Calculates the average loss according to the passed loss_fn.
 
     Args:
-        loss_fn (callable): a callble taking a prediction tensor, a target
-            tensor, eventually other arguments, and returns the average loss
+        loss_fn (callable): a callable taking a prediction tensor, a target
+            tensor, optionally other arguments, and returns the average loss
             over all observations in the batch.
         output_transform (callable): a callable that is used to transform the
             :class:`ignite.engine.Engine`'s `process_function`'s output into the

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -15,9 +15,6 @@ class Metric(object):
             form expected by the metric.
             This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-            The output is is expected to be a tuple (prediction, target) or
-            (prediction, target, kwargs) where kwargs is a dictionary of extra
-            keywords arguments.
 
     """
     __metaclass__ = ABCMeta

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -15,6 +15,9 @@ class Metric(object):
             form expected by the metric.
             This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
+            The output is is expected to be a tuple (prediction, target) or
+            (prediction, target, kwargs) where kwargs is a dictionary of extra
+            keywords arguments.
 
     """
     __metaclass__ = ABCMeta

--- a/tests/ignite/metrics/test_loss.py
+++ b/tests/ignite/metrics/test_loss.py
@@ -50,6 +50,15 @@ def test_non_averaging_loss():
         loss.update((y_pred, y))
 
 
+def test_kwargs_loss():
+    loss = Loss(nll_loss)
+
+    y_pred = torch.Tensor([[0.1, 0.4, 0.5], [0.1, 0.7, 0.2]]).log()
+    y = torch.LongTensor([2, 2])
+    loss.update((y_pred, y, {"weight": torch.Tensor([0, 0, 0])}))
+    assert_almost_equal(loss.compute(), 0)
+
+
 def test_reset():
     loss = Loss(nll_loss)
 


### PR DESCRIPTION
Fixes #218 

Description:
- Added the solution suggested by @jasonkriss : `Loss` accepts a 2 or 3-tuple as input;
- Change doc to `Loss` to reflect the new behaviour;
- Add a test under `test_loss.py` to test the `Loss` with keywords arguments.

Check list:
* [X] New tests are added (if a new feature is modified)
* [X] New doc strings: text and/or example code are in RST format
* [ ] Documentation is updated (if required)
