### PR TITLE
Fixes docs build warnings

### DIFF
--- a/docs/source/contrib/handlers.rst
+++ b/docs/source/contrib/handlers.rst
@@ -23,7 +23,7 @@ tensorboard_logger
    :members:
    :inherited-members:
 
-See `mnist example <https://github.com/pytorch/ignite/blob/master/examples/contrib/mnist/mnist_with_tensorboard_logger.py>`_
+See `tensorboardX mnist example <https://github.com/pytorch/ignite/blob/master/examples/contrib/mnist/mnist_with_tensorboard_logger.py>`_
 and `CycleGAN and EfficientNet notebooks <https://github.com/pytorch/ignite/tree/master/examples/notebooks>`_ for detailed usage.
 
 
@@ -34,7 +34,7 @@ visdom_logger
    :members:
    :inherited-members:
 
-See `mnist example <https://github.com/pytorch/ignite/blob/master/examples/contrib/mnist/mnist_with_visdom_logger.py>`_
+See `visdom mnist example <https://github.com/pytorch/ignite/blob/master/examples/contrib/mnist/mnist_with_visdom_logger.py>`_
 for detailed usage.
 
 

--- a/ignite/contrib/handlers/mlflow_logger.py
+++ b/ignite/contrib/handlers/mlflow_logger.py
@@ -152,7 +152,7 @@ class MLflowLogger(BaseLogger):
     `MLflow <https://mlflow.org>`_ tracking client handler to log parameters and metrics during the training
     and validation.
 
-    This class requires `mlflow <https://github.com/mlflow/mlflow/>`_ package to be installed:
+    This class requires `mlflow package <https://github.com/mlflow/mlflow/>`_ to be installed:
 
     .. code-block:: bash
 


### PR DESCRIPTION
Description:
Fixes docs build warnings
- [docs/source/contrib/handlers.rst:2: WARNING: Duplicate explicit target name: "mnist example".](https://travis-ci.org/pytorch/ignite/jobs/575006899#L2625)
- [ignite/contrib/handlers/mlflow_logger.py:docstring of ignite.contrib.handlers.mlflow_logger.OptimizerParamsHandler:25: WARNING: Duplicate explicit target name: "mlflow".](https://travis-ci.org/pytorch/ignite/jobs/575006899#L2626)
