### PR TITLE
Remove all occurences of `from __future__ import print_function`

### DIFF
--- a/examples/contrib/mnist/mnist_with_tensorboard_logger.py
+++ b/examples/contrib/mnist/mnist_with_tensorboard_logger.py
@@ -17,8 +17,6 @@
     python mnist_with_tensorboard_logger.py --log_dir=/tmp/tensorboard_logs
     ```
 """
-from __future__ import print_function
-
 import sys
 from argparse import ArgumentParser
 import logging

--- a/examples/contrib/mnist/mnist_with_visdom_logger.py
+++ b/examples/contrib/mnist/mnist_with_visdom_logger.py
@@ -17,8 +17,6 @@
     python mnist_with_visdom_logger.py
     ```
 """
-from __future__ import print_function
-
 from argparse import ArgumentParser
 import logging
 

--- a/examples/fast_neural_style/neural_style.py
+++ b/examples/fast_neural_style/neural_style.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-from __future__ import print_function, division
-
 import argparse
 import os
 import sys

--- a/examples/gan/dcgan.py
+++ b/examples/gan/dcgan.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import os
 import random

--- a/examples/mnist/mnist_with_tensorboardx.py
+++ b/examples/mnist/mnist_with_tensorboardx.py
@@ -14,7 +14,6 @@
     ```
 """
 
-from __future__ import print_function
 from argparse import ArgumentParser
 import torch
 from torch.utils.data import DataLoader

--- a/examples/mnist/mnist_with_visdom.py
+++ b/examples/mnist/mnist_with_visdom.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from argparse import ArgumentParser
 
 import torch


### PR DESCRIPTION
Fixes #732 

Description:
Removes all occurrences of `from __future__ import print_function`, which were necessary for Python 2.7 support

Check list:
* [x] New tests are added (if a new feature is added) [Not Necessary]
* [x] New doc strings: description and/or example code are in RST format [Not Necessary]
* [x] Documentation is updated (if required) [Not Necessary]
