### PR TITLE
Remove 'module' key for parallel checkpointing

### DIFF
--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -858,4 +858,3 @@ def test_distributed_parallel_checkpoint_load(distributed_context_single_node_gl
     # not used to run cpu tests!
     local_rank = distributed_context_single_node_gloo['local_rank']
     _test_checkpoint_load(torch.nn.parallel.DistributedDataParallel)
-

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -805,10 +805,9 @@ def test_checkpoint_keys_parallel():
 
 @pytest.mark.distributed
 def test_checkpoint_keys_distributed_parallel(distributed_context_single_node_gloo):
+    # not used to run CPU tests!
     local_rank = distributed_context_single_node_gloo['local_rank']
-    _test_checkpoint_keys(torch.nn.parallel.DistributedDataParallel,
-                          device_ids=[local_rank, ],
-                          output_device=local_rank)
+    _test_checkpoint_keys(torch.nn.parallel.DistributedDataParallel)
 
 
 def _test_checkpoint_load(wrapper_cls, **kwargs):
@@ -856,8 +855,7 @@ def test_parallel_checkpoint_load():
 
 @pytest.mark.distributed
 def test_distributed_parallel_checkpoint_load(distributed_context_single_node_gloo):
+    # not used to run cpu tests!
     local_rank = distributed_context_single_node_gloo['local_rank']
-    _test_checkpoint_load(torch.nn.parallel.DistributedDataParallel,
-                          device_ids=[local_rank, ],
-                          output_device=local_rank)
+    _test_checkpoint_load(torch.nn.parallel.DistributedDataParallel)
 


### PR DESCRIPTION
Fixes #750 

Description:
Removes the 'module' prefix for checkpointing of parallel models

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)

cc @vfdev-5 