### PR TITLE
Remove extra memory usage in batch processing.

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -76,6 +76,7 @@ def create_supervised_evaluator(model, metrics={},
         model.to(device)
 
     def _inference(engine, batch):
+        engine.state.output = None
         model.eval()
         with torch.no_grad():
             x, y = prepare_batch(batch, device=device, non_blocking=non_blocking)

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -302,7 +302,6 @@ class Engine(object):
                 self.state.batch = batch
                 self.state.iteration += 1
                 self._fire_event(Events.ITERATION_STARTED)
-                self.state.output = None
                 self.state.output = self._process_function(self, batch)
                 self._fire_event(Events.ITERATION_COMPLETED)
                 if self.should_terminate or self.should_terminate_single_epoch:

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -302,6 +302,7 @@ class Engine(object):
                 self.state.batch = batch
                 self.state.iteration += 1
                 self._fire_event(Events.ITERATION_STARTED)
+                self.state.output = None
                 self.state.output = self._process_function(self, batch)
                 self._fire_event(Events.ITERATION_COMPLETED)
                 if self.should_terminate or self.should_terminate_single_epoch:


### PR DESCRIPTION
Description:

Output of previous process_function call was not deleted yet when process_function is called next time and returns new output.
If output use much memory (say, in segmentation tasks), it results in 'out of memory' error for batch size smaller then it could be if previous output is released before new process_function call.


