### PR TITLE
Update regression metrics docs

### DIFF
--- a/docs/source/contrib/metrics.rst
+++ b/docs/source/contrib/metrics.rst
@@ -9,3 +9,20 @@ Contribution module of metrics
    :members:
    :undoc-members:
    :imported-members:
+
+
+Regression metrics
+------------------
+
+Module `ignite.contrib.metrics.regression` provides implementations of
+metrics useful for the regression task. Definitions of metrics are based on `Botchkarev 2018`_, page 30 "Appendix 2. 
+Metrics mathematical definitions".
+
+.. _`Botchkarev 2018`:
+        https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf
+
+
+.. automodule:: ignite.contrib.metrics.regression
+   :members:
+   :undoc-members:
+   :imported-members:

--- a/docs/source/contrib/metrics.rst
+++ b/docs/source/contrib/metrics.rst
@@ -15,8 +15,7 @@ Regression metrics
 ------------------
 
 Module `ignite.contrib.metrics.regression` provides implementations of
-metrics useful for the regression task. Definitions of metrics are based on `Botchkarev 2018`_, page 30 "Appendix 2. 
-Metrics mathematical definitions".
+metrics useful for the regression task. Definitions of metrics are based on `Botchkarev 2018`_, page 30 "Appendix 2. Metrics mathematical definitions".
 
 .. _`Botchkarev 2018`:
         https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf

--- a/docs/source/contrib/metrics.rst
+++ b/docs/source/contrib/metrics.rst
@@ -15,7 +15,7 @@ Regression metrics
 ------------------
 
 Module `ignite.contrib.metrics.regression` provides implementations of
-metrics useful for the regression task. Definitions of metrics are based on `Botchkarev 2018`_, page 30 "Appendix 2. Metrics mathematical definitions".
+metrics useful for regression tasks. Definitions of metrics are based on `Botchkarev 2018`_, page 30 "Appendix 2. Metrics mathematical definitions".
 
 .. _`Botchkarev 2018`:
         https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf

--- a/ignite/contrib/metrics/regression/fractional_bias.py
+++ b/ignite/contrib/metrics/regression/fractional_bias.py
@@ -8,16 +8,17 @@ from ignite.metrics.metric import Metric
 
 class FractionalBias(Metric):
     r"""
-    Calculates the Fractional Bias.
+    Calculates the Fractional Bias:
 
-    It has been proposed in `Botchkarev 2018`__.
+    :math:`\text{FB} = \frac{1}{n}\sum_{j=1}^n\frac{2 * (A_j - P_j)}{A_j + P_j}`,
 
-    :math:`\text{FB} = \frac{1}{n}\sum _j^n\frac{2 * (A_j - P_j)}{A_j + P_j}`
+    where :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
 
-    Where, :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
+    More details can be found in `Botchkarev 2018`__.
 
     - `update` must receive output of the form `(y_pred, y)`.
     - `y` and `y_pred` must be of same shape.
+
 
     __ https://arxiv.org/abs/1809.03006
 

--- a/ignite/contrib/metrics/regression/manhattan_distance.py
+++ b/ignite/contrib/metrics/regression/manhattan_distance.py
@@ -8,15 +8,13 @@ from ignite.metrics.metric import Metric
 
 class ManhattanDistance(Metric):
     r"""
-    Calculates the Manhattan Distance.
+    Calculates the Manhattan Distance:
 
-    It has been proposed in `Botchkarev 2018`__.
+    :math:`\text{MD} = \sum_{j=1}^n (A_j - P_j)`,
 
-    More details can be found in `https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf`.
+    where :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
 
-    :math:`\text{MD} = \sum _j^n (A_j - P_j)`
-
-    Where, :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
+    More details can be found in `Botchkarev 2018`__.
 
     - `update` must receive output of the form `(y_pred, y)`.
     - `y` and `y_pred` must be of same shape.

--- a/ignite/contrib/metrics/regression/maximum_absolute_error.py
+++ b/ignite/contrib/metrics/regression/maximum_absolute_error.py
@@ -5,13 +5,13 @@ import torch
 
 class MaximumAbsoluteError(Metric):
     r"""
-    Calculates the Maximum Absolute Error.
+    Calculates the Maximum Absolute Error:
 
-    It has been proposed in `Botchkarev 2018`__.
+    :math:`\text{MaxAE} = \max_{j=1,n} \left( \lvert A_j-P_j \rvert \right)`,
 
-    :math:`\text{MaxAE} = \max_{j=1,n} \left( \lvert A_j-P_j \rvert \right)`
+    where :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
 
-    Where, :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
+    More details can be found in `Botchkarev 2018`__.
 
     - `update` must receive output of the form `(y_pred, y)`.
     - `y` and `y_pred` must be of same shape.

--- a/ignite/contrib/metrics/regression/mean_absolute_relative_error.py
+++ b/ignite/contrib/metrics/regression/mean_absolute_relative_error.py
@@ -6,18 +6,18 @@ import torch
 
 class MeanAbsoluteRelativeError(Metric):
     r"""
-    Calculate Mean Absolute Relative Error
+    Calculate Mean Absolute Relative Error:
 
-    :math:`\text{MARE} = \frac{1}{n}\sum _j^n\frac{\left|A_j-P_j\right|}{\left|A_j\right|}`
+    :math:`\text{MARE} = \frac{1}{n}\sum_{j=1}^n\frac{\left|A_j-P_j\right|}{\left|A_j\right|}`,
 
-    where, :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
+    where :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
 
-    More details can be found in the reference `Botchkarev 2018`_ .
+    More details can be found in the reference `Botchkarev 2018`__.
 
     - `update` must receive output of the form `(y_pred, y)`
 
-    .. _`Botchkarev 2018`:
-        https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf
+    __ https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf
+
     """
 
     def reset(self):

--- a/ignite/contrib/metrics/regression/mean_error.py
+++ b/ignite/contrib/metrics/regression/mean_error.py
@@ -8,13 +8,13 @@ from ignite.metrics.metric import Metric
 
 class MeanError(Metric):
     r"""
-    Calculates the Mean Error.
+    Calculates the Mean Error:
 
-    It has been proposed in `Botchkarev 2018`__.
+    :math:`\text{ME} = \frac{1}{n}\sum_{j=1}^n (A_j - P_j)`,
 
-    :math:`\text{ME} = \frac{1}{n}\sum _j^n (A_j - P_j)`
+    where :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
 
-    Where, :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
+    More details can be found in the reference `Botchkarev 2018`__.
 
     - `update` must receive output of the form `(y_pred, y)`.
     - `y` and `y_pred` must be of same shape.

--- a/ignite/contrib/metrics/regression/mean_normalized_bias.py
+++ b/ignite/contrib/metrics/regression/mean_normalized_bias.py
@@ -8,13 +8,13 @@ from ignite.metrics.metric import Metric
 
 class MeanNormalizedBias(Metric):
     r"""
-    Calculates the Mean Normalized Bias.
+    Calculates the Mean Normalized Bias:
 
-    It has been proposed in `Botchkarev 2018`__.
+    :math:`\text{MNB} = \frac{1}{n}\sum_{j=1}^n\frac{A_j - P_j}{A_j}`,
 
-    :math:`\text{MNB} = \frac{1}{n}\sum _j^n\frac{A_j - P_j}{A_j}`
+    where :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
 
-    Where, :math:`A_j` is the ground truth and :math:`P_j` is the predicted value.
+    More details can be found in the reference `Botchkarev 2018`__.
 
     - `update` must receive output of the form `(y_pred, y)`.
     - `y` and `y_pred` must be of same shape.


### PR DESCRIPTION
Updates regression metrics docs

Description:
Currently the docs for regression metrics is not present. This PR reveals it as a section as

<img width="903" alt="screen shot 2018-11-20 at 23 32 13" src="https://user-images.githubusercontent.com/2459423/48807094-bc5ed980-ed1c-11e8-9a1f-1c77be6f1da8.png">


Check list:
* [x] Documentation is updated (if required)

@jasonkriss could you please check the wording of the section:
```
Module `ignite.contrib.metrics.regression` provides implementations of
metrics useful for the regression task. Definitions of metrics are based on `Botchkarev 2018`_, page 30 "Appendix 2.
Metrics mathematical definitions".
```