### PR TITLE
Support for layer freezing with Tensorboard integration

### DIFF
--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -140,6 +140,9 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
 
         global_step = engine.state.get_event_attrib_value(event_name)
         for name, p in self.model.named_parameters():
+            if p.grad is None:
+                continue
+
             name = name.replace('.', '/')
             logger.writer.add_scalar("weights_{}/{}".format(self.reduction.__name__, name),
                                      self.reduction(p.data),
@@ -177,6 +180,9 @@ class WeightsHistHandler(BaseWeightsHistHandler):
 
         global_step = engine.state.get_event_attrib_value(event_name)
         for name, p in self.model.named_parameters():
+            if p.grad is None:
+                continue
+
             name = name.replace('.', '/')
             logger.writer.add_histogram(tag="weights/{}".format(name),
                                         values=p.data.detach().cpu().numpy(),
@@ -216,6 +222,9 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
 
         global_step = engine.state.get_event_attrib_value(event_name)
         for name, p in self.model.named_parameters():
+            if p.grad is None:
+                continue
+
             name = name.replace('.', '/')
             logger.writer.add_scalar("grads_{}/{}".format(self.reduction.__name__, name),
                                      self.reduction(p.grad),
@@ -252,6 +261,9 @@ class GradsHistHandler(BaseWeightsHistHandler):
 
         global_step = engine.state.get_event_attrib_value(event_name)
         for name, p in self.model.named_parameters():
+            if p.grad is None:
+                continue
+
             name = name.replace('.', '/')
             logger.writer.add_histogram(tag="grads/{}".format(name),
                                         values=p.grad.detach().cpu().numpy(),

--- a/tests/ignite/contrib/handlers/conftest.py
+++ b/tests/ignite/contrib/handlers/conftest.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+import torch
+from mock import Mock
+
+
+@pytest.fixture()
+def norm_mock():
+    def norm(x):
+        return np.linalg.norm(x)
+    norm_mock = Mock(side_effect=norm, spec=norm)
+    norm_mock.configure_mock(**{"__name__": "norm"})
+    norm_mock.reset_mock()
+    return norm_mock
+
+
+@pytest.fixture()
+def dummy_model_factory():
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super(DummyModel, self).__init__()
+            self.fc1 = torch.nn.Linear(10, 10)
+            self.fc2 = torch.nn.Linear(12, 12)
+            self.fc1.weight.data.zero_()
+            self.fc1.bias.data.zero_()
+            self.fc2.weight.data.fill_(1.0)
+            self.fc2.bias.data.fill_(1.0)
+
+    def get_dummy_model(with_grads=True, with_frozen_layer=False):
+        model = DummyModel()
+        if with_grads:
+            model.fc2.weight.grad = torch.zeros_like(model.fc2.weight)
+            model.fc2.bias.grad = torch.zeros_like(model.fc2.bias)
+
+            if not with_frozen_layer:
+                model.fc1.weight.grad = torch.zeros_like(model.fc1.weight)
+                model.fc1.bias.grad = torch.zeros_like(model.fc1.bias)
+
+        if with_frozen_layer:
+            for param in model.fc1.parameters():
+                param.requires_grad = False
+        return model
+
+    return get_dummy_model

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -6,7 +6,7 @@ import math
 import numpy as np
 import pytest
 
-from mock import MagicMock, call, ANY, Mock
+from mock import MagicMock, call, ANY
 
 import torch
 


### PR DESCRIPTION
Fixes #514 

Description: Adds support for frozen layers, so that only the ones that are not frozen will be visible in the output Tensorboard and no exception will be thrown.


Check list:
* [x] New tests are added (if a new feature is added)
* [ ] _New doc strings: description and/or example code are in RST format_ - **N/A**
* [ ] _Documentation is updated (if required)_ - **N/A**
