### PR TITLE
Move import of sklearn to average_precision_compute_fn

### DIFF
--- a/ignite/contrib/metrics/__init__.py
+++ b/ignite/contrib/metrics/__init__.py
@@ -1,2 +1,3 @@
 from ignite.contrib.metrics.average_precision import AveragePrecision
 from ignite.contrib.metrics.roc_auc import ROC_AUC
+import regression

--- a/ignite/contrib/metrics/__init__.py
+++ b/ignite/contrib/metrics/__init__.py
@@ -1,3 +1,3 @@
 from ignite.contrib.metrics.average_precision import AveragePrecision
 from ignite.contrib.metrics.roc_auc import ROC_AUC
-import regression
+import ignite.contrib.metrics.regression

--- a/ignite/contrib/metrics/average_precision.py
+++ b/ignite/contrib/metrics/average_precision.py
@@ -1,14 +1,13 @@
 from functools import partial
-
-try:
-    from sklearn.metrics import average_precision_score
-except ImportError:
-    raise RuntimeError("This contrib module requires sklearn to be installed")
-
 from ignite.metrics import EpochMetric
 
 
 def average_precision_compute_fn(y_preds, y_targets, activation=None):
+    try:
+        from sklearn.metrics import average_precision_score
+    except ImportError:
+        raise RuntimeError("This contrib module requires sklearn to be installed")
+
     y_true = y_targets.numpy()
     if activation is not None:
         y_preds = activation(y_preds)

--- a/ignite/contrib/metrics/roc_auc.py
+++ b/ignite/contrib/metrics/roc_auc.py
@@ -1,14 +1,13 @@
 from functools import partial
-
-try:
-    from sklearn.metrics import roc_auc_score
-except ImportError:
-    raise RuntimeError("This contrib module requires sklearn to be installed")
-
 from ignite.metrics import EpochMetric
 
 
 def roc_auc_compute_fn(y_preds, y_targets, activation=None):
+    try:
+        from sklearn.metrics import roc_auc_score
+    except ImportError:
+        raise RuntimeError("This contrib module requires sklearn to be installed")
+
     y_true = y_targets.numpy()
     if activation is not None:
         y_preds = activation(y_preds)


### PR DESCRIPTION
Otherwise the whole ignite.contrib.metrics would require sklearn

I get the following error on one of my CI for TorchANI:
```
2018-12-11T18:22:03.7697568Z   File "/home/vsts/work/1/s/torchani/ignite.py", line 9, in <module>
2018-12-11T18:22:03.7697655Z     from ignite.contrib.metrics.regression import MaximumAbsoluteError
2018-12-11T18:22:03.7698132Z   File "/home/vsts/work/1/s/.eggs/pytorch_ignite_nightly-20181211-py3.7.egg/ignite/contrib/metrics/__init__.py", line 1, in <module>
2018-12-11T18:22:03.7698348Z     from ignite.contrib.metrics.average_precision import AveragePrecision
2018-12-11T18:22:03.7698817Z   File "/home/vsts/work/1/s/.eggs/pytorch_ignite_nightly-20181211-py3.7.egg/ignite/contrib/metrics/average_precision.py", line 6, in <module>
2018-12-11T18:22:03.7698918Z     raise RuntimeError("This contrib module requires sklearn to be installed")
2018-12-11T18:22:03.7699034Z RuntimeError: This contrib module requires sklearn to be installed
```

See: https://zasdfgbnm.visualstudio.com/torchani/_build/results?buildId=421