### PR TITLE
Use Python built-in length function for batch_size in Loss metric

### DIFF
--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -26,7 +26,7 @@ class Loss(Metric):
     """
 
     def __init__(self, loss_fn, output_transform=lambda x: x,
-                 batch_size=lambda x: x.shape[0]):
+                 batch_size=lambda x: len(x)):
         super(Loss, self).__init__(output_transform)
         self._loss_fn = loss_fn
         self._batch_size = batch_size


### PR DESCRIPTION
Description:
The Loss metric now gets the batch_size using the Python built-in function `len` by default. This provides more general support for iterables (such as lists and tuples) without breaking existing functionality. Previously, only objects with a `shape` method like Torch Tensors or NumPy Arrays were supported.

For example: I'm working on an object detection model where the `y` argument for the loss function is a list. In this case, `y` can not be a tensor or array since the number of target objects is not constant across inputs. Currently, I override the default with `batch_size = len`, which seems cumbersome.

Related to #294

I ran `pytest tests` -  no new failures compared to the current master branch.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
