### PR TITLE
Added flag to display greatest tag as the main docs page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ jobs:
         - pip install git+https://github.com/anmolsjoshi/sphinxcontrib-versioning.git
 
       script:
-        - sphinx-versioning --use-master-conf build --whitelist-branches master docs/source docs/build/html
+        - sphinx-versioning --use-master-conf build --greatest-tag --whitelist-branches master docs/source docs/build/html
         # Create .nojekyll file to serve correctly _static and friends
         - touch docs/build/html/.nojekyll
       after_success: # Nothing to do


### PR DESCRIPTION
Fixes # 

Description:
Docs now shows greatest tag instead of master branch

Implemented here - https://anmolsjoshi.github.io/ignite_trial

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
