### PR TITLE
RunningAverage : allow alpha = 0 (+ ProgressBar discussion)

### DIFF
--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -33,7 +33,7 @@ class RunningAverage(Metric):
     def __init__(self, src=None, alpha=0.98, output_transform=None):
         if not (isinstance(src, Metric) or src is None):
             raise TypeError("Argument src should be a Metric or None")
-        if not (0.0 < alpha <= 1.0):
+        if not (0.0 <= alpha <= 1.0):
             raise ValueError("Argument alpha should be a float between 0.0 and 1.0")
 
         if isinstance(src, Metric):


### PR DESCRIPTION

**Description:**

Hi, I was trying to create an `Identity` metric that was computed at each iteration, in order to use `contrib.handlers.ProgressBar` to display a training loss. I decided to simply use a running average with alpha=0 (ignore all past values, and take 100% of the new value).

```python
trainer = engine.create_supervised_trainer(model, optimizer, loss)

metric = metrics.RunningAverage(output_transform=lambda x: x, alpha=0.0)
metric.attach(trainer, 'loss')
```

I ran into a `ValueError` because the value 0 for alpha is not allowed, I see no reason why it couldn't be.
=> I modified the check to be inclusive for zero.

No new test or documentation is needed.


**Check list:**
* [x] New tests are added (if a new feature is modified)
* [x] New doc strings: text and/or example code are in RST format
* [x] Documentation is updated (if required)


---

PS : The fact that `ProgressBar` only works with `RunningAverage` _(or generally all metrics that rewires `self.computed` on `Events.ITERATION_COMPLETED` instead of `Events.EPOCH_COMPLETED`)_ is not documented and that took me some time to figure out. (see https://github.com/pytorch/ignite/pull/256 for issues on non-`RunningAverage` metrics).