### PR TITLE
Label-wise accuracy metrics implemented for multilabel classification.

### DIFF
--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -121,7 +121,9 @@ class Accuracy(_BaseClassification):
         self._num_correct = None
         self._num_examples = None
         self._num_correct_labelwise = None
-        super(Accuracy, self).__init__(output_transform=output_transform, is_multilabel=is_multilabel, labelwise=labelwise)
+        super(Accuracy, self).__init__(output_transform=output_transform,
+                                       is_multilabel=is_multilabel,
+                                       labelwise=labelwise)
 
     def reset(self):
         self._num_correct = 0
@@ -145,17 +147,17 @@ class Accuracy(_BaseClassification):
             last_dim = y_pred.ndimension()
             y_pred = torch.transpose(y_pred, 1, last_dim - 1).reshape(-1, num_classes)
             y = torch.transpose(y, 1, last_dim - 1).reshape(-1, num_classes)
-            correct = torch.all(y == y_pred.type_as(y), dim=-1) # Sample-wise
-
+            correct = torch.all(y == y_pred.type_as(y), dim=-1)  # Sample-wise
 
         self._num_correct += torch.sum(correct).item()
         self._num_examples += correct.shape[0]
         if self._labelwise:
             if self._num_correct_labelwise is not None:
-                self._num_correct_labelwise = torch.add(self._num_correct_labelwise, torch.sum(y == y_pred.type_as(y), dim=0))
+                self._num_correct_labelwise = torch.add(self._num_correct_labelwise,
+                                                        torch.sum(y == y_pred.type_as(y),
+                                                                  dim=0))
             else:
                 self._num_correct_labelwise = torch.sum(y == y_pred.type_as(y), dim=0)
-
 
     def compute(self):
         if self._num_examples == 0:

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 from sklearn.metrics import accuracy_score
 
-
 torch.manual_seed(12)
 
 
@@ -74,7 +73,7 @@ def test_binary_input_N():
         assert accuracy_score(np_y, np_y_pred) == pytest.approx(acc.compute())
 
         acc.reset()
-        y_pred = torch.randint(0, 2, size=(10, )).type(torch.LongTensor)
+        y_pred = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
         y = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
         acc.update((y_pred, y))
         np_y = y.numpy().ravel()
@@ -446,7 +445,7 @@ def test_multilabel_input_N():
         np_y = y.numpy()
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn multi-label acc analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
         acc.reset()
         y_pred = torch.randint(0, 2, size=(50, 7)).type(torch.LongTensor)
@@ -456,7 +455,7 @@ def test_multilabel_input_N():
         np_y = y.numpy()
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn multi-label acc analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
         # labelspecific Batched Updates
         acc.reset()
@@ -474,7 +473,7 @@ def test_multilabel_input_N():
         np_y_pred = y_pred.numpy()
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn multi-label acc analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
     # check multiple random inputs as random exact occurencies are rare
     for _ in range(10):
@@ -534,7 +533,7 @@ def test_multilabel_input_NL():
         np_y = to_numpy_multilabel(y)  # (N, C, L, ...) -> (N * L ..., C)
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
         acc.reset()
         y_pred = torch.randint(0, 2, size=(4, 10, 8)).type(torch.LongTensor)
@@ -544,7 +543,7 @@ def test_multilabel_input_NL():
         np_y = to_numpy_multilabel(y)  # (N, C, L, ...) -> (N * L ..., C)
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
         # labelspecific Batched Updates
         acc.reset()
@@ -562,7 +561,7 @@ def test_multilabel_input_NL():
         np_y = to_numpy_multilabel(y)  # (N, C, L, ...) -> (N * L ..., C)
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
     # check multiple random inputs as random exact occurencies are rare
     for _ in range(10):
@@ -622,7 +621,7 @@ def test_multilabel_input_NHW():
         np_y = to_numpy_multilabel(y)  # (N, C, H, W, ...) -> (N * H * W ..., C)
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
         acc.reset()
         y_pred = torch.randint(0, 2, size=(4, 10, 12, 8)).type(torch.LongTensor)
@@ -632,7 +631,7 @@ def test_multilabel_input_NHW():
         np_y = to_numpy_multilabel(y)  # (N, C, H, W, ...) -> (N * H * W ..., C)
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
         # labelspecific Batched Updates
         acc.reset()
@@ -650,7 +649,7 @@ def test_multilabel_input_NHW():
         np_y = to_numpy_multilabel(y)  # (N, C, L, ...) -> (N * L ..., C)
         assert acc._type == 'multilabel'
         assert isinstance(acc.compute(), torch.Tensor)
-        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy()) # no sklearn analogy
+        assert np.mean(np_y == np_y_pred, axis=0) == pytest.approx(acc.compute().numpy())  # no sklearn analogy
 
     # check multiple random inputs as random exact occurencies are rare
     for _ in range(10):


### PR DESCRIPTION
Signed-off-by: James P Howard <github@jph.am>

Fixes: Feature added - label-wise accuracy option for Accuracy metric.

Description: `Accuracy()` metrics with `is_multilabel=True` can now be passed `labelwise=True`. When present, the metric returns a tensor of accuracies for each class. For example:

```
evaluator = create_supervised_evaluator(model,
    metrics={'loss': Loss(loss),
    'accuracy': Accuracy(output_transform=thresholded_output_transform, is_multilabel=True),
    'precision': Precision(output_transform=thresholded_output_transform, is_multilabel=True, average=True),
    'label_acc':Accuracy(output_transform=thresholded_output_transform, is_multilabel=True, labelwise=True)},
    device=device)

@trainer.on(Events.EPOCH_COMPLETED)
def log_training_results(engine):
    evaluator.run(train_loader)
    metrics = evaluator.state.metrics
    acc, loss, precision, label_acc = metrics['accuracy'], metrics['loss'], metrics['precision'], metrics['label_acc']
    print(f"\rEnd of epoch {engine.state.epoch:03d}")
    print(f"TRAINING Accuracy: {acc:.3f} | Loss: {loss:.3f} | Precision: {precision:.3f} | Label-wise accuracy: {label_acc}")
    writer.add_scalar("training/accuracy", acc, engine.state.epoch)

@trainer.on(Events.EPOCH_COMPLETED)
def log_validation_results(engine):
    evaluator.run(test_loader)
    metrics = evaluator.state.metrics
    acc, loss, precision, label_acc = metrics['accuracy'], metrics['loss'], metrics['precision'], metrics['label_acc']
    print(f"TESTING  Accuracy: {acc:.3f} | Loss: {loss:.3f} | Precision: {precision:.3f} | Label-wise accuracy: {label_acc}\n")
    writer.add_scalar("testing/loss", loss, engine.state.epoch)
    writer.add_scalar("testing/accuracy", acc, engine.state.epoch)

trainer.run(train_loader, max_epochs=30)

```

Yields:

```
End of epoch 001
TRAINING Accuracy: 0.753 | Loss: 0.334 | Precision: 0.212 | Label-wise accuracy: tensor([0.8662, 0.8662], device='cuda:0')
TESTING  Accuracy: 0.725 | Loss: 0.341 | Precision: 0.221 | Label-wise accuracy: tensor([0.8302, 0.8755], device='cuda:0')

End of epoch 002
TRAINING Accuracy: 0.748 | Loss: 0.363 | Precision: 0.160 | Label-wise accuracy: tensor([0.8134, 0.9022], device='cuda:0')
TESTING  Accuracy: 0.672 | Loss: 0.537 | Precision: 0.087 | Label-wise accuracy: tensor([0.7057, 0.8792], device='cuda:0') 

```
Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
