### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,42 @@
 language: python
 
-python:
-  - "3.7"
+matrix:
+    include:
+        - name: "Unittests Python 3.5 Stable PyTorch"
+          python: 3.5
+          dist: xenial
+          env:
+              - PYTORCH_CHANNEL="pytorch"
+              
+         - name: "Unittests Python 3.6 Stable PyTorch"
+          python: 3.6
+          dist: xenial
+          env:
+              - PYTORCH_CHANNEL="pytorch"    
+              
+        - name: "Unittests Python 3.7 Stable PyTorch"
+          python: 3.7
+          dist: xenial
+          env:
+              - PYTORCH_CHANNEL="pytorch"
 
-env:
-  - PYTORCH_CHANNEL=pytorch
-  - PYTORCH_CHANNEL=pytorch-nightly
+        - name: "Unittests Python 3.5 Nightly PyTorch"
+          python: 3.5
+          dist: xenial
+          env:
+              - PYTORCH_CHANNEL="pytorch-nightly"
+              
+         - name: "Unittests Python 3.6 Nightly PyTorch"
+          python: 3.6
+          dist: xenial
+          env:
+              - PYTORCH_CHANNEL="pytorch-nightly"    
+              
+        - name: "Unittests Python 3.7 Nightly PyTorch"
+          python: 3.7
+          dist: xenial
+          env:
+              - PYTORCH_CHANNEL="pytorch-nightly"
 
 stages:
   - Lint check


### PR DESCRIPTION
Adds unittests for Python 3.5 and 3.6

Currently all stages should be run 3 times: Once for Python 3.5, Python 3.6 and Python 3.7
