### PR TITLE
Added mean and sum ops to MetricsLambda

### DIFF
--- a/ignite/metrics/metrics_lambda.py
+++ b/ignite/metrics/metrics_lambda.py
@@ -1,3 +1,5 @@
+import torch
+
 from ignite.metrics.metric import Metric
 from ignite.engine import Events
 
@@ -68,3 +70,31 @@ class MetricsLambda(Metric):
         self._internal_attach(engine)
         # attach only handler on EPOCH_COMPLETED
         engine.add_event_handler(Events.EPOCH_COMPLETED, self.completed, name)
+
+    def mean(self):
+        """Helper operation to average the output metric
+
+        Example:
+
+        .. code-block:: python
+
+            precision = Precision(average=False)
+            recall = Recall(average=False)
+            f1 = (precision * recall * 2 / (precision + recall + 1e-20)).mean()
+
+        """
+        return MetricsLambda(lambda t: torch.mean(t).item(), self)
+
+    def sum(self):
+        """Helper operation to sum the output metric
+
+        Example:
+
+        .. code-block:: python
+
+            precision = Precision(average=False)
+            recall = Recall(average=False)
+            custom_metric = (precision + recall).sum()
+
+        """
+        return MetricsLambda(lambda t: torch.sum(t).item(), self)

--- a/tests/ignite/metrics/test_metrics_lambda.py
+++ b/tests/ignite/metrics/test_metrics_lambda.py
@@ -285,3 +285,68 @@ def test_recursive_attachment():
         return 2.0 + 0.2 * (p1 * p2 + p1 - p2) ** 0.5
 
     _test(some_metric, "some metric", compute_true_somemetric)
+
+
+def test_helper_ops():
+
+    def _test(composed_metric, metric_name, compute_true_value_fn):
+
+        metrics = {
+            metric_name: composed_metric,
+        }
+
+        y_pred = torch.rand(15, 10, 5).float()
+        y = torch.randint(0, 5, size=(15, 10)).long()
+
+        def update_fn(engine, batch):
+            y_pred, y = batch
+            return y_pred, y
+
+        validator = Engine(update_fn)
+
+        for name, metric in metrics.items():
+            metric.attach(validator, name)
+
+        def data(y_pred, y):
+            for i in range(y_pred.shape[0]):
+                yield (y_pred[i], y[i])
+
+        d = data(y_pred, y)
+        state = validator.run(d, max_epochs=1)
+
+        assert set(state.metrics.keys()) == set([metric_name, ])
+        np_y_pred = np.argmax(y_pred.numpy(), axis=-1).ravel()
+        np_y = y.numpy().ravel()
+        assert state.metrics[metric_name] == approx(compute_true_value_fn(np_y_pred, np_y))
+
+    precision_1 = Precision(average=False)
+    precision_2 = Precision(average=False)
+    mean_summed_precision = (precision_1 + precision_2).mean()
+
+    def compute_true_mean_summed_precision(y_pred, y):
+        p1 = precision_score(y, y_pred, average=None)
+        p2 = precision_score(y, y_pred, average=None)
+        return np.mean(p1 + p2)
+
+    _test(mean_summed_precision, "mean summed precision", compute_true_value_fn=compute_true_mean_summed_precision)
+
+    precision = Precision(average=False)
+    recall = Recall(average=False)
+    sum_precision_recall = (precision + recall).sum()
+
+    def compute_sum_precision_recall(y_pred, y):
+        p = precision_score(y, y_pred, average=None)
+        r = recall_score(y, y_pred, average=None)
+        return np.sum(p + r)
+
+    _test(sum_precision_recall, "sum precision recall", compute_true_value_fn=compute_sum_precision_recall)
+
+    precision = Precision(average=False)
+    recall = Recall(average=False)
+    f1 = (precision * recall * 2 / (precision + recall + 1e-20)).mean()
+
+    def compute_f1(y_pred, y):
+        f1 = f1_score(y, y_pred, average='macro')
+        return f1
+
+    _test(f1, "f1", compute_true_value_fn=compute_f1)


### PR DESCRIPTION
Fixes #414  

Description:
Added two basic helper ops `mean` and `sum`. To enable the below code:
```python
precision = Precision(average=False)
recall = Recall(average=False)
f1 = (precision * recall * 2 / (precision + recall + 1e-20)).mean()

precision = Precision(average=False)
recall = Recall(average=False)
custom_metric = (precision + recall).sum()
```
Check list:
* [x] New tests are added (if a new feature is modified)
* [x] New doc strings: text and/or example code are in RST format
* [ ] Documentation is updated (if required)
