### PR TITLE
Fixes #735, Replaced RuntimeWarning with EpochMetricWarning

### DIFF
--- a/ignite/metrics/epoch_metric.py
+++ b/ignite/metrics/epoch_metric.py
@@ -80,7 +80,11 @@ class EpochMetric(Metric):
                 self.compute_fn(self._predictions, self._targets)
             except Exception as e:
                 warnings.warn("Probably, there can be a problem with `compute_fn`:\n {}.".format(e),
-                              RuntimeWarning)
+                              EpochMetricWarning)
 
     def compute(self):
         return self.compute_fn(self._predictions, self._targets)
+
+
+class EpochMetricWarning(UserWarning):
+    pass

--- a/tests/ignite/metrics/test_epoch_metric.py
+++ b/tests/ignite/metrics/test_epoch_metric.py
@@ -2,6 +2,7 @@ import os
 import torch
 
 from ignite.metrics import EpochMetric
+from ignite.metrics.epoch_metric import EpochMetricWarning
 
 import pytest
 
@@ -113,7 +114,7 @@ def test_bad_compute_fn():
 
     em.reset()
     output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 4), dtype=torch.long))
-    with pytest.warns(RuntimeWarning):
+    with pytest.warns(EpochMetricWarning, match=r"Probably, there can be a problem with `compute_fn`"):
         em.update(output1)
 
 


### PR DESCRIPTION

Fixes #735  

Description: following the discussion in #735 
Replaced RuntimeWarning with EpochMetricWarning
- if compute_fn raises an error on batch data
such that it can be filtered if compute_fn fails only on batch data and not on complete data.

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)


cc @wangyirui 