### PR TITLE
Add start_epoch to Engine.run

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -290,18 +290,19 @@ class Engine(object):
         else:
             raise e
 
-    def run(self, data, max_epochs=1):
+    def run(self, data, max_epochs=1, start_epoch=0):
         """Runs the process_function over the passed data.
 
         Args:
             data (Iterable): Collection of batches allowing repeated iteration (e.g., list or `DataLoader`)
             max_epochs (int, optional): max epochs to run for (default: 1)
+            start_epoch (int, optional): start epoch, useful in resuming models (default: 0)
 
         Returns:
             State: output state
         """
 
-        self.state = State(dataloader=data, epoch=0, max_epochs=max_epochs, metrics={})
+        self.state = State(dataloader=data, epoch=start_epoch, max_epochs=max_epochs, metrics={})
 
         try:
             self._logger.info("Engine run starting with max_epochs={}".format(max_epochs))

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -416,9 +416,11 @@ def _create_mock_data_loader(epochs, batches_per_epoch):
 
 
 def test_iteration_events_are_fired():
+    start_epoch = 1
     max_epochs = 5
     num_batches = 3
-    data = _create_mock_data_loader(max_epochs, num_batches)
+    epochs = max_epochs - start_epoch
+    data = _create_mock_data_loader(epochs, num_batches)
 
     engine = Engine(MagicMock(return_value=1))
 
@@ -432,13 +434,13 @@ def test_iteration_events_are_fired():
     mock_manager.attach_mock(iteration_started, 'iteration_started')
     mock_manager.attach_mock(iteration_complete, 'iteration_complete')
 
-    engine.run(data, max_epochs=max_epochs)
+    engine.run(data, start_epoch=start_epoch, max_epochs=max_epochs)
 
-    assert iteration_started.call_count == num_batches * max_epochs
-    assert iteration_complete.call_count == num_batches * max_epochs
+    assert iteration_started.call_count == num_batches * epochs
+    assert iteration_complete.call_count == num_batches * epochs
 
     expected_calls = []
-    for i in range(max_epochs * num_batches):
+    for i in range(epochs * num_batches):
         expected_calls.append(call.iteration_started(engine))
         expected_calls.append(call.iteration_complete(engine))
 


### PR DESCRIPTION
**Description:**
This is useful for those wishing to resume training an existing
partially trained model. If you've got code set up to use
`engine.state.epochs` ideally you want to be able to resume training
without having to change this code to take into account the fact the
model has already been partially trained. The reason for adding the argument
after `max_epochs` is to maintain compatibility with existing code that uses the
position of `max_epochs` rather than kwarg.

**Check list:**
* [x] New tests are added (if a new feature is modified)
* [x] New doc strings: text and/or example code are in RST format
* [x] Documentation is updated (if required)
