### PR TITLE
Fix examples/mnist/mnist*.py 

### DIFF
--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -9,7 +9,7 @@ from torchvision.transforms import Compose, ToTensor, Normalize
 from torchvision.datasets import MNIST
 
 from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator
-from ignite.metrics import Accuracy, Loss
+from ignite.metrics import CategoricalAccuracy, Loss
 
 from tqdm import tqdm
 
@@ -52,12 +52,14 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     if torch.cuda.is_available():
         device = 'cuda'
 
+    model = model.to(device)
+
     optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
     trainer = create_supervised_trainer(model, optimizer, F.nll_loss, device=device)
-    evaluator = create_supervised_evaluator(model,
-                                            metrics={'accuracy': Accuracy(),
-                                                     'nll': Loss(F.nll_loss)},
-                                            device=device)
+    evaluator = create_supervised_evaluator(
+        model,
+        metrics={'accuracy': CategoricalAccuracy(), 'nll': Loss(F.nll_loss)},
+        device=device)
 
     desc = "ITERATION - loss: {:.2f}"
     pbar = tqdm(

--- a/examples/mnist/mnist_with_tensorboardx.py
+++ b/examples/mnist/mnist_with_tensorboardx.py
@@ -30,7 +30,7 @@ except ImportError:
     raise RuntimeError("No tensorboardX package is found. Please install with the command: \npip install tensorboardX")
 
 from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator
-from ignite.metrics import Accuracy, Loss
+from ignite.metrics import CategoricalAccuracy, Loss
 
 
 class Net(nn.Module):
@@ -83,12 +83,14 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval, lo
     if torch.cuda.is_available():
         device = 'cuda'
 
+    model = model.to(device)
+
     optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
     trainer = create_supervised_trainer(model, optimizer, F.nll_loss, device=device)
-    evaluator = create_supervised_evaluator(model,
-                                            metrics={'accuracy': Accuracy(),
-                                                     'nll': Loss(F.nll_loss)},
-                                            device=device)
+    evaluator = create_supervised_evaluator(
+        model,
+        metrics={'accuracy': CategoricalAccuracy(), 'nll': Loss(F.nll_loss)},
+        device=device)
 
     @trainer.on(Events.ITERATION_COMPLETED)
     def log_training_loss(engine):

--- a/examples/mnist/mnist_with_visdom.py
+++ b/examples/mnist/mnist_with_visdom.py
@@ -15,7 +15,7 @@ except ImportError:
     raise RuntimeError("No visdom package is found. Please install it with command: \n pip install visdom")
 
 from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator
-from ignite.metrics import Accuracy, Loss
+from ignite.metrics import CategoricalAccuracy, Loss
 
 
 class Net(nn.Module):
@@ -65,12 +65,14 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
     if torch.cuda.is_available():
         device = 'cuda'
 
+    model = model.to(device)
+
     optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
     trainer = create_supervised_trainer(model, optimizer, F.nll_loss, device=device)
-    evaluator = create_supervised_evaluator(model,
-                                            metrics={'accuracy': Accuracy(),
-                                                     'nll': Loss(F.nll_loss)},
-                                            device=device)
+    evaluator = create_supervised_evaluator(
+        model,
+        metrics={'accuracy': CategoricalAccuracy(), 'nll': Loss(F.nll_loss)},
+        device=device)
 
     train_loss_window = create_plot_window(vis, '#Iterations', 'Loss', 'Training Loss')
     train_avg_loss_window = create_plot_window(vis, '#Iterations', 'Loss', 'Training Average Loss')


### PR DESCRIPTION
Fixes # 2

Description:

The scripts wouldn't even run because

* Someone split `Accuracy` into `BinaryAccuracy` and `CategoricalAccuracy` without updating the client code! 
* On a machine with a GPU, the model wasn't being put to the device, but the inputs were.

Check list:
* [ ] New tests are added (if a new feature is modified)
* [ ] New doc strings: text and/or example code are in RST format
* [ ] Documentation is updated (if required)
