### PR TITLE
Update test_frequency.py

### DIFF
--- a/tests/ignite/metrics/test_frequency.py
+++ b/tests/ignite/metrics/test_frequency.py
@@ -40,8 +40,8 @@ def _test_frequency_with_engine(device, workers):
     @engine.on(Events.ITERATION_COMPLETED)
     def assert_wps(e):
         wps = e.state.metrics["wps"]
-        assert estimated_wps * 0.85 < wps < estimated_wps, "{}: {} < {} < {}".format(
-            e.state.iteration, estimated_wps * 0.85, wps, estimated_wps
+        assert estimated_wps * 0.80 < wps < estimated_wps, "{}: {} < {} < {}".format(
+            e.state.iteration, estimated_wps * 0.80, wps, estimated_wps
         )
 
     data = [[i] * batch_size for i in range(0, total_tokens, batch_size)]


### PR DESCRIPTION
Description:
Condition `estimated_wps * 0.85` fails randomly but rather frequently on travis. 
For example, 
```
E       AssertionError: 2: 2176.0 < 2141 < 2560.0
E       assert (2560.0 * 0.85) < 2141
```
with 0.8 we'll pass
```
2560.0 * 0.80 = 2048.0
```
Let's make it less strict on performance.


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
