### PR TITLE
Include Optuna integration badge in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ Ignite
 .. image:: https://img.shields.io/badge/dynamic/json.svg?label=docs&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fpytorch-ignite%2Fjson&query=%24.info.version&colorB=brightgreen&prefix=v
     :target: https://pytorch.org/ignite/index.html
     
+.. image:: https://img.shields.io/badge/Optuna-integrated-blue
+    :target: https://optuna.org
+    
 Ignite is a high-level library to help with training neural networks in PyTorch.
 
 - ignite helps you write compact but full-featured training loops in a few lines of code


### PR DESCRIPTION
Hi!

Optuna (optuna.org) is a new hyperparameter optimization library, and we’ve written an Optuna integration module for PyTorch Ignite to make it easy to search for good hyperparameter settings and prune unpromising trials. We’re looking for ways to let PyTorch Ignite users know this is available and thought a badge to show Optuna integration is available would be helpful.

Here’s our example of using the pruning integration with PyTorch Ignite: https://github.com/optuna/optuna/blob/master/examples/pytorch_ignite_simple.py

If there are other ways you would recommend reaching out to PyTorch Ignite users to let them know about Optuna, please let us know.

Thanks!

Check list:
* [-] New tests are added (if a new feature is added)
* [*] New doc strings: description and/or example code are in RST format
* [-] Documentation is updated (if required)
