### PR TITLE
Stacktrace filtering

### DIFF
--- a/docs/source/engine.rst
+++ b/docs/source/engine.rst
@@ -3,6 +3,8 @@ ignite.engine
 
 .. currentmodule:: ignite.engine
 
+.. autofunction:: filter_traceback
+
 .. autoclass:: Engine
    :members:
 

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -209,6 +209,10 @@ class Engine(object):
 
     def _filter_traceback(self, e):
         """ Returns exception with a filtered traceback. """
+
+        if not _FILTER_TB:
+            return e
+
         tb = e.__traceback__
         filtered = []
         full = []

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -12,6 +12,15 @@ _FILTER_TB = True
 
 
 def filter_traceback(flag=True):
+    """ Turns on or off the ignite traceback filtering (ON by default).
+
+    If traceback filtering is ON, the traceback printed in case of exception
+    will not contain frames from the ignite code.
+
+    Args:
+        flag (bool): if ``True``, turns on the traceback filtering. If
+        ``False``, turns it off.
+    """
     global _FILTER_TB
     _FILTER_TB = flag
 
@@ -195,9 +204,11 @@ class Engine(object):
                                  fn, fn_description, fn_params, passed_params, exception_msg))
 
     def _is_ignite_file(self, tb_frame):
+        """ Checks if a particular frame is from ignite code. """
         return tb_frame.f_globals['__name__'].split('.')[0] == 'ignite'
 
     def _filter_traceback(self, e):
+        """ Returns exception with a filtered traceback. """
         tb = e.__traceback__
         filtered = []
         full = []


### PR DESCRIPTION
Fixes #229 

This is sort of a proof-of-concept. I'm not sure how safe it is to re-write stacktrace like this, to be honest I can't think of any adverse effects. 

Here's the result of this patch:

Before:
![screenshot from 2018-12-08 19-11-40](https://user-images.githubusercontent.com/10772830/49689366-7bd6cc80-fb20-11e8-81d5-80886346252e.png)

After:
![screenshot from 2018-12-08 19-07-40](https://user-images.githubusercontent.com/10772830/49689367-7bd6cc80-fb20-11e8-8120-530eb424cb6d.png)
