### PR TITLE
Added event_to_attr in register_events

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -91,7 +91,7 @@ class Engine(object):
 
         self._check_signature(process_function, 'process_function', None)
 
-    def register_events(self, *event_names, event_to_attr=None):
+    def register_events(self, *event_names, **kwargs):
         """Add events that can be fired.
 
         Registering an event will let the user fire these events at any point.
@@ -118,6 +118,7 @@ class Engine(object):
             engine = Engine(process_function)
             engine.register_events(*Custom_Events)
         """
+        event_to_attr = kwargs.get('event_to_attr', None)
         if event_to_attr:
             if not isinstance(event_to_attr, dict):
                 raise ValueError('Expected event_to_attr to be dictionary. Got {}.'.format(type(event_to_attr)))

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -103,7 +103,7 @@ class Engine(object):
         Args:
             *event_names: An object (ideally a string or int) to define the
                 name of the event being supported.
-            event_to_attr (dict/object): A dictionary or object to map an event to a state attribute.
+            event_to_attr (dict): A dictionary to map an event to a state attribute.
 
         Example usage:
 
@@ -117,6 +117,25 @@ class Engine(object):
 
             engine = Engine(process_function)
             engine.register_events(*Custom_Events)
+
+
+        Example with State Attribute:
+
+        .. code-block:: python
+
+            from enum import Enum
+
+            class TBPTT_Events(Enum):
+                TIME_ITERATION_STARTED = "time_iteration_started"
+                TIME_ITERATION_COMPLETED = "time_iteration_completed"
+
+            TBPTT_event_to_attr = {TBPTT_Events.TIME_ITERATION_STARTED: 'time_iteration',
+                                   TBPTT_Events.TIME_ITERATION_STARTED: 'time_iteration'}
+
+            engine = Engine(process_function)
+            engine.register_events(*TBPTT_Events, event_to_attr=TBPTT_event_to_attr)
+            engine.run(data)
+            # engine.state contains an attribute time_iteration, which can be accessed using engine.state.time_iteration
         """
         event_to_attr = kwargs.get('event_to_attr', None)
         if event_to_attr:

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -231,6 +231,43 @@ def test_custom_events():
     assert handle.called
 
 
+def test_custom_events_with_event_to_attr():
+    class Custom_Events(Enum):
+        TEST_EVENT = "test_event"
+
+    custom_event_to_attr = {Custom_Events.TEST_EVENT: 'test_event'}
+
+    # Dummy engine
+    engine = Engine(lambda engine, batch: 0)
+    engine.register_events(*Custom_Events, event_to_attr=custom_event_to_attr)
+
+    # Handle is never called
+    handle = MagicMock()
+    engine.add_event_handler(Custom_Events.TEST_EVENT, handle)
+    engine.run(range(1))
+    assert hasattr(engine.state, 'test_event')
+    assert engine.state.test_event == 0
+
+    # Advanced engine
+    def process_func(engine, batch):
+        engine.fire_event(Custom_Events.TEST_EVENT)
+
+    engine = Engine(process_func)
+    engine.register_events(*Custom_Events, event_to_attr=custom_event_to_attr)
+
+    def handle(engine):
+        engine.state.test_event += 1
+
+    engine.add_event_handler(Custom_Events.TEST_EVENT, handle)
+    engine.run(range(25))
+    assert engine.state.test_event == 25
+
+    custom_event_to_attr = 'a'
+    engine = Engine(lambda engine, batch: 0)
+    with pytest.raises(ValueError):
+        engine.register_events(*Custom_Events, event_to_attr=custom_event_to_attr)
+
+
 def test_on_decorator_raises_with_invalid_event():
     engine = DummyEngine()
     with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #501  

Description:
* Added parameter in register_events to update state with Custom events
* Update State and Engine to initialize values using State.event_to_attr (removed hard coded epoch=0, iteration=0 in initialization of State)

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
