### PR TITLE
Checkpoint: fix returning worst model of the saved models.

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -126,8 +126,8 @@ class Checkpoint:
     Item = namedtuple("Item", ["priority", "filename"])
 
     def __init__(self, to_save: dict, save_handler: Callable, filename_prefix: str = "",
-                 score_function: Optional[Callable] = None, score_name: Optional[str] = None, n_saved: int = 1,
-                 global_step_transform: Callable = None, archived: bool = False):
+                 score_function: Optional[Callable] = None, score_name: Optional[str] = None,
+                 n_saved: Optional[int] = 1, global_step_transform: Callable = None, archived: bool = False):
 
         if not isinstance(to_save, collections.Mapping):
             raise TypeError("Argument `to_save` should be a dictionary, but given {}".format(type(to_save)))

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -161,7 +161,7 @@ class Checkpoint:
     def last_checkpoint(self) -> str:
         if len(self._saved) < 1:
             return None
-        return self._saved[0].filename
+        return self._saved[-1].filename
 
     def _check_lt_n_saved(self, or_equal=False):
         if self._n_saved is None:
@@ -404,7 +404,7 @@ class ModelCheckpoint(Checkpoint):
     def last_checkpoint(self) -> Union[str, None]:
         if len(self._saved) < 1:
             return None
-        return os.path.join(self.save_handler.dirname, self._saved[0].filename)
+        return os.path.join(self.save_handler.dirname, self._saved[-1].filename)
 
     def __call__(self, engine: Engine, to_save: Mapping) -> None:
 


### PR DESCRIPTION
Fixes # 
returning the model with the lowest priority of the saved models
Description:
The `self._saved` list is always sorted in an ascending order(ensured by sorting it each time a new element is added). Hence, returning `self._saved[0]` in `last_checkpoint` actually yields the oldest checkpoint of the saved ones, or the worst if a score function is provided. Changing the above to`self._saved[-1]` yields the expected result, i.e, the model with the highest priority.

Check list:
* [x] New tests are added (if a new feature is added)
* [X] New doc strings: description and/or example code are in RST format
* [X ] Documentation is updated (if required)
