### PR TITLE
Support namedtuple for "convert_tensor"

### DIFF
--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -52,6 +52,8 @@ def apply_to_type(input_: Union[Any, collections.Sequence,
         return input_
     elif isinstance(input_, collections.Mapping):
         return type(input_)({k: apply_to_type(sample, input_type, func) for k, sample in input_.items()})
+    elif isinstance(input_, tuple) and hasattr(input_, '_fields'):  # namedtuple
+        return type(input_)(*(apply_to_type(sample, input_type, func) for sample in input_))
     elif isinstance(input_, collections.Sequence):
         return type(input_)([apply_to_type(sample, input_type, func) for sample in input_])
     else:

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -30,14 +30,14 @@ def test_convert_tensor():
     assert isinstance(tuple_, tuple)
     assert torch.is_tensor(tuple_[0])
     assert torch.is_tensor(tuple_[1])
-    
+
     Point = namedtuple("Point", ['x', 'y'])
     x = Point(torch.tensor([0.0]), torch.tensor([0.0]))
     tuple_ = convert_tensor(x)
     assert isinstance(tuple_, Point)
     assert torch.is_tensor(tuple_[0])
     assert torch.is_tensor(tuple_[1])
-    
+
     x = {'a': torch.tensor([0.0]), 'b': torch.tensor([0.0])}
     dict_ = convert_tensor(x)
     assert isinstance(dict_, dict)

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -30,7 +30,14 @@ def test_convert_tensor():
     assert isinstance(tuple_, tuple)
     assert torch.is_tensor(tuple_[0])
     assert torch.is_tensor(tuple_[1])
-
+    
+    Point = namedtuple("Point", ['x', 'y'])
+    x = Point(torch.tensor([0.0]), torch.tensor([0.0]))
+    tuple_ = convert_tensor(x)
+    assert isinstance(tuple_, Point)
+    assert torch.is_tensor(tuple_[0])
+    assert torch.is_tensor(tuple_[1])
+    
     x = {'a': torch.tensor([0.0]), 'b': torch.tensor([0.0])}
     dict_ = convert_tensor(x)
     assert isinstance(dict_, dict)

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import torch
 
+from collections import namedtuple
 from ignite.utils import convert_tensor, to_onehot, setup_logger
 
 


### PR DESCRIPTION
convert_tensor support Map, List, but not namedtuple.

This change is similar to: https://github.com/pytorch/pytorch/blob/master/torch/utils/data/_utils/pin_memory.py#L45

Fixes # 

Description:


Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
