### PR TITLE
Removed deprecated arg save_interval

### DIFF
--- a/examples/references/classification/imagenet/code/scripts/common_training.py
+++ b/examples/references/classification/imagenet/code/scripts/common_training.py
@@ -99,14 +99,12 @@ def training(config, local_rank=None, with_mlflow_logging=False, with_plx_loggin
 
     model_output_transform = getattr(config, "model_output_transform", lambda x: x)
 
-    train_evaluator = create_supervised_evaluator(
-        model, metrics=val_metrics, device=device, non_blocking=non_blocking, prepare_batch=prepare_batch,
+    evaluator_args = dict(
+        model=model, metrics=val_metrics, device=device, non_blocking=non_blocking, prepare_batch=prepare_batch,
         output_transform=lambda x, y, y_pred: (model_output_transform(y_pred), y,)
     )
-    evaluator = create_supervised_evaluator(
-        model, metrics=val_metrics, device=device, non_blocking=non_blocking, prepare_batch=prepare_batch,
-        output_transform=lambda x, y, y_pred: (model_output_transform(y_pred), y,)
-    )
+    train_evaluator = create_supervised_evaluator(**evaluator_args)
+    evaluator = create_supervised_evaluator(**evaluator_args)
 
     if dist.get_rank() == 0 and with_mlflow_logging:
         ProgressBar(persist=False, desc="Train Evaluation").attach(train_evaluator)

--- a/examples/references/segmentation/pascal_voc2012/code/scripts/common_training.py
+++ b/examples/references/segmentation/pascal_voc2012/code/scripts/common_training.py
@@ -107,14 +107,12 @@ def training(config, local_rank=None, with_mlflow_logging=False, with_plx_loggin
 
     model_output_transform = getattr(config, "model_output_transform", lambda x: x)
 
-    train_evaluator = create_supervised_evaluator(
-        model, metrics=val_metrics, device=device, non_blocking=non_blocking, prepare_batch=prepare_batch,
+    evaluator_args = dict(
+        model=model, metrics=val_metrics, device=device, non_blocking=non_blocking, prepare_batch=prepare_batch,
         output_transform=lambda x, y, y_pred: (model_output_transform(y_pred), y,)
     )
-    evaluator = create_supervised_evaluator(
-        model, metrics=val_metrics, device=device, non_blocking=non_blocking, prepare_batch=prepare_batch,
-        output_transform=lambda x, y, y_pred: (model_output_transform(y_pred), y,)
-    )
+    train_evaluator = create_supervised_evaluator(**evaluator_args)
+    evaluator = create_supervised_evaluator(**evaluator_args)
 
     if dist.get_rank() == 0 and with_mlflow_logging:
         ProgressBar(persist=False, desc="Train Evaluation").attach(train_evaluator)

--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -150,7 +150,7 @@ def setup_common_distrib_training_handlers(trainer, train_sampler,
         if to_save is not None:
             if output_path is None:
                 raise ValueError("If to_save argument is provided then output_path argument should be also defined")
-            checkpoint_handler = ModelCheckpoint(dirname=output_path, filename_prefix="checkpoint", save_interval=1)
+            checkpoint_handler = ModelCheckpoint(dirname=output_path, filename_prefix="checkpoint")
             trainer.add_event_handler(Events.ITERATION_COMPLETED(every=save_every_iters), checkpoint_handler, to_save)
 
     return trainer

--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -285,7 +285,7 @@ def get_default_score_fn(metric_name):
     return wrapper
 
 
-def save_best_model_by_val_score(output_path, evaluator, model, metric_name, n_saved=3, trainer=None):
+def save_best_model_by_val_score(output_path, evaluator, model, metric_name, n_saved=3, trainer=None, tag="val"):
     """Method adds a handler to `evaluator` to save best models based on the score (named by `metric_name`)
     provided by `evaluator`.
 
@@ -297,6 +297,7 @@ def save_best_model_by_val_score(output_path, evaluator, model, metric_name, n_s
             `evaluator.state.metrics`.
         n_saved (int, optional): number of best models to store
         trainer (Engine, optional): trainer engine to fetch the epoch when saving the best model.
+        tag (str, optional): score name prefix: `{tag}_{metric_name}`. By default, tag is "val".
 
     """
     global_step_transform = None
@@ -307,7 +308,7 @@ def save_best_model_by_val_score(output_path, evaluator, model, metric_name, n_s
                                          filename_prefix="best",
                                          n_saved=n_saved,
                                          global_step_transform=global_step_transform,
-                                         score_name="val_{}".format(metric_name.lower()),
+                                         score_name="{}_{}".format(tag, metric_name.lower()),
                                          score_function=get_default_score_fn(metric_name))
     evaluator.add_event_handler(Events.COMPLETED, best_model_handler, {'model': model, })
 


### PR DESCRIPTION
Description:
- Removed deprecated arg `save_interval=1` from `setup_common_distrib_training_handlers`
- added tests for `save_best_model_by_val_score`, `add_early_stopping_by_val_score`
- refactored evaluator's creation for imagenet/pascal voc12 examples


Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
