### PR TITLE
Fixes #536

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ install:
   - python setup.py install
   - pip install numpy mock pytest codecov pytest-cov
   # Examples dependencies
-  - pip install torchvision matplotlib pandas
+  - pip install matplotlib pandas
+  - conda install torchvision-cpu -c pytorch
   - pip install gym==0.10.11
 
 script:


### PR DESCRIPTION
Fixes #536 

Description:
install `torchvision-cpu` instead of `torchvision` which starts to require cuda libs
