### PR TITLE
[1/2] Added nightly build stage into .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ stages:
   - Test
   - Docs
   - Deploy
+  - Nightly
 
 before_install: &before_install
   - sudo apt-get update
@@ -83,7 +84,7 @@ jobs:
     # GitHub Pages Deployment: https://docs.travis-ci.com/user/deployment/pages/
     - stage: Docs
       python: "3.5"
-
+      if: branch != nightly
       # Use previously defined before_install
       before_install: *before_install
 
@@ -161,3 +162,54 @@ jobs:
 
         on:
           tags: true
+
+    - stage: Nightly
+      python: "3.5"
+      env:
+        - PYTORCH_PACKAGE=pytorch-nightly-cpu
+      if: branch = nightly
+      # Use previously defined before_install
+      before_install: *before_install
+      install:
+        # Merge master into nightly
+        - git fetch origin master
+        - git merge FETCH_HEAD --no-edit
+        # Copy "nightly" files
+        - cp nightly/setup_nightly.py setup.py
+        - cp -R nightly/conda.recipe .
+        # Push to nightly branch
+        - git remote rm origin && git remote add origin https://$GITHUB_TOKEN@github.com/${TRAVIS_REPO_SLUG}.git
+        - git push origin nightly
+      script: true
+      after_success: # Nothing to do
+      before_deploy:
+        # Conda deploy if on tag
+        # ANACONDA_TOKEN should be provided by Travis
+        # How to generate ANACONDA_TOKEN: https://docs.anaconda.com/anaconda-cloud/user-guide/tasks/work-with-accounts#creating-access-tokens
+        # https://conda.io/docs/user-guide/tasks/build-packages/install-conda-build.html
+        - conda install -y conda-build conda-verify anaconda-client
+        - conda config --set anaconda_upload no
+        - conda build --quiet --no-test --output-folder conda_build conda.recipe -c pytorch
+        # Convert to other platforms: OSX, WIN
+        - conda convert --platform win-64 conda_build/linux-64/*.tar.bz2 -o conda_build/
+        - conda convert --platform osx-64 conda_build/linux-64/*.tar.bz2 -o conda_build/
+        # Upload to Anaconda
+        # We could use --all but too much platforms to uploaded
+# Uncomment when a package is available
+#        - ls conda_build/*/*.tar.bz2 | xargs -I {} anaconda -v -t $ANACONDA_TOKEN upload -u pytorch {}
+        - ls conda_build/*/*.tar.bz2 | xargs -I {} anaconda -v -t $ANACONDA_TOKEN upload {}
+      # PyPI Deployment: https://docs.travis-ci.com/user/deployment/pypi/
+      deploy:
+        provider: pypi
+        user: $PYPI_USER
+        # If password contains non alphanumeric characters
+        # https://github.com/travis-ci/dpl/issues/377
+        # pass it as secured variable
+        password: $PYPI_TOKEN
+        # otherwise, follow "How to encrypt the password": https://docs.travis-ci.com/user/encryption-keys/
+        # `travis encrypt deploy.password="password"`
+        #  secure: "secured_password"
+        skip_cleanup: true
+        distributions: "sdist bdist_wheel"
+        on:
+          branch: nightly


### PR DESCRIPTION
Related to #306 

The second part of the PR : https://github.com/pytorch/ignite/pull/344 

Description:
Idea is to build ignite master code every day. There is a possibility to build & upload some code with [travis cron jobs](https://docs.travis-ci.com/user/cron-jobs/). 
We need to upload the builds at another package storage: pytorch-ignite-nightly for PyPI and ignite-nightly for Conda.

Basic idea is to create a new branch `nightly` with all needed modifications in package name and dependencies. But the problem is how to synchronize the branch with master. So the idea is to create a special folder `nightly` that exists only in `nightly` branch, all other files are same as in master. At each cron build job, we can do the following:
```
        # Merge master into nightly
        - git fetch origin master
        - git merge FETCH_HEAD --no-edit
        # Copy "nightly" files
        - cp nightly/setup_nightly.py setup.py
        - cp -R nightly/conda.recipe .
        # Push to nightly branch
        - git remote rm origin && git remote add origin https://$GITHUB_TOKEN@github.com/${TRAVIS_REPO_SLUG}.git
        - git push origin nightly
```
We merge master branch into nightly and then push to the nightly. As all `nightly` modifications are separated into a folder `nightly`, most probably we'll never have a conflict to solve (exception if someone put `nightly` folder into master etc).

In this PR: 
Updated .travis.yml with new stage `Nightly` that merges master branch, replaces existing setup.py and meta.yml: version is YYYYMMDD and pytorch -> pytorch-nightly ; and finally git push to nightly branch.

