### PR TITLE
Remove python2 specific and unnecessary imports

### DIFF
--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from ignite.metrics import Metric
 from ignite.metrics.metric import sync_all_reduce, reinit__is_reduced
 from ignite.exceptions import NotComputableError

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from ignite.exceptions import NotComputableError
 from ignite.metrics import Metric
 from ignite.metrics.metric import sync_all_reduce, reinit__is_reduced

--- a/ignite/metrics/mean_absolute_error.py
+++ b/ignite/metrics/mean_absolute_error.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import torch
 
 from ignite.exceptions import NotComputableError

--- a/ignite/metrics/mean_pairwise_distance.py
+++ b/ignite/metrics/mean_pairwise_distance.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import torch
 from torch.nn.functional import pairwise_distance
 

--- a/ignite/metrics/mean_squared_error.py
+++ b/ignite/metrics/mean_squared_error.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import torch
 
 from ignite.exceptions import NotComputableError

--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import warnings
 
 import torch

--- a/ignite/metrics/recall.py
+++ b/ignite/metrics/recall.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import torch
 
 from ignite.metrics.precision import _BasePrecisionRecall

--- a/ignite/metrics/root_mean_squared_error.py
+++ b/ignite/metrics/root_mean_squared_error.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import math
 
 from ignite.metrics.mean_squared_error import MeanSquaredError

--- a/ignite/metrics/top_k_categorical_accuracy.py
+++ b/ignite/metrics/top_k_categorical_accuracy.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import torch
 
 from ignite.metrics.metric import Metric

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -1,4 +1,3 @@
-import os
 import collections.abc as collections
 import logging
 


### PR DESCRIPTION
Fixes #718 

Description:
Removes imports which were necessary to support python 2.7

Check list:
* [x] New tests are added (if a new feature is added)[Not Necessary]
* [x] New doc strings: description and/or example code are in RST format [Not Necessary]
* [x] Documentation is updated (if required) [Not Necessary]
