### PR TITLE
Improved accumulation metrics

### DIFF
--- a/ignite/metrics/accumulation.py
+++ b/ignite/metrics/accumulation.py
@@ -86,7 +86,10 @@ class Average(VariableAccumulation):
 
         - `+1` if input is a number
         - `+1` if input is a 1D `torch.Tensor`
-        - `+batch_size` if input is a ND `torch.Tensor`. Batch size is the first dimension (`shape[0]`).
+        - `+batch_size` if input is an ND `torch.Tensor`. Batch size is the first dimension (`shape[0]`).
+
+        For input `x` being an ND `torch.Tensor` with N > 1, the first dimension is seen as the number of samples and
+        is summed up and added to the accumulator: `accumulator += x.sum(dim=0)`
 
     Examples:
 
@@ -113,6 +116,8 @@ class Average(VariableAccumulation):
     def __init__(self, output_transform=lambda x: x, device=None):
 
         def _mean_op(a, x):
+            if isinstance(x, torch.Tensor) and x.ndim > 1:
+                x = x.sum(dim=0)
             return a + x
 
         super(Average, self).__init__(op=_mean_op, output_transform=output_transform, device=device)
@@ -140,6 +145,9 @@ class GeometricAverage(VariableAccumulation):
         - `+1` if input is a 1D `torch.Tensor`
         - `+batch_size` if input is a ND `torch.Tensor`. Batch size is the first dimension (`shape[0]`).
 
+        For input `x` being an ND `torch.Tensor` with N > 1, the first dimension is seen as the number of samples and
+        is aggregated and added to the accumulator: `accumulator *= prod(x, dim=0)`
+
     Args:
         output_transform (callable, optional): a callable that is used to transform the
             :class:`~ignite.engine.Engine`'s `process_function`'s output into the
@@ -155,7 +163,10 @@ class GeometricAverage(VariableAccumulation):
         def _geom_op(a, x):
             if not isinstance(x, torch.Tensor):
                 x = torch.tensor(x)
-            return a + torch.log(x)
+            x = torch.log(x)
+            if x.ndim > 1:
+                x = x.sum(dim=0)
+            return a + x
 
         super(GeometricAverage, self).__init__(op=_geom_op, output_transform=output_transform, device=device)
 

--- a/tests/ignite/metrics/test_accumulation.py
+++ b/tests/ignite/metrics/test_accumulation.py
@@ -47,6 +47,16 @@ def test_variable_accumulation_mean_variable():
     assert a.numpy() == pytest.approx(y_true.sum(dim=0).numpy())
     assert n == len(y_true)
 
+    mean_var = VariableAccumulation(lambda a, x: a + x.sum(dim=0))
+    # iterate by batch of 16 samples
+    y_true = torch.rand(8, 16, 10)
+    for y in y_true:
+        mean_var.update(y)
+
+    a, n = mean_var.compute()
+    assert a.numpy() == pytest.approx(y_true.reshape(-1, 10).sum(dim=0).numpy())
+    assert n == y_true.shape[0] * y_true.shape[1]
+
 
 def test_average():
 

--- a/tests/ignite/metrics/test_accumulation.py
+++ b/tests/ignite/metrics/test_accumulation.py
@@ -81,6 +81,14 @@ def test_average():
     m = mean_var.compute()
     assert m.numpy() == pytest.approx(y_true.mean(dim=0).numpy())
 
+    mean_var = Average()
+    y_true = torch.rand(8, 16, 10) + torch.randint(0, 10, size=(8, 16, 10)).float()
+    for y in y_true:
+        mean_var.update(y)
+
+    m = mean_var.compute()
+    assert m.numpy() == pytest.approx(y_true.reshape(-1, 10).mean(dim=0).numpy())
+
 
 def _geom_mean(t):
     np_t = t.numpy()
@@ -109,6 +117,14 @@ def test_geom_average():
 
     m = mean_var.compute()
     np.testing.assert_almost_equal(m.numpy(), _geom_mean(y_true), decimal=5)
+
+    mean_var = GeometricAverage()
+    y_true = torch.rand(8, 16, 10) + torch.randint(0, 10, size=(8, 16, 10)).float()
+    for y in y_true:
+        mean_var.update(y)
+
+    m = mean_var.compute()
+    np.testing.assert_almost_equal(m.numpy(), _geom_mean(y_true.reshape(-1, 10)), decimal=5)
 
 
 def test_integration():


### PR DESCRIPTION
Fixes bad behaviour of accumulation metrics if input tensor is given as a batch.

More precisely, make the following case work as expected:

```python
    mean_var = Average()
    # provides 8 batchs of 16 samples of vectors of size 10.
    y_true = torch.rand(8, 16, 10) + torch.randint(0, 10, size=(8, 16, 10)).float()
    for y in y_true:
        mean_var.update(y)

    m = mean_var.compute()
    assert m.numpy() == pytest.approx(y_true.reshape(-1, 10).mean(dim=0).numpy())
```

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
