### PR TITLE
Early stopping min delta

### DIFF
--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -10,7 +10,7 @@ class EarlyStopping(object):
         patience (int):
             Number of events to wait if no improvement and then stop the training.
         min_delta (float):
-            Minimum increase in the monitored quantity to qualify as an improvement,
+            Minimum increase in the score to qualify as an improvement,
             i.e. an increase of less than min_delta, will count as no improvement.
         score_function (callable):
             It should be a function taking a single argument, an :class:`~ignite.engine.Engine` object,

--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -62,7 +62,7 @@ class EarlyStopping(object):
 
         if self.best_score is None:
             self.best_score = score
-        elif score - self.best_score <= self.min_delta:
+        elif score <= self.best_score + self.min_delta:
             if score > self.best_score:
                 self.best_score = score
             self.counter += 1

--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -10,7 +10,7 @@ class EarlyStopping(object):
         patience (int):
             Number of events to wait if no improvement and then stop the training.
         min_delta (float):
-            Minimum increase in the score to qualify as an improvement,
+            Minimum increase in the score after one event to qualify as an improvement,
             i.e. an increase of less than min_delta, will count as no improvement.
         score_function (callable):
             It should be a function taking a single argument, an :class:`~ignite.engine.Engine` object,

--- a/tests/ignite/handlers/test_early_stopping.py
+++ b/tests/ignite/handlers/test_early_stopping.py
@@ -47,28 +47,29 @@ def test_simple_early_stopping():
     assert trainer.should_terminate
 
 
-def test_early_stopping_based_on_delta():
+def test_early_stopping_on_delta():
 
-    scores = iter([1.0, 2.0, 2.01, 2.02])
-
-    def score_function(engine):
-        return next(scores)
+    scores = iter([1.0, 2.0, 2.01, 3.0, 3.01, 3.02])
 
     def update_fn(engine, batch):
         pass
 
     trainer = Engine(update_fn)
 
-    h = EarlyStopping(patience=2, min_delta=0.1, score_function=score_function, trainer=trainer)
-    # Call 3 times and check if stopped
+    h = EarlyStopping(patience=2, min_delta=0.1, score_function=lambda _: next(scores), trainer=trainer)
+
     assert not trainer.should_terminate
-    h(None)
+    h(None)  # counter == 0
     assert not trainer.should_terminate
-    h(None)
+    h(None)  # counter == 0
     assert not trainer.should_terminate
-    h(None)
+    h(None)  # counter == 1
     assert not trainer.should_terminate
-    h(None)
+    h(None)  # counter == 0
+    assert not trainer.should_terminate
+    h(None)  # counter == 1
+    assert not trainer.should_terminate
+    h(None)  # counter == 2
     assert trainer.should_terminate
 
 

--- a/tests/ignite/handlers/test_early_stopping.py
+++ b/tests/ignite/handlers/test_early_stopping.py
@@ -71,7 +71,7 @@ def test_early_stopping_on_delta():
     assert trainer.should_terminate
 
 
-def test_early_stopping_on_single_event_delta():
+def test_early_stopping_on_last_event_delta():
 
     scores = iter([0.0, 0.3, 0.6])
 

--- a/tests/ignite/handlers/test_early_stopping.py
+++ b/tests/ignite/handlers/test_early_stopping.py
@@ -271,20 +271,20 @@ def _test_distrib_integration_engine_early_stopping(device):
     n_iters = 20
 
     y_preds = [
-                  torch.randint(0, 2, size=(n_iters, ws)).to(device)
-              ] + [
-                  torch.ones(n_iters, ws).to(device)
-              ] + [
-                  torch.randint(0, 2, size=(n_iters, ws)).to(device) for _ in range(n_epochs - 2)
-              ]
+        torch.randint(0, 2, size=(n_iters, ws)).to(device)
+    ] + [
+        torch.ones(n_iters, ws).to(device)
+    ] + [
+        torch.randint(0, 2, size=(n_iters, ws)).to(device) for _ in range(n_epochs - 2)
+    ]
 
     y_true = [
-                 torch.randint(0, 2, size=(n_iters, ws)).to(device)
-             ] + [
-                 torch.ones(n_iters, ws).to(device)
-             ] + [
-                 torch.randint(0, 2, size=(n_iters, ws)).to(device) for _ in range(n_epochs - 2)
-             ]
+        torch.randint(0, 2, size=(n_iters, ws)).to(device)
+    ] + [
+        torch.ones(n_iters, ws).to(device)
+    ] + [
+        torch.randint(0, 2, size=(n_iters, ws)).to(device) for _ in range(n_epochs - 2)
+    ]
 
     def update(engine, _):
         e = trainer.state.epoch - 1

--- a/tests/ignite/handlers/test_early_stopping.py
+++ b/tests/ignite/handlers/test_early_stopping.py
@@ -47,6 +47,31 @@ def test_simple_early_stopping():
     assert trainer.should_terminate
 
 
+def test_early_stopping_based_on_delta():
+
+    scores = iter([1.0, 2.0, 2.01, 2.02])
+
+    def score_function(engine):
+        return next(scores)
+
+    def update_fn(engine, batch):
+        pass
+
+    trainer = Engine(update_fn)
+
+    h = EarlyStopping(patience=2, min_delta=0.1, score_function=score_function, trainer=trainer)
+    # Call 3 times and check if stopped
+    assert not trainer.should_terminate
+    h(None)
+    assert not trainer.should_terminate
+    h(None)
+    assert not trainer.should_terminate
+    h(None)
+    assert not trainer.should_terminate
+    h(None)
+    assert trainer.should_terminate
+
+
 def test_simple_early_stopping_on_plateau():
 
     def score_function(engine):

--- a/tests/ignite/handlers/test_early_stopping.py
+++ b/tests/ignite/handlers/test_early_stopping.py
@@ -17,6 +17,9 @@ def test_args_validation():
     with pytest.raises(ValueError, match=r"Argument patience should be positive integer."):
         EarlyStopping(patience=-1, score_function=lambda engine: 0, trainer=trainer)
 
+    with pytest.raises(ValueError, match=r"Argument min_delta should not be a negative number."):
+        EarlyStopping(patience=2, min_delta=-0.1, score_function=lambda engine: 0, trainer=trainer)
+
     with pytest.raises(TypeError, match=r"Argument score_function should be a function."):
         EarlyStopping(patience=2, score_function=12345, trainer=trainer)
 


### PR DESCRIPTION
This PR introduces a new early stopping parameter that enables definition of minimum increase in the score to qualify as an improvement.

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)