### PR TITLE
Bugfix & Enhancement `GpuInfo` and `CpuInfo` to threaded implementation

### DIFF
--- a/ignite/contrib/metrics/cpu_info.py
+++ b/ignite/contrib/metrics/cpu_info.py
@@ -21,6 +21,7 @@ class CpuInfo(Thread):
         per_cpu (bool): log overall CPU-utilization (`False`) by default or each CPU separately (`True`)
         unit (['KB', 'MB', 'GB']): logging unit defaults to `'GB'`
     """
+
     def __init__(self, logger_directory, logger_name='CPULogger', log_interval_seconds=0.5, per_cpu=False, unit='GB'):
         super().__init__(name=logger_name, daemon=True)
         # CAUTION: Always avoid more than one `SummaryWriter` logging to the same directory
@@ -69,7 +70,7 @@ class CpuInfo(Thread):
         cpu_utilization = {}
         if self._per_cpu:
             for idx_cpu, cpu_percentage in enumerate(cpu_percentages):
-                        cpu_utilization['CPU{}'.format(idx_cpu)] = cpu_percentage
+                cpu_utilization['CPU{}'.format(idx_cpu)] = cpu_percentage
         else:
             cpu_utilization['overall'] = cpu_percentages
         # log CPU utilization to tensorboard

--- a/ignite/contrib/metrics/cpu_info.py
+++ b/ignite/contrib/metrics/cpu_info.py
@@ -1,0 +1,86 @@
+from threading import Thread
+from time import sleep, time
+from psutil import cpu_count, cpu_percent, virtual_memory
+from torch.utils.tensorboard import SummaryWriter
+
+
+class CpuInfo(Thread):
+    """
+    Logger for the CPU resources CPU and RAM utilization run on a separate thread.
+
+    `CpuInfo` is implemented on a separate thread as any attachment to an event would would effectively measure
+    the GPU/CPU-utilization of the downtime, as all events are not fired during the `Engine().process()` where the
+    GPU/CPU is in use. Triggering the logging independently will randomize the measurements during
+    _up times_ (when `Engine().process()` is running) and _down times_.
+
+    Args:
+        logger_directory: directory for tensorboard logs
+        logger_name: name of logger
+        log_interval_seconds: logging interval in seconds. This interval practically cannot be reduced below 0.1sec \
+        as this is the minimum CPU measurement time of `psutil.cpu_percent` (see docu).
+        per_cpu (bool): log overall CPU-utilization (`False`) by default or each CPU separately (`True`)
+        unit (['KB', 'MB', 'GB']): logging unit defaults to `'GB'`
+    """
+    def __init__(self, logger_directory, logger_name='CPULogger', log_interval_seconds=0.5, per_cpu=False, unit='GB'):
+        super().__init__(name=logger_name, daemon=True)
+        # CAUTION: Always avoid more than one `SummaryWriter` logging to the same directory
+        # because this will lead to log file losses
+        self.logger_directory = logger_directory
+        self._log_interval_seconds = log_interval_seconds
+        self._per_cpu = per_cpu
+        self.cpu_count = cpu_count()
+        self._tb_logger = SummaryWriter(logdir=self.logger_directory)
+        self._memory_stats_to_log = ['total', 'used', 'free']
+        self._log_cpu = True
+        self._unit = unit
+        self._units = {'KB': 1024, 'MB': 1024**2, 'GB': 1024**3}
+        self._start_time = None
+
+    def run(self):
+        """
+        Target function of the thread that logs cpu resources to tensoboard till it is closed.
+        CAUTION:
+            DO NOT CALL `self.run()`  on its own but CALL `self.start()` inherited from `Thread`.Otherwise
+            `self.run()` will simple be executed instead of passed as target function to the thread.
+        :return:
+        """
+        self._start_time = time()
+        while self._log_cpu:
+            self._log_cpu_utilization()
+            self._log_cpu_memory()
+            sleep(secs=self._log_interval_seconds)
+
+    def _log_cpu_memory(self):
+        # Get current memory stats
+        memory_sizes = virtual_memory()._asdict()
+        memory_stats = {}
+        # Select memory statistics to be logged and calculate units
+        for mem_stat in self._memory_stats_to_log:
+            memory_stats[mem_stat] = memory_sizes[mem_stat] / self._units[self._unit]
+        # log memory statistics to tensorboard
+        self._tb_logger.add_scalars(main_tag='CPU_memory_' + self._unit,
+                                    tag_scalar_dict=memory_stats,
+                                    global_step=time() - self._start_time)
+
+    def _log_cpu_utilization(self):
+        # Get current CPU utilization in percent
+        # NOTE: the argument `interval=0.1` is shortest (usefull) interval for cpu logging of `cpu_percent`, see docu
+        cpu_percentages = cpu_percent(interval=0.1, percpu=self._per_cpu)
+        cpu_utilization = {}
+        if self._per_cpu:
+            for idx_cpu, cpu_percentage in enumerate(cpu_percentages):
+                        cpu_utilization['CPU{}'.format(idx_cpu)] = cpu_percentage
+        else:
+            cpu_utilization['overall'] = cpu_percentages
+        # log CPU utilization to tensorboard
+        self._tb_logger.add_scalars(main_tag='CPUs_utilization_percentage',
+                                    tag_scalar_dict=cpu_utilization,
+                                    global_step=time() - self._start_time)
+
+    def close(self):
+        # Quit while-loop in `self.run()`
+        self._log_cpu = False
+        # Close tensorboard logger
+        self._tb_logger.close()
+        # Join thread
+        self.join()

--- a/ignite/contrib/metrics/gpu_info.py
+++ b/ignite/contrib/metrics/gpu_info.py
@@ -21,6 +21,7 @@ class GpuPynvmlLogger(Thread):
         reasonably increase (> ~5-30%) the GPU-utilization by the measurement task
         unit (['KB', 'MB', 'GB']): logging unit defaults to `'GB'`
     """
+
     def __init__(self, logger_directory, logger_name='GPULogger', log_interval_seconds=1, unit='GB'):
         super(GpuPynvmlLogger, self).__init__(name=logger_name, daemon=True)
         # CAUTION: Always avoid more than one `SummaryWriter` logging to the same directory

--- a/ignite/contrib/metrics/gpu_info.py
+++ b/ignite/contrib/metrics/gpu_info.py
@@ -1,100 +1,90 @@
-# -*- coding: utf-8 -*-
-import warnings
-
-import torch
-
-from ignite.metrics import Metric
-from ignite.engine import Events
+from threading import Thread
+from time import sleep, time
+from pynvml import nvmlInit, nvmlDeviceGetCount, nvmlDeviceGetHandleByIndex, nvmlDeviceGetMemoryInfo, \
+    nvmlDeviceGetName, nvmlDeviceGetUtilizationRates
+from torch.utils.tensorboard import SummaryWriter
 
 
-class GpuInfo(Metric):
-    """Provides GPU information: a) used memory percentage, b) gpu utilization percentage values as Metric
-    on each iterations.
-
-    Examples:
-
-        .. code-block:: python
-
-            # Default GPU measurements
-            GpuInfo().attach(trainer, name='gpu')  # metric names are 'gpu:X mem(%)', 'gpu:X util(%)'
-
-            # Logging with TQDM
-            ProgressBar(persist=True).attach(trainer, metric_names=['gpu:0 mem(%)', 'gpu:0 util(%)'])
-            # Progress bar will looks like
-            # Epoch [2/10]: [12/24]  50%|█████      , gpu:0 mem(%)=79, gpu:0 util(%)=59 [00:17<1:23]
-
-            # Logging with Tensorboard
-            tb_logger.attach(trainer,
-                             log_handler=OutputHandler(tag="training", metric_names='all'),
-                             event_name=Events.ITERATION_COMPLETED)
+class GpuPynvmlLogger(Thread):
     """
+    Logger for the GPU resources GPU and RAM utilization.
 
-    def __init__(self):
-        try:
-            import pynvml
-        except ImportError:
-            raise RuntimeError(
-                "This contrib module requires pynvml to be installed. "
-                "Please install it with command: \n pip install pynvml"
-            )
-            # Let's check available devices
-        if not torch.cuda.is_available():
-            raise RuntimeError("This contrib module requires available GPU")
+    `CpuInfo` is implemented on a separate thread as any attachment to an event would would effectively measure
+    the GPU/CPU-utilization of the downtime, as all events are not fired during the `Engine().process()` where the
+    GPU/CPU is in use. Triggering the logging independently will randomize the measurements during
+    _up times_ (when `Engine().process()` is running) and _down times_.
 
-        from pynvml.smi import nvidia_smi
+    Args:
+        logger_directory: directory for tensorboard logs
+        logger_name: name of logger
+        log_interval_seconds: logging interval in seconds. Decreasing the `log_interval_seconds < 0.1` may \
+        reasonably increase (> ~5-30%) the GPU-utilization by the measurement task
+        unit (['KB', 'MB', 'GB']): logging unit defaults to `'GB'`
+    """
+    def __init__(self, logger_directory, logger_name='GPULogger', log_interval_seconds=1, unit='GB'):
+        super(GpuPynvmlLogger, self).__init__(name=logger_name, daemon=True)
+        # CAUTION: Always avoid more than one `SummaryWriter` logging to the same directory
+        # because this will lead to log file losses
+        self.logger_directory = logger_directory
+        self.log_interval_seconds = log_interval_seconds
+        nvmlInit()
+        self.gpu_count = nvmlDeviceGetCount()
+        self.gpu_handles = {}
+        for gpu_idx in range(self.gpu_count):
+            hdl = nvmlDeviceGetHandleByIndex(gpu_idx)
+            name = nvmlDeviceGetName(hdl).decode('ascii').replace(' ', '_')
+            self.gpu_handles['GPU{}_{}'.format(gpu_idx, name)] = hdl
+        self._tb_logger = SummaryWriter(logdir=self.logger_directory)
+        self._memory_stats_to_log = ['total', 'used', 'free']
+        self._log_gpu = True
+        self._unit = unit
+        self._units = {'KB': 1024, 'MB': 1024**2, 'GB': 1024**3}
+        self._start_time = None
 
-        # Let it fail if no libnvidia drivers or NMVL library found
-        self.nvsmi = nvidia_smi.getInstance()
-        super(GpuInfo, self).__init__()
+    def run(self):
+        """
+        Target function of the thread that logs GPU resources to tensoboard till it is closed.
+        CAUTION:
+            DO NOT CALL `self.run()`  on its own but CALL `self.start()` inherited from `Thread`.
+            Otherwise `self.run()` will simple be executed in the `MainThread` instead of passed
+            as target function to the new thread.
+        :return:
+        """
+        self._start_time = time()
+        while self._log_gpu:
+            self._log_gpu_utilization()
+            self._log_gpu_memory()
+            sleep(self.log_interval_seconds)
 
-    def reset(self):
-        pass
+    def _log_gpu_memory(self):
+        # Get memory statistics for each GPU
+        for gpu_name, gpu_hdl in self.gpu_handles.items():
+            # Get current memory stats
+            memory_sizes = nvmlDeviceGetMemoryInfo(handle=gpu_hdl)
+            memory_stats = {}
+            # Select memory statistics to be logged and calculate units
+            for mem_stat in self._memory_stats_to_log:
+                memory_stats[mem_stat] = memory_sizes.__getattribute__(mem_stat) / self._units[self._unit]
+            # log memory statistics to tensorboard
+            self._tb_logger.add_scalars(main_tag='{}_memory_{}'.format(gpu_name, self._unit),
+                                        tag_scalar_dict=memory_stats,
+                                        global_step=time() - self._start_time)
 
-    def update(self, output):
-        pass
+    def _log_gpu_utilization(self):
+        gpu_utilizations = {}
+        # Get current GPU utilizations in percent
+        for gpu_name, gpu_hdl in self.gpu_handles.items():
+            gpu_percentage = nvmlDeviceGetUtilizationRates(handle=gpu_hdl).gpu
+            gpu_utilizations[gpu_name] = gpu_percentage
+        # log CPU utilization to tensorboard
+        self._tb_logger.add_scalars(main_tag='GPUs_utilization_percentage',
+                                    tag_scalar_dict=gpu_utilizations,
+                                    global_step=time() - self._start_time)
 
-    def compute(self):
-        data = self.nvsmi.DeviceQuery("memory.used, memory.total, utilization.gpu")
-        if len(data) == 0 or ("gpu" not in data):
-            warnings.warn("No GPU information available")
-            return []
-        return data["gpu"]
-
-    def completed(self, engine, name):
-        data = self.compute()
-        if len(data) < 1:
-            warnings.warn("No GPU information available")
-            return
-
-        for i, data_by_rank in enumerate(data):
-            mem_name = "{}:{} mem(%)".format(name, i)
-
-            if "fb_memory_usage" not in data_by_rank:
-                warnings.warn("No GPU memory usage information available in {}".format(data_by_rank))
-                continue
-            mem_report = data_by_rank["fb_memory_usage"]
-            if not ("used" in mem_report and "total" in mem_report):
-                warnings.warn(
-                    "GPU memory usage information does not provide used/total "
-                    "memory consumption information in {}".format(mem_report)
-                )
-                continue
-
-            engine.state.metrics[mem_name] = int(mem_report["used"] * 100.0 / mem_report["total"])
-
-        for i, data_by_rank in enumerate(data):
-            util_name = "{}:{} util(%)".format(name, i)
-            if "utilization" not in data_by_rank:
-                warnings.warn("No GPU utilization information available in {}".format(data_by_rank))
-                continue
-            util_report = data_by_rank["utilization"]
-            if not ("gpu_util" in util_report):
-                warnings.warn(
-                    "GPU utilization information does not provide 'gpu_util' information in " "{}".format(util_report)
-                )
-                continue
-
-            engine.state.metrics[util_name] = int(util_report["gpu_util"])
-
-    def attach(self, engine, name="gpu", event_name=Events.ITERATION_COMPLETED):
-        engine.add_event_handler(event_name, self.completed, name)
+    def close(self):
+        # Quit while-loop in `self.run()`
+        self._log_gpu = False
+        # Close tensorboard logger
+        self._tb_logger.close()
+        # Join thread
+        self.join()


### PR DESCRIPTION
As far as I understand, the current `GpuInfo` is a `Metric` attached to `Events.ITERATION_COMPLETED`, meaning it logs the current GPU utilization during its downtime when the model in not  updated or inferring as `Engine().process_function()` is completed:
```python
class Engine():
...
   def _run_once_on_dataset(..):
        ...
        self._fire_event(Events.ITERATION_STARTED)
        self.state.output = self._process_function(self, self.state.batch)
        self._fire_event(Events.ITERATION_COMPLETED)
        ...
```
Therefore the measurement is not representative for the actual GPU usage during training. Or did I miss anything?

An alternative quick-fix to the suggestion below for the current `GpuInfo` - at least for the memory logging - would be to replace the `self.nvsmi.DeviceQuery("memory.used")` by [`torch.cuda.max_memory_allocated()`](https://pytorch.org/docs/stable/cuda.html#torch.cuda.max_memory_allocated) which would return the maximum used GPU-memory for each iteration (don't forget to also rest the method after logging).

Description:

The suggested `GpuInfo` and `CpuInfo` are both run on independent threads logging the hardware every user-defined time interval. This should basically lead to a random logging of GPU/CPU uptime and downtime usage which represents the actual use much better.