### PR TITLE
Handlers sorted

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -508,7 +508,7 @@ class Engine(object):
             raise ValueError("Error adding {} '{}': "
                              "takes parameters {} but will be called with {} "
                              "({}).".format(
-                               fn, fn_description, fn_params, passed_params, exception_msg))
+                                 fn, fn_description, fn_params, passed_params, exception_msg))
 
     def on(self, event_name, priority=0, *args, **kwargs):
         """Decorator shortcut for add_event_handler.

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -508,7 +508,7 @@ class Engine(object):
             raise ValueError("Error adding {} '{}': "
                              "takes parameters {} but will be called with {} "
                              "({}).".format(
-                fn, fn_description, fn_params, passed_params, exception_msg))
+                                fn, fn_description, fn_params, passed_params, exception_msg))
 
     def on(self, event_name, priority=0, *args, **kwargs):
         """Decorator shortcut for add_event_handler.

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -306,8 +306,8 @@ class Engine(object):
     """
     def __init__(self, process_function):
         self._event_handlers = defaultdict(list)
-        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
-        self.logger.addHandler(logging.NullHandler())
+        self._logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
+        self._logger.addHandler(logging.NullHandler())
         self._process_function = process_function
         self.last_event_name = None
         self.should_terminate = False
@@ -435,14 +435,14 @@ class Engine(object):
             handler = self._handler_wrapper(handler, event_name, event_filter)
 
         if event_name not in self._allowed_events:
-            self.logger.error("attempt to add event handler to an invalid event %s.", event_name)
+            self._logger.error("attempt to add event handler to an invalid event %s.", event_name)
             raise ValueError("Event {} is not a valid event for this Engine.".format(event_name))
 
         event_args = (Exception(), ) if event_name == Events.EXCEPTION_RAISED else ()
         Engine._check_signature(self, handler, 'handler', *(event_args + args), **kwargs)
 
         self._event_handlers[event_name].append((priority, handler, args, kwargs))
-        self.logger.debug("added handler for event %s.", event_name)
+        self._logger.debug("added handler for event %s.", event_name)
 
         return RemovableEventHandle(event_name, handler, self)
 
@@ -548,7 +548,7 @@ class Engine(object):
 
         """
         if event_name in self._allowed_events:
-            self.logger.debug("firing handlers for event %s ", event_name)
+            self._logger.debug("firing handlers for event %s ", event_name)
             self.last_event_name = event_name
             for _, func, args, kwargs in self._event_handlers[event_name]:
                 kwargs.update(event_kwargs)
@@ -580,13 +580,13 @@ class Engine(object):
     def terminate(self):
         """Sends terminate signal to the engine, so that it terminates completely the run after the current iteration.
         """
-        self.logger.info("Terminate signaled. Engine will stop after current iteration is finished.")
+        self._logger.info("Terminate signaled. Engine will stop after current iteration is finished.")
         self.should_terminate = True
 
     def terminate_epoch(self):
         """Sends terminate signal to the engine, so that it terminates the current epoch after the current iteration.
         """
-        self.logger.info("Terminate current epoch is signaled. "
+        self._logger.info("Terminate current epoch is signaled. "
                          "Current epoch iteration will stop after current iteration is finished.")
         self.should_terminate_single_epoch = True
 
@@ -605,7 +605,7 @@ class Engine(object):
                     break
 
         except BaseException as e:
-            self.logger.error("Current run is terminating due to exception: %s.", str(e))
+            self._logger.error("Current run is terminating due to exception: %s.", str(e))
             self._handle_exception(e)
 
         time_taken = time.time() - start_time
@@ -649,14 +649,14 @@ class Engine(object):
         self._sort_handlers()  # sort all handlers at the beginning of a run
 
         try:
-            self.logger.info("Engine run starting with max_epochs={}.".format(max_epochs))
+            self._logger.info("Engine run starting with max_epochs={}.".format(max_epochs))
             start_time = time.time()
             self._fire_event(Events.STARTED)
             while self.state.epoch < max_epochs and not self.should_terminate:
                 self.state.epoch += 1
                 self._fire_event(Events.EPOCH_STARTED)
                 hours, mins, secs = self._run_once_on_dataset()
-                self.logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.state.epoch, hours, mins, secs)
+                self._logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.state.epoch, hours, mins, secs)
                 if self.should_terminate:
                     break
                 self._fire_event(Events.EPOCH_COMPLETED)
@@ -664,10 +664,10 @@ class Engine(object):
             self._fire_event(Events.COMPLETED)
             time_taken = time.time() - start_time
             hours, mins, secs = _to_hours_mins_secs(time_taken)
-            self.logger.info("Engine run complete. Time taken %02d:%02d:%02d" % (hours, mins, secs))
+            self._logger.info("Engine run complete. Time taken %02d:%02d:%02d" % (hours, mins, secs))
 
         except BaseException as e:
-            self.logger.error("Engine run is terminating due to exception: %s.", str(e))
+            self._logger.error("Engine run is terminating due to exception: %s.", str(e))
             self._handle_exception(e)
 
         return self.state

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -508,7 +508,7 @@ class Engine(object):
             raise ValueError("Error adding {} '{}': "
                              "takes parameters {} but will be called with {} "
                              "({}).".format(
-                                fn, fn_description, fn_params, passed_params, exception_msg))
+                               fn, fn_description, fn_params, passed_params, exception_msg))
 
     def on(self, event_name, priority=0, *args, **kwargs):
         """Decorator shortcut for add_event_handler.

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -124,12 +124,13 @@ class Metric(with_metaclass(ABCMeta, object)):
             result = result.item()
         engine.state.metrics[name] = result
 
-    def attach(self, engine, name):
-        engine.add_event_handler(Events.EPOCH_COMPLETED, self.completed, name)
+    def attach(self, engine, name, priority=1):
+        # metric is prioritized higher by default
+        engine.add_event_handler(Events.EPOCH_COMPLETED, self.completed, priority, name)
         if not engine.has_event_handler(self.started, Events.EPOCH_STARTED):
-            engine.add_event_handler(Events.EPOCH_STARTED, self.started)
+            engine.add_event_handler(Events.EPOCH_STARTED, self.started, priority)
         if not engine.has_event_handler(self.iteration_completed, Events.ITERATION_COMPLETED):
-            engine.add_event_handler(Events.ITERATION_COMPLETED, self.iteration_completed)
+            engine.add_event_handler(Events.ITERATION_COMPLETED, self.iteration_completed, priority)
 
     def __add__(self, other):
         from ignite.metrics import MetricsLambda

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -1175,3 +1175,22 @@ def test_state_get_event_attrib_value():
     assert state.get_event_attrib_value(e) == state.epoch
     e = Events.EPOCH_COMPLETED(once=5)
     assert state.get_event_attrib_value(e) == state.epoch
+
+
+def test_handlers_sorted():
+    engine = DummyEngine()
+
+    @engine.on(Events.ITERATION_COMPLETED, 2)
+    def prio2(_): pass
+
+    @engine.on(Events.ITERATION_COMPLETED, 3)
+    def prio3(_): pass
+
+    @engine.on(Events.ITERATION_COMPLETED)
+    def prio0(_): pass
+
+    metric = MeanSquaredError()
+    metric.attach(engine, 'mock')
+    engine._sort_handlers()
+    prio_list = list(zip(*engine._event_handlers[Events.ITERATION_COMPLETED]))[0]
+    assert np.all(np.diff(prio_list) <= 0)


### PR DESCRIPTION
Fixes #706 

Description:
Add ability to control handlers' execution order (by default, all handlers related to metrics are fired before other, manually added, handlers

Check list: _All Done_