### PR TITLE
Pytorch schedulers

### DIFF
--- a/ignite/contrib/handlers/__init__.py
+++ b/ignite/contrib/handlers/__init__.py
@@ -1,5 +1,5 @@
 
 from ignite.contrib.handlers.param_scheduler import ParamScheduler, CyclicalScheduler, \
-    LinearCyclicalScheduler, CosineAnnealingScheduler
+    LinearCyclicalScheduler, CosineAnnealingScheduler, ConcatScheduler, ReduceLROnPlateau
 
 from ignite.contrib.handlers.tqdm_logger import ProgressBar

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -304,7 +304,7 @@ class LRScheduler(ParamScheduler):
 
         trainer.add_event_handler(Events.ITERATION_COMPLETED, scheduler)
     """
-    def __init__(self, lr_scheduler, save_history=False):
+    def __init__(self, lr_scheduler, save_history=False, **kwds):
 
         self.lr_scheduler = lr_scheduler
         super(LRScheduler, self).__init__(
@@ -338,10 +338,13 @@ class ReduceLROnPlateau(ParamScheduler):
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
-        metric_name (str, optional): name of  metrics by which to measure plateau (either `metric_name` or
+        metric_name (str, optional): name of  metrics by which to
+             measure plateau (either `metric_name` or
             `output_transform` should be used, but not both).
-        output_transform (Callable, optional): a function to select (from the engine's output) what you want
-         to measure plateau by. This function should return a single scalar. (either `metric_name` or
+        output_transform (Callable, optional): a function to select
+            (from the engine's output) what you want
+            to measure plateau by. This function should return a
+            single scalar. (either `metric_name` or
             `output_transform` should be used, but not both).
         mode (str): One of `min`, `max`. In `min` mode, lr will
             be reduced when the quantity monitored has stopped
@@ -381,15 +384,15 @@ class ReduceLROnPlateau(ParamScheduler):
         scheduler = ReduceLROnPlateau(optimizer, output_transform=lambda x: x, patience=2, factor=0.2)
         trainer.add_event_handler(Events.ITERATION_COMPLETED, scheduler)
     """
-    def __init__(self, optimizer, metric_name=None, output_transform=None, mode='min', factor=0.1,
-                 patience=10, threshold=1e-4, threshold_mode='rel',
-                 cooldown=0, min_lr=0, eps=1e-8, save_history=False):
+    def __init__(self, optimizer, metric_name=None, output_transform=None, mode='min',
+                 factor=0.1, patience=10, threshold=1e-4, threshold_mode='rel',
+                 cooldown=0, min_lr=0, eps=1e-8, save_history=False, **kwds):
 
         assert (metric_name is None and output_transform is not None) or \
                (metric_name is not None and output_transform is None), \
             "One of the parameters: `metric_name`, `output_transform` should be used but not both. "
 
-        import torch.optim.lr_scheduler.ReduceLROnPlateau as pytorch_ROP
+        from torch.optim.lr_scheduler import ReduceLROnPlateau as pytorch_ROP
 
         self._lr_scheduler = pytorch_ROP(
             optimizer=optimizer,

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -447,5 +447,3 @@ class ReduceLROnPlateau(ParamScheduler):
         param_group = list(self.optimizer_param_groups)[0]
 
         return param_group[self.param_name]
-
-

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -373,7 +373,6 @@ class ReduceLROnPlateau(ParamScheduler):
         eps (float): Minimal decay applied to lr. If the difference
             between new and old lr is smaller than eps, the update is
             ignored. Default: 1e-8.
-        metric (subclass of `ignite.metrics.metric`): The metric by which to measure plateau.
         save_history (bool, optional): whether to log the parameter values
             (default=False)
 
@@ -424,7 +423,7 @@ class ReduceLROnPlateau(ParamScheduler):
             if self.metric_name not in engine.state.metrics:
                 raise KeyError("metric {} not found in engine.state.metrics".format(self.metric_name))
 
-            metric = engine.state.metrics[name]
+            metric = engine.state.metrics[self.metric_name]
         else:
             metric = self.output_transform(engine.state.output)
 


### PR DESCRIPTION
Description:

Add wrappers that allow using "native" `torch.optim lr_scheduler` objects as (or together with)`ignite.contrib.handlers.param_scheduler` objects. For example this allowing attaching `ReduceLROnPlateau` to a `trainer` object or concatenate it with other `ParamScheduler` objects.

Check list:
* [ ] New tests are added (if a new feature is modified)
* [x] New doc strings: text and/or example code are in RST format
* [ ] Documentation is updated (if required)
