### PR TITLE
Fixes #340 and added tests against pytorch-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
+
+env:
+  - PYTORCH_PACKAGE=pytorch-cpu
+  - PYTORCH_PACKAGE=pytorch-nightly-cpu
 
 stages:
   - Lint check
@@ -20,7 +25,7 @@ before_install: &before_install
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment -c pytorch python=$TRAVIS_PYTHON_VERSION pytorch-cpu
+  - conda create -q -n test-environment -c pytorch python=$TRAVIS_PYTHON_VERSION $PYTORCH_PACKAGE
   - source activate test-environment
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install enum34; fi
   # Test contrib dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 
 env:
   - PYTORCH_PACKAGE=pytorch-cpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.7"
   - "3.5"
-  - "3.6"
 
 env:
   - PYTORCH_PACKAGE=pytorch-cpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,8 @@ jobs:
 
     - stage: Deploy
       python: "3.5"
+      env:
+        - PYTORCH_PACKAGE=pytorch-cpu
       if: tag IS present
 
       # Use previously defined before_install

--- a/tests/ignite/handlers/test_terminate_on_nan.py
+++ b/tests/ignite/handlers/test_terminate_on_nan.py
@@ -41,7 +41,7 @@ def test_terminate_on_nan_and_inf():
     assert trainer.should_terminate
     trainer.should_terminate = False
 
-    trainer.state.output = (10.0, 1.0 / torch.randint(0, 2, size=(4,)), 1.0)
+    trainer.state.output = (10.0, 1.0 / torch.randint(0, 2, size=(4,)).type(torch.float), 1.0)
     h(trainer)
     assert trainer.should_terminate
     trainer.should_terminate = False
@@ -50,7 +50,7 @@ def test_terminate_on_nan_and_inf():
     h(trainer)
     assert not trainer.should_terminate
 
-    trainer.state.output = 1.0 / torch.randint(0, 2, size=(4, 4))
+    trainer.state.output = 1.0 / torch.randint(0, 2, size=(4, 4)).type(torch.float)
     h(trainer)
     assert trainer.should_terminate
     trainer.should_terminate = False
@@ -95,7 +95,7 @@ def test_with_terminate_on_inf():
     torch.manual_seed(12)
 
     data = [1.0, 0.8, torch.rand(4, 4),
-            (1.0 / torch.randint(0, 2, size=(4,)), torch.tensor(1.234)),
+            (1.0 / torch.randint(0, 2, size=(4,)).type(torch.float), torch.tensor(1.234)),
             torch.rand(5), torch.asin(torch.randn(4, 4)), 0.0, 1.0]
 
     def update_fn(engine, batch):


### PR DESCRIPTION
Fixes #340

Description:

1) In 0.4.1 `torch.isfinite(1.0 / torch.arange(-1, 2))` raises `RuntimeException` and in 1.0-preview it is finite. Terminate on nan catches `RuntimeException` and thus tests passed for 0.4.1 and fail with 1.0-preview. This PR properly transforms int to float when 1.0 / int_value

2) Added tests for python 3.6 and {pytorch-cpu, pytorch-nightly-cpu}

Check list:
* [x] New tests are added
