### PR TITLE
Increase early stopping counter on plateau

### DIFF
--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -55,7 +55,7 @@ class EarlyStopping(object):
 
         if self.best_score is None:
             self.best_score = score
-        elif score < self.best_score:
+        elif score <= self.best_score:
             self.counter += 1
             self._logger.debug("EarlyStopping: %i / %i" % (self.counter, self.patience))
             if self.counter >= self.patience:


### PR DESCRIPTION
Description:
In the current implementation, the early stopping never terminates training if the score function returns the same value (e.g. `loss == 0`). With the new fix, if the score plateaus, the counter is increased and the training is eventually terminated.
