### PR TITLE
Bug Fix for Multiclass Precision/Recall, if num_classes is less than label in y

### DIFF
--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -90,6 +90,9 @@ class Precision(_BasePrecisionRecall):
             y = y.view(-1)
         elif self._type == "multiclass":
             num_classes = y_pred.size(1)
+            if y.max() + 1 > num_classes:
+                raise ValueError("y_pred contains less classes than y. Number of classes in output is {}"
+                                 " and element in y has invalid class = {}.".format(num_classes, y.max().item() + 1))
             y = to_onehot(y.view(-1), num_classes=num_classes)
             indices = torch.max(y_pred, dim=1)[1].view(-1)
             y_pred = to_onehot(indices, num_classes=num_classes)

--- a/ignite/metrics/recall.py
+++ b/ignite/metrics/recall.py
@@ -65,6 +65,9 @@ class Recall(_BasePrecisionRecall):
             y = y.view(-1)
         elif self._type == "multiclass":
             num_classes = y_pred.size(1)
+            if y.max() + 1 > num_classes:
+                raise ValueError("y_pred contains less classes than y. Number of predicted classes is {}"
+                                 " and element in y has invalid class = {}.".format(num_classes, y.max().item() + 1))
             y = to_onehot(y.view(-1), num_classes=num_classes)
             indices = torch.max(y_pred, dim=1)[1].view(-1)
             y_pred = to_onehot(indices, num_classes=num_classes)

--- a/tests/ignite/metrics/test_precision.py
+++ b/tests/ignite/metrics/test_precision.py
@@ -643,3 +643,18 @@ def test_incorrect_type():
 
     _test(average=True)
     _test(average=False)
+
+
+def test_incorrect_y_classes():
+
+    def _test(average):
+        pr = Precision(average=average)
+
+        y_pred = torch.randint(0, 2, size=(10, 4)).float()
+        y = torch.randint(0, 5, size=(10, )).long()
+
+        with pytest.raises(ValueError):
+            pr.update((y_pred, y))
+
+    _test(average=True)
+    _test(average=False)

--- a/tests/ignite/metrics/test_recall.py
+++ b/tests/ignite/metrics/test_recall.py
@@ -643,3 +643,18 @@ def test_incorrect_type():
 
     _test(average=True)
     _test(average=False)
+
+
+def test_incorrect_y_classes():
+
+    def _test(average):
+        re = Recall(average=average)
+
+        y_pred = torch.randint(0, 2, size=(10, 4)).float()
+        y = torch.randint(0, 5, size=(10, )).long()
+
+        with pytest.raises(ValueError):
+            re.update((y_pred, y))
+
+    _test(average=True)
+    _test(average=False)


### PR DESCRIPTION
Fixes #411  

Description:
For multiclass case, raises error if y.max() + 1 > num_classes ( aka y_pred.size(1)). Added tests. 

Check list:
* [x] New tests are added (if a new feature is modified)
* [ ] New doc strings: text and/or example code are in RST format
* [ ] Documentation is updated (if required)
