### PR TITLE
[Step 1/4: Ready for review] Add Engine.has_event_handler

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -142,16 +142,24 @@ class Engine(object):
         self._event_handlers[event_name].append((handler, args, kwargs))
         self._logger.debug("added handler for event %s ", event_name)
 
-    def has_event_handler(self, event_name, handler):
+    def has_event_handler(self, handler, event_name=None):
         """Check if the specified event has the specified handler.
 
         Args:
-            event_name: The event the handler attached to.
             handler (Callable): the callable event handler.
+            event_name: The event the handler attached to. Set this
+                to ``None`` to search all events.
         """
-        for h, _, _ in self._event_handlers[event_name]:
-            if h == handler:
-                return True
+        if event_name is not None:
+            if event_name not in self._event_handlers:
+                return False
+            events = [event_name]
+        else:
+            events = self._event_handlers
+        for e in events:
+            for h, _, _ in self._event_handlers[e]:
+                if h == handler:
+                    return True
         return False
 
     def _check_signature(self, fn, fn_description, *args, **kwargs):

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -142,6 +142,18 @@ class Engine(object):
         self._event_handlers[event_name].append((handler, args, kwargs))
         self._logger.debug("added handler for event %s ", event_name)
 
+    def has_event_handler(self, event_name, handler):
+        """Check if the specified event has the specified handler.
+
+        Args:
+            event_name: The event the handler attached to.
+            handler (Callable): the callable event handler.
+        """
+        for h, _, _ in self._event_handlers[event_name]:
+            if h == handler:
+                return True
+        return False
+
     def _check_signature(self, fn, fn_description, *args, **kwargs):
         exception_msg = None
 

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -142,10 +142,12 @@ def test_has_event_handler():
         assert engine.has_event_handler(handler, Events.STARTED)
         assert engine.has_event_handler(handler)
         assert not engine.has_event_handler(handler, Events.COMPLETED)
+        assert not engine.has_event_handler(handler, Events.EPOCH_STARTED)
 
     assert not engine.has_event_handler(m, Events.STARTED)
     assert engine.has_event_handler(m, Events.COMPLETED)
     assert engine.has_event_handler(m)
+    assert not engine.has_event_handler(m, Events.EPOCH_STARTED)
 
 
 def test_args_and_kwargs_are_passed_to_event():

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -130,6 +130,21 @@ def test_adding_multiple_event_handlers():
         handler.assert_called_once_with(engine)
 
 
+def test_has_event_handler():
+    engine = DummyEngine()
+    handlers = [MagicMock(), MagicMock()]
+    m = MagicMock()
+    for handler in handlers:
+        engine.add_event_handler(Events.STARTED, handler)
+    engine.add_event_handler(Events.COMPLETED, m)
+
+    for handler in handlers:
+        assert engine.has_event_handler(Events.STARTED, handler)
+        assert not engine.has_event_handler(Events.COMPLETED, handler)
+    assert not engine.has_event_handler(Events.STARTED, m)
+    assert engine.has_event_handler(Events.COMPLETED, m)
+
+
 def test_args_and_kwargs_are_passed_to_event():
     engine = DummyEngine()
     kwargs = {'a': 'a', 'b': 'b'}

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -139,10 +139,13 @@ def test_has_event_handler():
     engine.add_event_handler(Events.COMPLETED, m)
 
     for handler in handlers:
-        assert engine.has_event_handler(Events.STARTED, handler)
-        assert not engine.has_event_handler(Events.COMPLETED, handler)
-    assert not engine.has_event_handler(Events.STARTED, m)
-    assert engine.has_event_handler(Events.COMPLETED, m)
+        assert engine.has_event_handler(handler, Events.STARTED)
+        assert engine.has_event_handler(handler)
+        assert not engine.has_event_handler(handler, Events.COMPLETED)
+
+    assert not engine.has_event_handler(m, Events.STARTED)
+    assert engine.has_event_handler(m, Events.COMPLETED)
+    assert engine.has_event_handler(m)
 
 
 def test_args_and_kwargs_are_passed_to_event():


### PR DESCRIPTION
As discussed in https://github.com/pytorch/ignite/pull/323#issuecomment-436819733

@vfdev-5 Which do you think we should have?
`has_handler(func)`, or `has_event_handler(event_name, func)`, or both?