### PR TITLE
Relax every > 1 condition, accept every=1 to disable filtering

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -51,13 +51,16 @@ class CallableEvents(object):
         if (event_filter is not None) and not callable(event_filter):
             raise TypeError("Argument event_filter should be a callable")
 
-        if (every is not None) and not (isinstance(every, numbers.Integral) and every > 1):
-            raise ValueError("Argument every should be integer and greater than one")
+        if (every is not None) and not (isinstance(every, numbers.Integral) and every > 0):
+            raise ValueError("Argument every should be integer and greater than zero")
 
         if (once is not None) and not (isinstance(once, numbers.Integral) and once > 0):
             raise ValueError("Argument every should be integer and positive")
 
         if every is not None:
+            if every == 1:
+                # Just return the event itself
+                return self
             event_filter = CallableEvents.every_event_filter(every)
 
         if once is not None:

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -361,7 +361,7 @@ def test_callable_events_with_wrong_inputs():
     with pytest.raises(TypeError, match=r"Argument event_filter should be a callable"):
         Events.ITERATION_STARTED(event_filter="123")
 
-    with pytest.raises(ValueError, match=r"Argument every should be integer and greater than one"):
+    with pytest.raises(ValueError, match=r"Argument every should be integer and greater than zero"):
         Events.ITERATION_STARTED(every=-1)
 
     with pytest.raises(ValueError, match=r"but will be called with"):
@@ -407,6 +407,12 @@ def test_callable_events():
         assert id(e1) != id(e2)
 
     _attach(Events.ITERATION_STARTED(every=10), Events.ITERATION_COMPLETED(every=10))
+
+
+def test_callable_events_every_eq_one():
+    e = Events.ITERATION_STARTED(every=1)
+    assert not isinstance(e, EventWithFilter)
+    assert isinstance(e, Events)
 
 
 def test_every_event_filter_with_engine():


### PR DESCRIPTION
Description: Relax every > 1 condition, accept every=1 to disable filtering

This can be helpful to have unique code base for cases like
```python
@trainer.on(Events.ITERATION_STARTED(every=every))
def some_handler(_):
    pass
```
with every = 1 and every > 1.


Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
