### PR TITLE
Return removable handle from Engine.add_event_handler().

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -103,7 +103,7 @@ reference returned by :meth:`~ignite.engine.Engine.add_event_handler`. This can 
         print("Epoch: {} - {} accuracy: {:.2f}"
                .format(trainer.state.epoch, title, engine.state.metrics['acc']))
 
-    @trainer.on(Events.EPOCH_COMPLETED):
+    @trainer.on(Events.EPOCH_COMPLETED)
     def evaluate(trainer):
         with evaluator.add_event_handler(Events.COMPLETED, log_metrics, "train"):
             evaluator.run(train_loader)

--- a/docs/source/engine.rst
+++ b/docs/source/engine.rst
@@ -14,3 +14,7 @@ ignite.engine
    :undoc-members:
 
 .. autoclass:: State
+
+.. autoclass:: RemovableEventHandler
+   :members:
+   :undoc-members:

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -53,7 +53,9 @@ class RemovableEventHandle(object):
     """A weakref handle to remove a registered event.
 
     A handle that may be used to remove a registered event handler via the
-    remove method or with-statement.
+    remove method, with-statement, or context manager protocol. Returned from
+    :meth:`~ignite.engine.Engine.add_event_handler`.
+
 
     Args:
         event_name: Registered event name.

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -1,5 +1,6 @@
 from __future__ import division
 from enum import Enum
+import gc
 
 import pytest
 from mock import call, MagicMock, Mock
@@ -200,6 +201,10 @@ def test_event_removable_handle():
         return _handle
 
     removable_handle = _add_in_closure()
+
+    # gc.collect, resolving reference cycles in engine/state
+    # required to ensure object deletion in python2
+    gc.collect()
 
     assert removable_handle.engine() is None
     assert removable_handle.handler() is None


### PR DESCRIPTION
Fixes #586

Description:

As per #586, return a weakref-based `RemovableEventHandle` from calls to `Engine.add_event_handler`. Handle is patterned on torch's `register_hook` interface, providing an explicit `remove()` method to remove the attached event as-well-as implementing the context manager protocol to provide support for `with`-statement based event scopes.

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
