### PR TITLE
Updated pbar description: custom desc + [epoch/n_epochs]

### DIFF
--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -20,9 +20,9 @@ class ProgressBar(object):
             r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]'. For more details on the
             formatting, see `tqdm docs <https://tqdm.github.io/docs/tqdm/>`_.
         **tqdm_kwargs: kwargs passed to tqdm progress bar.
-            By default, progress bar description displays "Epoch [5/10]". If tqdm_kwargs defines
-            `desc`, e.g. "Predictions", than the description is "Predictions [5/7]" if number of epochs is more
-            than one otherwise it is simply "Predictions".
+            By default, progress bar description displays "Epoch [5/10]" where 5 is the current epoch and 10 is the
+            number of epochs. If tqdm_kwargs defines `desc`, e.g. "Predictions", than the description is
+            "Predictions [5/10]" if number of epochs is more than one otherwise it is simply "Predictions".
 
     Examples:
 

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -86,8 +86,8 @@ class ProgressBar:
         if self.pbar is None:
             self._reset(engine)
 
-        if 'desc' not in self.tqdm_kwargs:
-            self.pbar.set_description('Epoch [{}/{}]'.format(engine.state.epoch, engine.state.max_epochs))
+        desc = "Epoch" if 'desc' not in self.tqdm_kwargs else self.tqdm_kwargs['desc']
+        self.pbar.set_description('{} [{}/{}]'.format(desc, engine.state.epoch, engine.state.max_epochs))
 
         metrics = {}
         if metric_names is not None:

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -86,7 +86,7 @@ class ProgressBar:
         if self.pbar is None:
             self._reset(engine)
 
-        desc = "Epoch" if 'desc' not in self.tqdm_kwargs else self.tqdm_kwargs['desc']
+        desc = self.tqdm_kwargs.get("desc", "Epoch")
         self.pbar.set_description('{} [{}/{}]'.format(desc, engine.state.epoch, engine.state.max_epochs))
 
         metrics = {}

--- a/tests/ignite/contrib/handlers/test_pbar.py
+++ b/tests/ignite/contrib/handlers/test_pbar.py
@@ -146,5 +146,5 @@ def test_pbar_with_tqdm_kwargs(capsys):
     err = captured.err.split('\r')
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = u'My description: [4/5]  80%|████████  , output=1.00e+00 [00:00<00:00]'.format()
+    expected = u'My description:  [10/10]: [4/5]  80%|████████  , output=1.00e+00 [00:00<00:00]'.format()
     assert err[-1] == expected


### PR DESCRIPTION
Description:
Minor pbar update to display current epoch / num_epochs with custom description:
```python
    pbar = ProgressBar(desc="Validation")
    pbar.attach(engine, output_transform=lambda x: x)
    engine.run(loader, max_epochs=n_epochs)
    expected = u'Validation [10/10]: [4/5]  80%|████████  , output=1.00e+00 [00:00<00:00]'
```

Check list:
* [x] Tests updated


cc @amitibo @miguelvr 