### PR TITLE
Add `epoch_bound` parameter to `RunningAverage`.

### DIFF
--- a/tests/ignite/metrics/test_running_average.py
+++ b/tests/ignite/metrics/test_running_average.py
@@ -108,15 +108,15 @@ def test_integration():
 
 
 def test_epoch_unbound():
-    
+
     n_iters = 10
     n_epochs = 3
     batch_size = 10
     n_classes = 10
     data = list(range(n_iters))
-    loss_values = iter(range(n_epochs*n_iters))
-    y_true_batch_values = iter(np.random.randint(0, n_classes, size=(n_epochs*n_iters, batch_size)))
-    y_pred_batch_values = iter(np.random.rand(n_epochs*n_iters, batch_size, n_classes))
+    loss_values = iter(range(n_epochs * n_iters))
+    y_true_batch_values = iter(np.random.randint(0, n_classes, size=(n_epochs * n_iters, batch_size)))
+    y_pred_batch_values = iter(np.random.rand(n_epochs * n_iters, batch_size, n_classes))
 
     def update_fn(engine, batch):
         loss_value = next(loss_values)
@@ -212,4 +212,3 @@ def test_multiple_attach():
 
     data = list(range(n_iters))
     trainer.run(data)
-

--- a/tests/ignite/metrics/test_running_average.py
+++ b/tests/ignite/metrics/test_running_average.py
@@ -107,6 +107,73 @@ def test_integration():
     trainer.run(data, max_epochs=1)
 
 
+def test_epoch_unbound():
+    
+    n_iters = 10
+    n_epochs = 3
+    batch_size = 10
+    n_classes = 10
+    data = list(range(n_iters))
+    loss_values = iter(range(n_epochs*n_iters))
+    y_true_batch_values = iter(np.random.randint(0, n_classes, size=(n_epochs*n_iters, batch_size)))
+    y_pred_batch_values = iter(np.random.rand(n_epochs*n_iters, batch_size, n_classes))
+
+    def update_fn(engine, batch):
+        loss_value = next(loss_values)
+        y_true_batch = next(y_true_batch_values)
+        y_pred_batch = next(y_pred_batch_values)
+        return loss_value, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+    trainer = Engine(update_fn)
+    alpha = 0.98
+
+    acc_metric = RunningAverage(Accuracy(output_transform=lambda x: [x[1], x[2]]), alpha=alpha, epoch_bound=False)
+    acc_metric.attach(trainer, 'running_avg_accuracy')
+
+    avg_output = RunningAverage(output_transform=lambda x: x[0], alpha=alpha, epoch_bound=False)
+    avg_output.attach(trainer, 'running_avg_output')
+
+    running_avg_acc = [None]
+
+    @trainer.on(Events.STARTED)
+    def running_avg_output_init(engine):
+        engine.state.running_avg_output = None
+
+    @trainer.on(Events.ITERATION_COMPLETED, running_avg_acc)
+    def manual_running_avg_acc(engine, running_avg_acc):
+        _, y_pred, y = engine.state.output
+        indices = torch.max(y_pred, 1)[1]
+        correct = torch.eq(indices, y).view(-1)
+        num_correct = torch.sum(correct).item()
+        num_examples = correct.shape[0]
+        batch_acc = num_correct * 1.0 / num_examples
+        if running_avg_acc[0] is None:
+            running_avg_acc[0] = batch_acc
+        else:
+            running_avg_acc[0] = running_avg_acc[0] * alpha + (1.0 - alpha) * batch_acc
+        engine.state.running_avg_acc = running_avg_acc[0]
+
+    @trainer.on(Events.ITERATION_COMPLETED)
+    def running_avg_output_update(engine):
+        if engine.state.running_avg_output is None:
+            engine.state.running_avg_output = engine.state.output[0]
+        else:
+            engine.state.running_avg_output = engine.state.running_avg_output * alpha + \
+                (1.0 - alpha) * engine.state.output[0]
+
+    @trainer.on(Events.ITERATION_COMPLETED)
+    def assert_equal_running_avg_acc_values(engine):
+        assert engine.state.running_avg_acc == engine.state.metrics['running_avg_accuracy'], \
+            "{} vs {}".format(engine.state.running_avg_acc, engine.state.metrics['running_avg_accuracy'])
+
+    @trainer.on(Events.ITERATION_COMPLETED)
+    def assert_equal_running_avg_output_values(engine):
+        assert engine.state.running_avg_output == engine.state.metrics['running_avg_output'], \
+            "{} vs {}".format(engine.state.running_avg_output, engine.state.metrics['running_avg_output'])
+
+    trainer.run(data, max_epochs=3)
+
+
 def test_multiple_attach():
     n_iters = 100
     errD_values = iter(np.random.rand(n_iters, ))
@@ -145,3 +212,4 @@ def test_multiple_attach():
 
     data = list(range(n_iters))
     trainer.run(data)
+


### PR DESCRIPTION
This optional parameter controls whether the running average should be reset after each epoch.

Check list:
* [ ] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
