### PR TITLE
Compute IoU, Precision, Recall based on CM on CPU

### DIFF
--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -136,8 +136,8 @@ def IoU(cm, ignore_index=None):
         if not (isinstance(ignore_index, numbers.Integral) and 0 <= ignore_index < cm.num_classes):
             raise ValueError("ignore_index should be non-negative integer, but given {}".format(ignore_index))
 
-    # Increase floating point precision
-    cm = cm.type(torch.float64)
+    # Increase floating point precision and pass to CPU
+    cm = cm.type(torch.DoubleTensor)
     iou = cm.diag() / (cm.sum(dim=1) + cm.sum(dim=0) - cm.diag() + 1e-15)
     if ignore_index is not None:
 
@@ -190,8 +190,8 @@ def cmAccuracy(cm):
     Returns:
         MetricsLambda
     """
-    # Increase floating point precision
-    cm = cm.type(torch.float64)
+    # Increase floating point precision and pass to CPU
+    cm = cm.type(torch.DoubleTensor)
     return cm.diag().sum() / (cm.sum() + 1e-15)
 
 
@@ -205,8 +205,8 @@ def cmPrecision(cm, average=True):
         MetricsLambda
     """
 
-    # Increase floating point precision
-    cm = cm.type(torch.float64)
+    # Increase floating point precision and pass to CPU
+    cm = cm.type(torch.DoubleTensor)
     precision = cm.diag() / (cm.sum(dim=0) + 1e-15)
     if average:
         return precision.mean()
@@ -223,8 +223,8 @@ def cmRecall(cm, average=True):
         MetricsLambda
     """
 
-    # Increase floating point precision
-    cm = cm.type(torch.float64)
+    # Increase floating point precision and pass to CPU
+    cm = cm.type(torch.DoubleTensor)
     recall = cm.diag() / (cm.sum(dim=1) + 1e-15)
     if average:
         return recall.mean()


### PR DESCRIPTION
Description: Minor fix to compute IoU, Precision, Recall based on Confusion Matrix on CPU instead of GPU


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
