### PR TITLE
Replace metrics={} with metrics=None in create_supervised_evaluator

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -55,7 +55,7 @@ def create_supervised_trainer(model, optimizer, loss_fn,
     return Engine(_update)
 
 
-def create_supervised_evaluator(model, metrics={},
+def create_supervised_evaluator(model, metrics=None,
                                 device=None, non_blocking=False,
                                 prepare_batch=_prepare_batch,
                                 output_transform=lambda x, y, y_pred: (y_pred, y,)):
@@ -81,6 +81,8 @@ def create_supervised_evaluator(model, metrics={},
     Returns:
         Engine: an evaluator engine with supervised inference function.
     """
+    metrics = metrics or {}
+
     if device:
         model.to(device)
 


### PR DESCRIPTION
Tiny fix to change `metrics={}` to `metrics=None` and using `None` as a sentinel value for an empty `dict`.

Mutable default arguments get weird because they are created once when the signature is declared and can be mutated inside of the function's body. It wasn't an issue in this function but if anyone used this as an example to write their own evaluator, they may stumble into some tricky bugs if they start mutating `metrics`.