### PR TITLE
[tqdm_logger] Change format from "Epoch: epoch" to "Epoch: [epoch/max_epochs]"

### DIFF
--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -68,7 +68,7 @@ class ProgressBar:
         if self.pbar is None:
             self._reset(engine)
 
-        self.pbar.set_description('Epoch {}'.format(engine.state.epoch))
+        self.pbar.set_description('Epoch [{}/{}]'.format(engine.state.epoch, engine.state.max_epochs))
 
         metrics = {}
         if metric_names is not None:

--- a/tests/ignite/contrib/handlers/test_pbar.py
+++ b/tests/ignite/contrib/handlers/test_pbar.py
@@ -29,7 +29,7 @@ def test_pbar(capsys):
     err = captured.err.split('\r')
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = u'Epoch 2: [1/2]  50%|█████     , a=1.00e+00 [00:00<00:00]'
+    expected = u'Epoch [2/2]: [1/2]  50%|█████     , a=1.00e+00 [00:00<00:00]'
     assert err[-1] == expected
 
 
@@ -85,7 +85,7 @@ def test_pbar_no_metric_names(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = u'Epoch 2: [1/2]  50%|█████      [00:00<00:00]'
+    expected = u'Epoch [2/2]: [1/2]  50%|█████      [00:00<00:00]'
     assert actual == expected
 
 
@@ -103,7 +103,7 @@ def test_pbar_with_output(capsys):
     err = captured.err.split('\r')
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = u'Epoch 2: [1/2]  50%|█████     , a=1.00e+00 [00:00<00:00]'
+    expected = u'Epoch [2/2]: [1/2]  50%|█████     , a=1.00e+00 [00:00<00:00]'
     assert err[-1] == expected
 
 
@@ -129,5 +129,5 @@ def test_pbar_with_scalar_output(capsys):
     err = captured.err.split('\r')
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = u'Epoch 2: [1/2]  50%|█████     , output=1.00e+00 [00:00<00:00]'
+    expected = u'Epoch [2/2]: [1/2]  50%|█████     , output=1.00e+00 [00:00<00:00]'
     assert err[-1] == expected


### PR DESCRIPTION
Consider we're using 10 epochs, every epoch the tqdm logger now displays:

`Epoch [1/10]: [1/2]  50%|█████     , a=1.00e+00 [00:00<00:00]`

instead of:

`Epoch 1: [1/2]  50%|█████     , a=1.00e+00 [00:00<00:00]`
