### PR TITLE
Handle mlflow exceptions

### DIFF
--- a/ignite/contrib/handlers/mlflow_logger.py
+++ b/ignite/contrib/handlers/mlflow_logger.py
@@ -216,9 +216,14 @@ class MLflowLogger(BaseLogger):
     def __getattr__(self, attr):
 
         import mlflow
+        from mlflow.exceptions import MlflowException
 
         def wrapper(*args, **kwargs):
-            return getattr(mlflow, attr)(*args, **kwargs)
+            try:
+                return getattr(mlflow, attr)(*args, **kwargs)
+            except MlflowException as e:
+                warnings.warn(e.message)
+
         return wrapper
 
     def close(self):

--- a/tests/ignite/contrib/handlers/test_mlflow_logger.py
+++ b/tests/ignite/contrib/handlers/test_mlflow_logger.py
@@ -244,6 +244,15 @@ def test_integration_as_context_manager(dirname):
         trainer.run(data, max_epochs=n_epochs)
 
 
+def test_mlflow_exceptions_handling(dirname):
+
+    with MLflowLogger(os.path.join(dirname, "mlruns")) as mlflow_logger:
+        with pytest.warns(UserWarning, match=r"Invalid metric name"):
+            mlflow_logger.log_metrics({
+                "metric:0 in %": 123.0
+            })
+
+
 @pytest.fixture
 def no_site_packages():
     import sys


### PR DESCRIPTION
Description:
mlflow throws an exception if metric/param name is not conformal to their conditions. For example, 
```
Invalid metric name: 'training gpu:0 mem(%)'. Names may only contain alphanumerics,underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/).
```

In this PR, it is proposed to catch `MlflowException` and simply warn about this.

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
