### PR TITLE
TensorboardLogger init - forwarding kwargs to SummaryWriter

### DIFF
--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -322,7 +322,8 @@ class TensorboardLogger(BaseLogger):
 
 
     Args:
-        log_dir (str): path to the directory where to log.
+        *args: Positional arguments accepted from :class:`~tensorboardx.SummaryWriter`.
+        **kwargs: Keyword arguments accepted from :class:`~tensorboardx.SummaryWriter`.
 
     Examples:
 

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -324,7 +324,7 @@ class TensorboardLogger(BaseLogger):
     Args:
         *args: Positional arguments accepted from :class:`~tensorboardx.SummaryWriter`.
         **kwargs: Keyword arguments accepted from :class:`~tensorboardx.SummaryWriter`, for example,
-        `log_dir` to setup path to the directory where to log.
+            `log_dir` to setup path to the directory where to log.
 
     Examples:
 

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -399,23 +399,14 @@ class TensorboardLogger(BaseLogger):
 
     """
 
-    def __init__(self, log_dir):
+    def __init__(self, *args, **kwargs):
         try:
             from tensorboardX import SummaryWriter
         except ImportError:
             raise RuntimeError("This contrib module requires tensorboardX to be installed. "
                                "Please install it with command: \n pip install tensorboardX")
 
-        try:
-            self.writer = SummaryWriter(logdir=log_dir)
-        except TypeError as err:
-            if "type object got multiple values for keyword argument 'logdir'" == str(err):
-                self.writer = SummaryWriter(log_dir=log_dir)
-                warnings.warn('tensorboardX version < 1.7 will not be supported '
-                              'after ignite 0.3.0; please upgrade',
-                              DeprecationWarning)
-            else:
-                raise err
+        self.writer = SummaryWriter(*args, **kwargs)
 
     def close(self):
         self.writer.close()

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -323,7 +323,8 @@ class TensorboardLogger(BaseLogger):
 
     Args:
         *args: Positional arguments accepted from :class:`~tensorboardx.SummaryWriter`.
-        **kwargs: Keyword arguments accepted from :class:`~tensorboardx.SummaryWriter`.
+        **kwargs: Keyword arguments accepted from :class:`~tensorboardx.SummaryWriter`, for example,
+        `log_dir` to setup path to the directory where to log.
 
     Examples:
 

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -564,18 +564,6 @@ def mock_tb_module():
     sys.modules[module_name] = prev_tb_module
 
 
-def test_init_tb1p6(mock_tb_module):
-
-    def side_effect_v1p6(*args, **kwargs):
-        if 'logdir' in kwargs:
-            raise TypeError("type object got multiple values for keyword argument 'logdir'")
-
-    mock_tb_module.SummaryWriter = Mock(name='tensorboardX.SummaryWriter', side_effect=side_effect_v1p6)
-
-    with pytest.warns(DeprecationWarning, match=r'tensorboardX version < 1.7 will not be supported'):
-        TensorboardLogger(log_dir=None)
-
-
 def test_init_typeerror_exception(mock_tb_module):
 
     def side_effect(*args, **kwargs):


### PR DESCRIPTION
Fixes #597 

Description:
Class TensorboardLogger creates a SummaryWriter object during initialization but does not allow to pass keyword arguments other than `log_dir`. Now, TensorboadLogger fowards all positional and keyword arguments to SummaryWriter to enable full configuartion.


Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
