### PR TITLE
Add missing imports to quickstart.rst

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -11,6 +11,7 @@ Code
 .. code-block:: python
 
     from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator
+    from ignite.metrics import Accuracy, Loss
 
     model = Net()
     train_loader, val_loader = get_data_loaders(train_batch_size, val_batch_size)


### PR DESCRIPTION
Accuracy and Loss are used to create the supervised evaluator but the imports are missing.

Fixes # 

Description:
Minor change to add missing imports

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
