### PR TITLE
Proposal - Support of periodic event handler execution

### DIFF
--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -579,7 +579,7 @@ def test_terminate_epoch_stops_mid_epoch():
     state = engine.run(data=[None] * num_iterations_per_epoch, max_epochs=max_epochs)
     # completes the iteration but doesn't increment counter (this happens just before a new iteration starts)
     assert state.iteration == num_iterations_per_epoch * (max_epochs - 1) + \
-           iteration_to_stop % num_iterations_per_epoch
+        iteration_to_stop % num_iterations_per_epoch
 
 
 def _create_mock_data_loader(epochs, batches_per_epoch):

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -106,18 +106,47 @@ def test_add_event_handler():
 
     def handle_iteration_started(engine, counter):
         counter.count += 1
+
     engine.add_event_handler(Events.STARTED, handle_iteration_started, started_counter)
 
     completed_counter = Counter()
 
     def handle_iteration_completed(engine, counter):
         counter.count += 1
+
     engine.add_event_handler(Events.COMPLETED, handle_iteration_completed, completed_counter)
 
     engine.run(15)
 
     assert started_counter.count == 15
     assert completed_counter.count == 15
+
+
+def test_add_event_handler_with_interval():
+    engine = Engine(process_func)
+
+    class Counter(object):
+        def __init__(self, count=0):
+            self.count = count
+
+    started_counter = Counter()
+
+    def handle_iteration_started(engine, counter):
+        counter.count += 1
+
+    engine.add_event_handler(Events.EPOCH_STARTED, handle_iteration_started, started_counter, interval=3)
+
+    completed_counter = Counter()
+
+    def handle_iteration_completed(engine, counter):
+        counter.count += 1
+
+    engine.add_event_handler(Events.EPOCH_COMPLETED, handle_iteration_completed, completed_counter, interval=3)
+
+    engine.run(iter(range(15)), max_epochs=15)
+
+    assert started_counter.count == 5
+    assert completed_counter.count == 5
 
 
 def test_adding_multiple_event_handlers():
@@ -132,7 +161,6 @@ def test_adding_multiple_event_handlers():
 
 
 def test_event_removable_handle():
-
     # Removable handle removes event from engine.
     engine = DummyEngine()
     handler = MagicMock()
@@ -551,7 +579,7 @@ def test_terminate_epoch_stops_mid_epoch():
     state = engine.run(data=[None] * num_iterations_per_epoch, max_epochs=max_epochs)
     # completes the iteration but doesn't increment counter (this happens just before a new iteration starts)
     assert state.iteration == num_iterations_per_epoch * (max_epochs - 1) + \
-        iteration_to_stop % num_iterations_per_epoch
+           iteration_to_stop % num_iterations_per_epoch
 
 
 def _create_mock_data_loader(epochs, batches_per_epoch):
@@ -796,7 +824,6 @@ def test_create_supervised_with_metrics():
 
 
 def test_reset_should_terminate():
-
     def update_fn(engine, batch):
         pass
 


### PR DESCRIPTION
Fixes nothing -> proposal

Description:
I want to propose and discuss an enhancement to the `ignite.engine.Engine` class to support intervalled event handler execution. I am commonly facing the need to execute event handlers not every event but every *n-th* event, e.g. when
- the model is large and you want to log the model every n-th epoch or n-th iteration to keep log files smaller
- you are working on a remote machine and want to sync your logs every n-th epoch
- ....

The current solution is to wrap the handler into an intervalled executed handler with something like this (not tested):
```python
def handler_interval_wrapper(handler, interval=1):
    def _intervalled_handler(engine, *args, **kwargs):
        if (engine.State.epoch-1) % interval == 0:
            handler(engine,*args,**kwargs)
    return _intervalled_handler
```

Another solution is to use `ignite.contrib.handlers.custom_events.CustomPeriodicEvent` which requires much more code to achieve the same behaviour and requires code changes as changing the period/interval changes the event name. 



To make things easier, I think that `add_event_handler` can be enhanced to accept a keyword argument (e.g. named `interval`), that is stored in `Engine._event_handlers` and is used in `Engine._fire_event`. 
* This enables to add custom defined execution intervals to every event handler and is backward compatible except that the keyword argument `interval` is reserved now. 
* For custom events, it requires to register events and provide the `event_to_attr` dict. If not, fallback solution is to ignore `interval` and execute the handler every time the event occurs.

**Comparison of using `CustomPeriodicEvent` and proposed intervalled/periodic event handler execution:**
*Periodic Events with `CustomPeriodicEvent` (Example from docs):*
```python
trainer = ignite.engine.Engine(process_fun)

cpe1 = CustomPeriodicEvent(n_iterations=1000)
cpe1.attach(trainer)

# Let's define an event every 10 epochs
cpe2 = CustomPeriodicEvent(n_epochs=10)
cpe2.attach(trainer)

@trainer.on(cpe1.Events.ITERATIONS_1000_COMPLETED)
def on_every_1000_iterations(engine):
    # run a computation after 1000 iterations
    # ...
    print(engine.state.iterations_1000)

@trainer.on(cpe2.Events.EPOCHS_10_STARTED)
def on_every_10_epochs(engine):
    # run a computation every 10 epochs
    # ...
    print(engine.state.epochs_10)
```

*Intervalled/Periodic event handler execution with proposed feature using decorators:*
```python
trainer = ignite.engine.Engine(process_fun)

@trainer.on(Events.ITERATION_COMPLETED, interval=1000)
def on_every_1000_iterations(engine):
    # run a computation after 1000 iterations
    # ...
    print(engine.state.iteration)

@trainer.on(Events.EPOCH_STARTED, interval=10)
def on_every_10_epochs(engine):
    # run a computation every 10 epochs
    # ...
    print(engine.state.epoch)
```
or using `engine.add_event_handler` instead of decorators:

```python
trainer = ignite.engine.Engine(process_fun)

def on_every_1000_iterations(engine):
    # run a computation after 1000 iterations
    # ...
    print(engine.state.iteration)

trainer.add_event_handler(Events.ITERATION_COMPLETED, on_every_1000_iterations, interval=1000)

def on_every_10_epochs(engine):
    # run a computation every 10 epochs
    # ...
    print(engine.state.epoch)

trainer.add_event_handler(Events.EPOCH_STARTED, on_every_10_epochs, interval=10)
```
The keyword `interval` equals the argument `n_iterations` from `CustomPeriodicEvent` in case of iteration events and equals `n_epochs` in case of epoch events. Perhaps `perod`, `period_length` or `exec_interval` is a better argument name than `interval`.


@vfdev-5  What do you think about this? I created a PR for better discussion and I wanted to see, if this feature can be implemented with little changes to `Engine`. 
I also added a first test, to see if it works in general. But the PR isn't complete. 

~~At the moment, I have problems to run all tests locally without errors to investigate side-effects but `tests/ignite/engine/test_engine.py` passes.~~ Tests are all passing.


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
