### PR TITLE
Fixes #319

### DIFF
--- a/docs/source/contrib/engines.rst
+++ b/docs/source/contrib/engines.rst
@@ -8,3 +8,4 @@ Contribution module of engines
 .. automodule:: ignite.contrib.engines
    :members:
    :undoc-members:
+   :imported-members:

--- a/docs/source/contrib/handlers.rst
+++ b/docs/source/contrib/handlers.rst
@@ -8,3 +8,4 @@ Contribution module of handlers
 .. automodule:: ignite.contrib.handlers
    :members:
    :undoc-members:
+   :imported-members:

--- a/docs/source/contrib/metrics.rst
+++ b/docs/source/contrib/metrics.rst
@@ -5,8 +5,7 @@ Contribution module of metrics
 
 .. currentmodule:: ignite.contrib.metrics
 
-.. autoclass:: ROC_AUC
-
-.. autoclass:: AveragePrecision
-
-.. autoclass:: MaximumAbsoluteError
+.. automodule:: ignite.contrib.metrics
+   :members:
+   :undoc-members:
+   :imported-members:

--- a/ignite/contrib/engines/__init__.py
+++ b/ignite/contrib/engines/__init__.py
@@ -2,6 +2,3 @@
 
 from ignite.contrib.engines.tbptt import create_supervised_tbptt_trainer
 from ignite.contrib.engines.tbptt import Tbptt_Events
-
-
-__all__ = ["create_supervised_tbptt_trainer", "Tbptt_Events"]

--- a/ignite/contrib/handlers/__init__.py
+++ b/ignite/contrib/handlers/__init__.py
@@ -3,5 +3,3 @@ from ignite.contrib.handlers.param_scheduler import ParamScheduler, CyclicalSche
     LinearCyclicalScheduler, CosineAnnealingScheduler
 
 from ignite.contrib.handlers.tqdm_logger import ProgressBar
-
-__all__ = ['ProgressBar']


### PR DESCRIPTION
Fixes #319 

Description:
Removed `__all__` and added `:imported-members:`. This allows to generate the docs automatically for all members. No need to remember to add `.. autoclass:: CoolClass`. Drawback of this is that all classes are mixed together without logical separtion. 

Check list:
* [X] Documentation is updated (if required)
