### PR TITLE
contrib|add tensorboardX import fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install: &before_install
   - source activate test-environment
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install enum34; fi
   # Test contrib dependencies
-  - pip install tqdm scikit-learn tensorboardX visdom polyaxon-client mlflow
+  - pip install tqdm scikit-learn tensorboardX visdom polyaxon-client mlflow tensorboard
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install pynvml; fi
   # Futures should be already installed via visdom -> tornado -> futures
   # Let's reinstall it anyway to be sure

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -414,7 +414,12 @@ class TensorboardLogger(BaseLogger):
         try:
             from tensorboardX import SummaryWriter
         except ImportError:
-            from torch.utils.tensorboard import SummaryWriter
+            try:
+                from torch.utils.tensorboard import SummaryWriter
+            except ModuleNotFoundError:
+                raise RuntimeError("This contrib module requires either tensorboardX or torch >= 1.2.0. "
+                                   "You may install tensorboardX with command: \n pip install tensorboardX \n"
+                                   "or upgrade PyTorch using your package manager of choice (pip or conda).")
 
         self.writer = SummaryWriter(*args, **kwargs)
 

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -322,13 +322,13 @@ class TensorboardLogger(BaseLogger):
     """
     TensorBoard handler to log metrics, model/optimizer parameters, gradients during the training and validation.
 
-    This class favors `tensorboardX <https://github.com/lanpa/tensorboardX>`_ package if installed:
+    By default, this class favors `tensorboardX <https://github.com/lanpa/tensorboardX>`_ package if installed:
 
     .. code-block:: bash
 
         pip install tensorboardX
 
-    else, it falls back to using PyTorch's new SummaryWriter.
+    otherwise, it falls back to using PyTorch's SummaryWriter (>=v1.2.0).
 
     Args:
         *args: Positional arguments accepted from :class:`~tensorboardx.SummaryWriter`.

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -416,7 +416,7 @@ class TensorboardLogger(BaseLogger):
         except ImportError:
             try:
                 from torch.utils.tensorboard import SummaryWriter
-            except ModuleNotFoundError:
+            except ImportError:
                 raise RuntimeError("This contrib module requires either tensorboardX or torch >= 1.2.0. "
                                    "You may install tensorboardX with command: \n pip install tensorboardX \n"
                                    "or upgrade PyTorch using your package manager of choice (pip or conda).")

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -322,12 +322,13 @@ class TensorboardLogger(BaseLogger):
     """
     TensorBoard handler to log metrics, model/optimizer parameters, gradients during the training and validation.
 
-    This class requires `tensorboardX <https://github.com/lanpa/tensorboardX>`_ package to be installed:
+    This class favors `tensorboardX <https://github.com/lanpa/tensorboardX>`_ package if installed:
 
     .. code-block:: bash
 
         pip install tensorboardX
 
+    else, it falls back to using PyTorch's new SummaryWriter.
 
     Args:
         *args: Positional arguments accepted from :class:`~tensorboardx.SummaryWriter`.
@@ -413,8 +414,7 @@ class TensorboardLogger(BaseLogger):
         try:
             from tensorboardX import SummaryWriter
         except ImportError:
-            raise RuntimeError("This contrib module requires tensorboardX to be installed. "
-                               "Please install it with command: \n pip install tensorboardX")
+            from torch.utils.tensorboard import SummaryWriter
 
         self.writer = SummaryWriter(*args, **kwargs)
 

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -560,68 +560,88 @@ def test_integration_as_context_manager(dirname):
     assert len(written_files) > 0
 
 
-@pytest.fixture
-def no_tensorboardX_package():
-    import sys
-    import tensorboardX
-    from torch.utils import tensorboard
-    # remove tensorboardX
-    tensorboardX_module = sys.modules['tensorboardX']
-    del sys.modules['tensorboardX']
-    # save and replace sys.path
-    prev_path = list(sys.path)
-    sys.path = [p for p in sys.path if "site-packages" not in p]
-    yield "no_site_packages"
-    # put everything back in place
-    sys.path = prev_path
-    sys.modules['tensorboardX'] = tensorboardX_module
+# @pytest.fixture
+# def no_tensorboardX_package():
+#     import sys
+#     import tensorboardX
+#     from torch.utils import tensorboard
+#     # remove tensorboardX
+#     tensorboardX_module = sys.modules['tensorboardX']
+#     del sys.modules['tensorboardX']
+#     # save and replace sys.path
+#     prev_path = list(sys.path)
+#     sys.path = [p for p in sys.path if "site-packages" not in p]
+#     yield "no_site_packages"
+#     # put everything back in place
+#     sys.path = prev_path
+#     sys.modules['tensorboardX'] = tensorboardX_module
 
 
-def test_no_tensorboardX(dirname, no_tensorboardX_package):
+# def test_no_tensorboardX(dirname, no_tensorboardX_package):
 
+#     from torch.utils.tensorboard import SummaryWriter
+#     with TensorboardLogger(log_dir=dirname) as tb_logger:
+#         assert isinstance(tb_logger.writer, SummaryWriter), type(tb_logger.writer)
+
+
+# @pytest.fixture
+# def mock_tb_module():
+#     import sys
+#     import types
+
+#     module_name = 'tensorboardX'
+#     tb_module = types.ModuleType(module_name)
+#     prev_tb_module = sys.modules[module_name]
+#     sys.modules[module_name] = tb_module
+
+#     yield tb_module
+#     sys.modules[module_name] = prev_tb_module
+
+
+# def test_init_typeerror_exception(mock_tb_module):
+
+#     def side_effect(*args, **kwargs):
+#         raise TypeError("a problem")
+
+#     mock_tb_module.SummaryWriter = Mock(name='tensorboardX.SummaryWriter', side_effect=side_effect)
+
+#     with pytest.raises(TypeError, match=r'a problem'):
+#         TensorboardLogger(log_dir=None)
+
+
+# @pytest.fixture
+# def mock_no_torch_utils_tensorboard():
+#     import sys
+#     from torch.utils import tensorboard
+#     orig_module = sys.modules['torch.utils.tensorboard']
+#     mock_module = Mock(spec=tensorboard)
+#     del mock_module.SummaryWriter
+#     sys.modules['torch.utils.tensorboard'] = mock_module
+#     yield mock_module
+#     sys.modules['torch.utils.tensorboard'] = orig_module
+
+
+# def test_no_torch_utils_tensorboard(no_tensorboardX_package, mock_no_torch_utils_tensorboard):
+
+#     with pytest.raises(RuntimeError, match=r'This contrib module requires either tensorboardX or torch'):
+#         TensorboardLogger(log_dir=None)
+
+
+def test_no_tensorboardX_package(dirname):
     from torch.utils.tensorboard import SummaryWriter
-    with TensorboardLogger(log_dir=dirname) as tb_logger:
+    with patch.dict('sys.modules', {'tensorboardX': None}):
+        tb_logger = TensorboardLogger(log_dir=dirname)
         assert isinstance(tb_logger.writer, SummaryWriter), type(tb_logger.writer)
 
 
-@pytest.fixture
-def mock_tb_module():
-    import sys
-    import types
-
-    module_name = 'tensorboardX'
-    tb_module = types.ModuleType(module_name)
-    prev_tb_module = sys.modules[module_name]
-    sys.modules[module_name] = tb_module
-
-    yield tb_module
-    sys.modules[module_name] = prev_tb_module
+def test_no_torch_utils_tensorboard_package(dirname):
+    from tensorboardX import SummaryWriter
+    with patch.dict('sys.modules', {'torch.utils.tensorboard': None}):
+        tb_logger = TensorboardLogger(log_dir=dirname)
+        assert isinstance(tb_logger.writer, SummaryWriter), type(tb_logger.writer)
 
 
-def test_init_typeerror_exception(mock_tb_module):
-
-    def side_effect(*args, **kwargs):
-        raise TypeError("a problem")
-
-    mock_tb_module.SummaryWriter = Mock(name='tensorboardX.SummaryWriter', side_effect=side_effect)
-
-    with pytest.raises(TypeError, match=r'a problem'):
-        TensorboardLogger(log_dir=None)
-
-
-@pytest.fixture
-def mock_no_torch_utils_tensorboard():
-    import sys
-    from torch.utils import tensorboard
-    orig_module = sys.modules['torch.utils.tensorboard']
-    mock_module = Mock(spec=tensorboard)
-    del mock_module.SummaryWriter
-    sys.modules['torch.utils.tensorboard'] = mock_module
-    yield mock_module
-    sys.modules['torch.utils.tensorboard'] = orig_module
-
-
-def test_no_torch_utils_tensorboard(no_tensorboardX_package, mock_no_torch_utils_tensorboard):
-
-    with pytest.raises(RuntimeError, match=r'This contrib module requires either tensorboardX or torch'):
-        TensorboardLogger(log_dir=None)
+def test_no_tensorboardX_nor_torch_utils_tensorboard():
+    with patch.dict('sys.modules', {'tensorboardX': None, 'torch.utils.tensorboard': None}):
+        with pytest.raises(RuntimeError, match=r'This contrib module requires either tensorboardX or torch'):
+            TensorboardLogger(log_dir=None)

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -561,15 +561,22 @@ def test_integration_as_context_manager(dirname):
 
 
 @pytest.fixture
-def no_site_packages():
+def no_tensorboardX_package():
     import sys
     tensorboardX_module = sys.modules['tensorboardX']
     del sys.modules['tensorboardX']
     prev_path = list(sys.path)
-    sys.path = [p for p in sys.path if "site-packages" not in p]
-    yield "no_site_packages"
+    sys.path = [p for p in sys.path if "tensorboardX" not in p]
+    yield "no_tensorboardX_package"
     sys.path = prev_path
     sys.modules['tensorboardX'] = tensorboardX_module
+
+
+def test_no_tensorboardX(dirname, no_tensorboardX_package):
+
+    with TensorboardLogger(log_dir=dirname) as tb_logger:
+        assert isinstance(tb_logger.writer, torch.utils.tensorboard.SummaryWriter), (
+            "in the absence of tensorboardX, SummaryWriter should come from torch.utils.tensorboard")
 
 
 @pytest.fixture

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -572,12 +572,6 @@ def no_site_packages():
     sys.modules['tensorboardX'] = tensorboardX_module
 
 
-def test_no_tensorboardX(dirname, no_site_packages):
-
-    with pytest.raises(RuntimeError, match=r"This contrib module requires tensorboardX to be installed"):
-        TensorboardLogger(log_dir=dirname)
-
-
 @pytest.fixture
 def mock_tb_module():
     import sys

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -563,13 +563,24 @@ def test_integration_as_context_manager(dirname):
 @pytest.fixture
 def no_tensorboardX_package():
     import sys
+    # import bare minimum for torch.utils.tensorboard to load
+    import tensorboard.summary.writer.record_writer
+    import caffe2.python
+    import past.builtins
+    # remove tensorboardX
     tensorboardX_module = sys.modules['tensorboardX']
     del sys.modules['tensorboardX']
+    # save and replace sys.path
     prev_path = list(sys.path)
-    sys.path = [p for p in sys.path if "tensorboardX" not in p]
-    yield "no_tensorboardX_package"
+    sys.path = [p for p in sys.path if "site-packages" not in p]
+    yield "no_site_packages"
+    # put everything back in place
     sys.path = prev_path
     sys.modules['tensorboardX'] = tensorboardX_module
+    # removing imported modules
+    del sys.modules['tensorboard']
+    del sys.modules['caffe2.python']
+    del sys.modules['past.builtins']
 
 
 def test_no_tensorboardX(dirname, no_tensorboardX_package):

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -574,9 +574,9 @@ def no_tensorboardX_package():
 
 def test_no_tensorboardX(dirname, no_tensorboardX_package):
 
+    from torch.utils.tensorboard import SummaryWriter
     with TensorboardLogger(log_dir=dirname) as tb_logger:
-        assert isinstance(tb_logger.writer, torch.utils.tensorboard.SummaryWriter), (
-            "in the absence of tensorboardX, SummaryWriter should come from torch.utils.tensorboard")
+        assert isinstance(tb_logger.writer, SummaryWriter), type(tb_logger.writer)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #553 

Description: If TensorboardX is not present, then fall back on importing PyTorch's
new SummaryWriter. 

Check list:
* [x] New tests are added (no new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [X] Documentation is updated (if required)
