### PR TITLE
Adding the ability to control the bar_format parameter of the progresbar

### DIFF
--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -12,6 +12,17 @@ class ProgressBar:
 
     Args:
         persist (bool, optional): set to ``True`` to persist the progress bar after completion (default = ``False``)
+        bar_format  (str, optional): Specify a custom bar string formatting. May impact performance.
+            [default: '{desc}[{n_fmt}/{total_fmt}] {percentage:3.0f}%|{bar}{postfix} [{elapsed}<{remaining}]'].
+            Set to ``None`` to use ``tqdm`` default bar formatting: '{l_bar}{bar}{r_bar}', where
+            l_bar='{desc}: {percentage:3.0f}%|' and
+            r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
+              '{rate_fmt}{postfix}]'
+            Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
+              percentage, rate, rate_fmt, rate_noinv, rate_noinv_fmt,
+              rate_inv, rate_inv_fmt, elapsed, remaining, desc, postfix.
+            Note that a trailing ": " is automatically removed after {desc}
+            if the latter is empty.
 
     Examples:
 
@@ -50,15 +61,17 @@ class ProgressBar:
         ``pbar.log_message`` to guarantee the correct format of the stdout.
     """
 
-    def __init__(self, persist=False):
+    def __init__(self, persist=False,
+                 bar_format='{desc}[{n_fmt}/{total_fmt}] {percentage:3.0f}%|{bar}{postfix} [{elapsed}<{remaining}]'):
         self.pbar = None
         self.persist = persist
+        self.bar_format = bar_format
 
     def _reset(self, engine):
         self.pbar = tqdm(
             total=len(engine.state.dataloader),
             leave=self.persist,
-            bar_format='{desc}[{n_fmt}/{total_fmt}] {percentage:3.0f}%|{bar}{postfix} [{elapsed}<{remaining}]')
+            bar_format=self.bar_format)
 
     def _close(self, engine):
         self.pbar.close()


### PR DESCRIPTION
Description:

This PR adds the ability to set the `bar_format` of the `ProgressBar`. For example by setting it to `None`, the progress bar will use the default `tqdm` bar format that shows the iterations speed that is important for comparing network speeds.

Check list:
* [ ] New tests are added (if a new feature is modified)
* [x] New doc strings: text and/or example code are in RST format
* [ ] Documentation is updated (if required)
