### PR TITLE
Fix #477: output_transform parameter added to create_supervised... functions

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -35,7 +35,8 @@ def create_supervised_trainer(model, optimizer, loss_fn,
             are going to attach metrics to trainer, you should pass
             'output_transform = lambda x, y, y_pred, loss: (y_pred, y,)'
 
-    Note: `engine.state.output` for this engine is the loss of the processed batch.
+    Note: `engine.state.output` for this engine is defind by `output_transform` parameter and is the loss
+        of the processed batch by default.
 
     Returns:
         Engine: a trainer engine with supervised update function.
@@ -75,7 +76,8 @@ def create_supervised_evaluator(model, metrics={},
         output_transform (callable, optional): function that receives 'x', 'y', 'y_pred' and returns value
             to be assigned to engine's state.output after each iteration. Default is returning '(y_pred, y,)'
 
-    Note: `engine.state.output` for this engine is a tuple of `(batch_pred, batch_y)`.
+    Note: `engine.state.output` for this engine is defind by `output_transform` parameter and is
+        a tuple of `(batch_pred, batch_y)` by default.
 
     Returns:
         Engine: an evaluator engine with supervised inference function.

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -31,9 +31,7 @@ def create_supervised_trainer(model, optimizer, loss_fn,
         prepare_batch (callable, optional): function that receives `batch`, `device`, `non_blocking` and outputs
             tuple of tensors `(batch_x, batch_y)`.
         output_transform (callable, optional): function that receives 'x', 'y', 'y_pred', 'loss' and returns value
-            to be assigned to engine's state.output after each iteration. Default is returning `loss.item()`. If you
-            are going to attach metrics to trainer, you should pass
-            'output_transform = lambda x, y, y_pred, loss: (y_pred, y,)'
+            to be assigned to engine's state.output after each iteration. Default is returning `loss.item()`.
 
     Note: `engine.state.output` for this engine is defind by `output_transform` parameter and is the loss
         of the processed batch by default.
@@ -74,7 +72,8 @@ def create_supervised_evaluator(model, metrics={},
         prepare_batch (callable, optional): function that receives `batch`, `device`, `non_blocking` and outputs
             tuple of tensors `(batch_x, batch_y)`.
         output_transform (callable, optional): function that receives 'x', 'y', 'y_pred' and returns value
-            to be assigned to engine's state.output after each iteration. Default is returning `(y_pred, y,)`.
+            to be assigned to engine's state.output after each iteration. Default is returning `(y_pred, y,)` with fits
+            output expected by metrics. If you change it you should use `output_transform` in metrcis.
 
     Note: `engine.state.output` for this engine is defind by `output_transform` parameter and is
         a tuple of `(batch_pred, batch_y)` by default.

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -16,7 +16,7 @@ def _prepare_batch(batch, device=None, non_blocking=False):
 def create_supervised_trainer(model, optimizer, loss_fn,
                               device=None, non_blocking=False,
                               prepare_batch=_prepare_batch,
-                              output_transform = lambda x, y, y_pred, loss: loss.item() ):
+                              output_transform=lambda x, y, y_pred, loss: loss.item()):
     """
     Factory function for creating a trainer for supervised models.
 
@@ -59,7 +59,7 @@ def create_supervised_trainer(model, optimizer, loss_fn,
 def create_supervised_evaluator(model, metrics={},
                                 device=None, non_blocking=False,
                                 prepare_batch=_prepare_batch,
-                                output_transform = lambda x, y, y_pred: (y_pred, y,) ):
+                                output_transform=lambda x, y, y_pred: (y_pred, y,)):
     """
     Factory function for creating an evaluator for supervised models.
 

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -73,7 +73,7 @@ def create_supervised_evaluator(model, metrics={},
             tuple of tensors `(batch_x, batch_y)`.
         output_transform (callable, optional): function that receives 'x', 'y', 'y_pred' and returns value
             to be assigned to engine's state.output after each iteration. Default is returning `(y_pred, y,)` with fits
-            output expected by metrics. If you change it you should use `output_transform` in metrcis.
+            output expected by metrics. If you change it you should use `output_transform` in metrics.
 
     Note: `engine.state.output` for this engine is defind by `output_transform` parameter and is
         a tuple of `(batch_pred, batch_y)` by default.

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -72,7 +72,7 @@ def create_supervised_evaluator(model, metrics={},
         prepare_batch (callable, optional): function that receives `batch`, `device`, `non_blocking` and outputs
             tuple of tensors `(batch_x, batch_y)`.
         output_transform (callable, optional): function that receives 'x', 'y', 'y_pred' and returns value
-            to be assigned to engine's state.output after each iteration. Default is returning `(y_pred, y,)` with fits
+            to be assigned to engine's state.output after each iteration. Default is returning `(y_pred, y,)` which fits
             output expected by metrics. If you change it you should use `output_transform` in metrics.
 
     Note: `engine.state.output` for this engine is defind by `output_transform` parameter and is


### PR DESCRIPTION
'output_transform' parameter added to create_supervised_trainer(...) and create_supervised_evaluator(...) functions.

It can be used to change value being assigned to engine.state.output
For instance, it can be changed from loss.item() to (y, pred_y) if one need to attach metrics to training process.

Fixes #477 

