### PR TITLE
Update checkpoint.py

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -1,5 +1,4 @@
 import os
-import os.path
 import tempfile
 
 import torch

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import tempfile
 
 import torch
@@ -83,7 +84,7 @@ class ModelCheckpoint(object):
                  create_dir=True,
                  save_as_state_dict=False):
 
-        self._dirname = dirname
+        self._dirname = os.path.expanduser(dirname)
         self._fname_prefix = filename_prefix
         self._n_saved = n_saved
         self._save_interval = save_interval


### PR DESCRIPTION
Change `ignite.handlers.ModelCheckpoint` to call `os.path.expanduser()` on the `dirname` argument before it is assigned as an attribute.

@apaszke said this was small enough that it did not warrant a new issue.