### PR TITLE
onehot method returns tensor with uint8 dtype

### DIFF
--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -43,7 +43,10 @@ def apply_to_type(input_, input_type, func):
 
 def to_onehot(indices, num_classes):
     """Convert a tensor of indices of any shape `(N, ...)` to a
-    tensor of one-hot indicators of shape `(N, num_classes, ...)`.
+    tensor of one-hot indicators of shape `(N, num_classes, ...) and of type uint8. Output's device is equal to the
+    input's device`.
     """
-    onehot = torch.zeros(indices.shape[0], num_classes, *indices.shape[1:], device=indices.device)
+    onehot = torch.zeros(indices.shape[0], num_classes, *indices.shape[1:],
+                         dtype=torch.uint8,
+                         device=indices.device)
     return onehot.scatter_(1, indices.unsqueeze(1), 1)

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -4,25 +4,25 @@ from ignite.utils import convert_tensor, to_onehot
 
 
 def test_convert_tensor():
-    x = torch.Tensor([0.0])
+    x = torch.tensor([0.0])
     tensor = convert_tensor(x)
     assert torch.is_tensor(tensor)
 
-    x = torch.Tensor([0.0])
+    x = torch.tensor([0.0])
     tensor = convert_tensor(x, device='cpu', non_blocking=True)
     assert torch.is_tensor(tensor)
 
-    x = torch.Tensor([0.0])
+    x = torch.tensor([0.0])
     tensor = convert_tensor(x, device='cpu', non_blocking=False)
     assert torch.is_tensor(tensor)
 
-    x = (torch.Tensor([0.0]), torch.Tensor([0.0]))
+    x = (torch.tensor([0.0]), torch.tensor([0.0]))
     list_ = convert_tensor(x)
     assert isinstance(list_, list)
     assert torch.is_tensor(list_[0])
     assert torch.is_tensor(list_[1])
 
-    x = {'a': torch.Tensor([0.0]), 'b': torch.Tensor([0.0])}
+    x = {'a': torch.tensor([0.0]), 'b': torch.tensor([0.0])}
     dict_ = convert_tensor(x)
     assert isinstance(dict_, dict)
     assert torch.is_tensor(dict_['a'])
@@ -35,9 +35,9 @@ def test_convert_tensor():
 
 
 def test_to_onehot():
-    indices = torch.LongTensor([0, 1, 2, 3])
+    indices = torch.tensor([0, 1, 2, 3], dtype=torch.long)
     actual = to_onehot(indices, 4)
-    expected = torch.eye(4)
+    expected = torch.eye(4, dtype=torch.uint8)
     assert actual.equal(expected)
 
     y = torch.randint(0, 21, size=(1000,))


### PR DESCRIPTION
Description: previously the output of onehot returned float tensor which seems unnatural to transform indices into float tensor with 0 and 1's. 
This PR fixes the output to torch.uint8 and such that it consumes less memory.
This change can be potentionally breaking BC if previousy users multiplied float tensors by the output of onehot. 

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
