### PR TITLE
Batch size loss metric

### DIFF
--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -20,6 +20,8 @@ class Loss(Metric):
             The output is is expected to be a tuple (prediction, target) or
             (prediction, target, kwargs) where kwargs is a dictionary of extra
             keywords arguments.
+        batch_size (callable): a callable taking a target tensor that returns the
+            first dimension size (usually the batch size).
 
     """
 
@@ -43,6 +45,7 @@ class Loss(Metric):
 
         if len(average_loss.shape) != 0:
             raise ValueError('loss_fn did not return the average loss')
+
         N = self._batch_size(y)
         self._sum += average_loss.item() * N
         self._num_examples += N

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -23,9 +23,11 @@ class Loss(Metric):
 
     """
 
-    def __init__(self, loss_fn, output_transform=lambda x: x):
+    def __init__(self, loss_fn, output_transform=lambda x: x,
+                 batch_size=lambda x: x.shape[0]):
         super(Loss, self).__init__(output_transform)
         self._loss_fn = loss_fn
+        self._batch_size = batch_size
 
     def reset(self):
         self._sum = 0
@@ -41,9 +43,9 @@ class Loss(Metric):
 
         if len(average_loss.shape) != 0:
             raise ValueError('loss_fn did not return the average loss')
-
-        self._sum += average_loss.item() * y.shape[0]
-        self._num_examples += y.shape[0]
+        N = self._batch_size(y)
+        self._sum += average_loss.item() * N
+        self._num_examples += N
 
     def compute(self):
         if self._num_examples == 0:


### PR DESCRIPTION
Fixes #293 

Description:
The Loss metric now takes a optional argument batch_size that is used to access
the  batch size from the target variable y.

Check list:
* [ ] New tests are added (if a new feature is modified) (uses the same test)
* [ ] New doc strings: text and/or example code are in RST format (is necessary to add an example?)
* [x] Documentation is updated (if required)