### PR TITLE
Fixes #770

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -236,11 +236,20 @@ class Checkpoint:
         Args:
             to_load (Mapping): a dictionary with objects, e.g. `{"model": model, "optimizer": optimizer, ...}`
             checkpoint (Mapping): a dictionary with state_dicts to load, e.g. `{"model": model_state_dict,
-                "optimizer": opt_state_dict}`
+                "optimizer": opt_state_dict}`. If `to_load` contains a single key, then checkpoint can contain directly
+                corresponding state_dict.
         """
         Checkpoint._check_objects(to_load, "load_state_dict")
         if not isinstance(checkpoint, collections.Mapping):
             raise TypeError("Argument checkpoint should be a dictionary, but given {}".format(type(checkpoint)))
+        if len(to_load) == 1:
+            # single object and checkpoint is directly a state_dict
+            key, obj = list(to_load.items())[0]
+            if key not in checkpoint:
+                obj.load_state_dict(checkpoint)
+                return
+
+        # multiple objects to load
         for k, obj in to_load.items():
             if k not in checkpoint:
                 raise ValueError("Object labeled by '{}' from `to_load` is not found in the checkpoint".format(k))

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -700,7 +700,7 @@ def test_checkpoint_load_objects():
         Checkpoint.load_objects({"a": None}, {"a": None})
 
     model = DummyModel()
-    to_load = {'model': model}
+    to_load = {'model': model, 'another_model': model}
 
     with pytest.raises(ValueError, match=r"from `to_load` is not found in the checkpoint"):
         Checkpoint.load_objects(to_load, {})
@@ -712,6 +712,52 @@ def test_checkpoint_load_objects():
     chkpt = {'model': model2.state_dict()}
     Checkpoint.load_objects(to_load, chkpt)
     assert model.state_dict() == model2.state_dict()
+
+
+def test_checkpoint_load_objects_from_saved_file(dirname):
+
+    def _get_single_obj_to_save():
+        model = DummyModel()
+        to_save = {
+            "model": model,
+        }
+        return to_save
+
+    def _get_multiple_objs_to_save():
+        model = DummyModel()
+        optim = torch.optim.SGD(model.parameters(), lr=0.001)
+        lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(optim, gamma=0.5)
+        to_save = {
+            "model": model,
+            "optimizer": optim,
+            "lr_scheduler": lr_scheduler,
+        }
+        return to_save
+
+    handler = ModelCheckpoint(dirname, _PREFIX, create_dir=False, n_saved=1)
+    trainer = Engine(lambda e, b: None)
+    trainer.state = State(epoch=0, iteration=0)
+    # case: multiple objects
+    to_save = _get_multiple_objs_to_save()
+    handler(trainer, to_save)
+    fname = handler.last_checkpoint
+    assert isinstance(fname, str)
+    assert os.path.join(dirname, _PREFIX) in fname
+    assert os.path.exists(fname)
+    loaded_objects = torch.load(fname)
+    Checkpoint.load_objects(to_save, loaded_objects)
+    os.remove(fname)
+
+    # case: single object
+    handler = ModelCheckpoint(dirname, _PREFIX, create_dir=False, n_saved=1)
+    to_save = _get_single_obj_to_save()
+    handler(trainer, to_save)
+    fname = handler.last_checkpoint
+    assert isinstance(fname, str)
+    assert os.path.join(dirname, _PREFIX) in fname
+    assert os.path.exists(fname)
+    loaded_objects = torch.load(fname)
+    Checkpoint.load_objects(to_save, loaded_objects)
 
 
 def test_disksaver_wrong_input(dirname):


### PR DESCRIPTION
Fixes #770

Description:
load_objects can load checlpoints from Checkpoint's stored checkpoints (single object case)


Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
