### PR TITLE
Mlflow exceptions

### DIFF
--- a/tests/ignite/contrib/handlers/test_mlflow_logger.py
+++ b/tests/ignite/contrib/handlers/test_mlflow_logger.py
@@ -206,16 +206,32 @@ def test_integration(dirname):
 
     mlflow_logger = MLflowLogger(tracking_uri=os.path.join(dirname, "mlruns"))
 
+    true_values = []
+
     def dummy_handler(engine, logger, event_name):
         global_step = engine.state.get_event_attrib_value(event_name)
-        logger.log_metrics({"{}".format("test_value"): global_step}, step=global_step)
+        v = global_step * 0.1
+        true_values.append(v)
+        logger.log_metrics({"{}".format("test_value"): v}, step=global_step)
 
     mlflow_logger.attach(trainer,
                          log_handler=dummy_handler,
                          event_name=Events.EPOCH_COMPLETED)
 
+    import mlflow
+
+    active_run = mlflow.active_run()
+
     trainer.run(data, max_epochs=n_epochs)
     mlflow_logger.close()
+
+    from mlflow.tracking import MlflowClient
+
+    client = MlflowClient(tracking_uri=os.path.join(dirname, "mlruns"))
+    stored_values = client.get_metric_history(active_run.info.run_id, "test_value")
+
+    for t, s in zip(true_values, stored_values):
+        assert t == s.value
 
 
 def test_integration_as_context_manager(dirname):
@@ -229,28 +245,59 @@ def test_integration_as_context_manager(dirname):
     def update_fn(engine, batch):
         return next(losses_iter)
 
+    true_values = []
+
     with MLflowLogger(os.path.join(dirname, "mlruns")) as mlflow_logger:
 
         trainer = Engine(update_fn)
 
         def dummy_handler(engine, logger, event_name):
             global_step = engine.state.get_event_attrib_value(event_name)
-            logger.log_metrics({"{}".format("test_value"): global_step}, step=global_step)
+            v = global_step * 0.1
+            true_values.append(v)
+            logger.log_metrics({"{}".format("test_value"): v}, step=global_step)
 
         mlflow_logger.attach(trainer,
                              log_handler=dummy_handler,
                              event_name=Events.EPOCH_COMPLETED)
 
+        import mlflow
+        active_run = mlflow.active_run()
+
         trainer.run(data, max_epochs=n_epochs)
+
+    from mlflow.tracking import MlflowClient
+
+    client = MlflowClient(tracking_uri=os.path.join(dirname, "mlruns"))
+    stored_values = client.get_metric_history(active_run.info.run_id, "test_value")
+
+    for t, s in zip(true_values, stored_values):
+        assert t == s.value
 
 
 def test_mlflow_exceptions_handling(dirname):
-
+    true_values = [123.0, 23.4, 333.4]
     with MLflowLogger(os.path.join(dirname, "mlruns")) as mlflow_logger:
+
+        import mlflow
+        active_run = mlflow.active_run()
+
         with pytest.warns(UserWarning, match=r"Invalid metric name"):
             mlflow_logger.log_metrics({
                 "metric:0 in %": 123.0
             })
+        for v in true_values:
+            mlflow_logger.log_metrics({
+                "metric 0": v
+            })
+
+    from mlflow.tracking import MlflowClient
+
+    client = MlflowClient(tracking_uri=os.path.join(dirname, "mlruns"))
+    stored_values = client.get_metric_history(active_run.info.run_id, "metric 0")
+
+    for t, s in zip(true_values, stored_values):
+        assert t == s.value
 
 
 @pytest.fixture


### PR DESCRIPTION
Description: if mlflow encounters a non-valid metric's name it raises an exception. In #628 we catched the exception and warns the user about the problem. However in this case batch of metric values with valid and non-valid names are discarded. In this PR, idea is to remove non-valid metric names and log only valid names.


Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
