### PR TITLE
Fix #283, refactor create tbtt engine method

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -5,6 +5,9 @@ from ignite._utils import convert_tensor
 
 
 def _prepare_batch(batch, device=None, non_blocking=False):
+    """Prepare batch for training: pass to a device with options
+
+    """
     x, y = batch
     return (convert_tensor(x, device=device, non_blocking=non_blocking),
             convert_tensor(y, device=device, non_blocking=non_blocking))


### PR DESCRIPTION
Fixes #283 

Description: refactored `create_supervised_tbptt_trainer` method following #283. 
Removed completely `_prepare_tbptt_batch`.

- [ ] ~~Replace `convert_tensor` by `prepare_batch` ([line](https://github.com/pytorch/ignite/blob/d3d7b146d56efb5b497f3cf4b22caab976774e7e/ignite/contrib/engines/tbptt.py#L29))~~
- [x] Call `prepare_batch` on time chunks (the quantity used to compute gradients) rather that whole time series mini bactch
- [x] Add `prepare_batch` function in the arguments
- [x] Add `non_blocking` in the arguments

@AntoinePrv please review the modifications.

Check list:
* [x] Documentation is updated (if required)
