### PR TITLE
Improved tqdm output value handler

### DIFF
--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -228,6 +228,8 @@ class _OutputHandler(BaseOutputHandler):
                 for i, v in enumerate(value):
                     k = "{}_{}".format(key, i)
                     rendered_metrics[k] = "{:.2e}".format(v)
+            elif isinstance(value, str):
+                rendered_metrics[key] = value
             else:
                 warnings.warn("ProgressBar can not log "
                               "metrics value type {}".format(type(value)))

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -152,6 +152,9 @@ class ProgressBar(BaseLogger):
                 :class:`~ignite.engine.Events`.
             closing_event_name: event's name on which the progress bar is closed. Valid events are from
                 :class:`~ignite.engine.Events`.
+
+        Note: accepted output value types are numbers, 0d and 1d torch tensors and strings
+
         """
         desc = self.tqdm_kwargs.get("desc", "Epoch")
 

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -147,6 +147,24 @@ def test_pbar_with_scalar_output(capsys):
     assert err[-1] == expected
 
 
+def test_pbar_with_str_output(capsys):
+    n_epochs = 2
+    loader = [1, 2]
+    engine = Engine(update_fn)
+
+    pbar = ProgressBar()
+    pbar.attach(engine, output_transform=lambda x: "red")
+
+    engine.run(loader, max_epochs=n_epochs)
+
+    captured = capsys.readouterr()
+    err = captured.err.split('\r')
+    err = list(map(lambda x: x.strip(), err))
+    err = list(filter(None, err))
+    expected = u'Epoch [2/2]: [1/2]  50%|█████     , output=red [00:00<00:00]'
+    assert err[-1] == expected
+
+
 def test_pbar_with_tqdm_kwargs(capsys):
     n_epochs = 10
     loader = [1, 2, 3, 4, 5]


### PR DESCRIPTION
String value is now accept

Description:
This PR will allow to log string values using ProgressBar.
For example, 
```
poch
[40/40] 100%|██████████, gpu memory=493 / 11176 MiB [00:04<00:00]
```


Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
