### PR TITLE
Bugfix #823 trainer common setup and transform output with numbers

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -1,5 +1,6 @@
 from functools import partial
 import warnings
+import numbers
 
 from collections.abc import Sequence, Mapping
 
@@ -129,7 +130,7 @@ def _setup_common_training_handlers(
                 return x[name]
             elif isinstance(x, Sequence):
                 return x[index]
-            elif isinstance(x, torch.Tensor):
+            elif isinstance(x, (torch.Tensor, numbers.Number)):
                 return x
             else:
                 raise ValueError(

--- a/ignite/contrib/handlers/custom_events.py
+++ b/ignite/contrib/handlers/custom_events.py
@@ -72,11 +72,11 @@ class CustomPeriodicEvent:
 
         self.custom_state_attr = "{}_{}".format(prefix, self.period)
         event_name = "{}_{}".format(prefix.upper(), self.period)
-        setattr(self, "Events",
-                EventEnum("Events",
-                          " ".join(["{}_STARTED".format(event_name),
-                                    "{}_COMPLETED".format(event_name)])
-                          ))
+        setattr(
+            self,
+            "Events",
+            EventEnum("Events", " ".join(["{}_STARTED".format(event_name), "{}_COMPLETED".format(event_name)])),
+        )
 
         # Update State.event_to_attr
         for e in self.Events:

--- a/ignite/contrib/handlers/time_profilers.py
+++ b/ignite/contrib/handlers/time_profilers.py
@@ -216,16 +216,27 @@ class BasicTimeProfiler:
         events_to_ignore = [Events.EXCEPTION_RAISED]
         total_eh_time = sum([sum(self.event_handlers_times[e]) for e in Events if e not in events_to_ignore])
 
-        return OrderedDict([
-            ("processing_stats", self._compute_basic_stats(self.processing_times)),
-            ("dataflow_stats", self._compute_basic_stats(self.dataflow_times)),
-            ("event_handlers_stats",
-                dict([(str(e.name).replace(".", "_"), self._compute_basic_stats(self.event_handlers_times[e]))
-                      for e in Events if e not in events_to_ignore] + [("total_time", total_eh_time)])
-             ),
-            ("event_handlers_names", {str(e.name).replace(".", "_") + "_names": v
-                                      for e, v in self.event_handlers_names.items()})
-        ])
+        return OrderedDict(
+            [
+                ("processing_stats", self._compute_basic_stats(self.processing_times)),
+                ("dataflow_stats", self._compute_basic_stats(self.dataflow_times)),
+                (
+                    "event_handlers_stats",
+                    dict(
+                        [
+                            (str(e.name).replace(".", "_"), self._compute_basic_stats(self.event_handlers_times[e]))
+                            for e in Events
+                            if e not in events_to_ignore
+                        ]
+                        + [("total_time", total_eh_time)]
+                    ),
+                ),
+                (
+                    "event_handlers_names",
+                    {str(e.name).replace(".", "_") + "_names": v for e, v in self.event_handlers_names.items()},
+                ),
+            ]
+        )
 
     def write_results(self, output_path):
         """

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -175,20 +175,18 @@ class ProgressBar(BaseLogger):
         desc = self.tqdm_kwargs.get("desc", "Epoch")
 
         if event_name not in engine._allowed_events:
-            raise ValueError('Logging event {} is not in allowed events for this engine'.format(event_name.name))
+            raise ValueError("Logging event {} is not in allowed events for this engine".format(event_name.name))
 
-        if isinstance(closing_event_name,
-                      CallableEventWithFilter):
+        if isinstance(closing_event_name, CallableEventWithFilter):
             if closing_event_name.filter != CallableEventWithFilter.default_event_filter:
-                raise ValueError('Closing Event should not be a filtered event')
+                raise ValueError("Closing Event should not be a filtered event")
 
         if not self._compare_lt(event_name, closing_event_name):
             raise ValueError(
                 "Logging event {} should be called before closing event {}".format(event_name, closing_event_name)
             )
 
-        log_handler = _OutputHandler(desc, metric_names, output_transform,
-                                     closing_event_name=closing_event_name)
+        log_handler = _OutputHandler(desc, metric_names, output_transform, closing_event_name=closing_event_name)
 
         super(ProgressBar, self).attach(engine, log_handler, event_name)
         engine.add_event_handler(closing_event_name, self._close)

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -7,12 +7,12 @@ from ignite.utils import convert_tensor
 from ignite.metrics import Metric
 
 __all__ = [
-    'create_supervised_trainer',
-    'create_supervised_evaluator',
-    'Engine',
-    'Events',
-    'EventEnum',
-    'CallableEventWithFilter'
+    "create_supervised_trainer",
+    "create_supervised_evaluator",
+    "Engine",
+    "Events",
+    "EventEnum",
+    "CallableEventWithFilter",
 ]
 
 

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -189,7 +189,7 @@ class Engine:
             # engine.state contains an attribute time_iteration, which can be accessed using engine.state.time_iteration
         """
         if not (event_to_attr is None or isinstance(event_to_attr, dict)):
-            raise ValueError('Expected event_to_attr to be dictionary. Got {}.'.format(type(event_to_attr)))
+            raise ValueError("Expected event_to_attr to be dictionary. Got {}.".format(type(event_to_attr)))
 
         for e in event_names:
             self._allowed_events.append(e)
@@ -244,8 +244,10 @@ class Engine:
             See :class:`~ignite.engine.Events` for more details.
 
         """
-        if (isinstance(event_name,
-                       CallableEventWithFilter) and event_name.filter != CallableEventWithFilter.default_event_filter):
+        if (
+            isinstance(event_name, CallableEventWithFilter)
+            and event_name.filter != CallableEventWithFilter.default_event_filter
+        ):
             event_filter = event_name.filter
             handler = Engine._handler_wrapper(handler, event_name, event_filter)
 
@@ -263,10 +265,13 @@ class Engine:
 
     @staticmethod
     def _assert_non_filtered_event(event_name: str):
-        if (isinstance(event_name,
-                       CallableEventWithFilter) and event_name.filter != CallableEventWithFilter.default_event_filter):
-            raise TypeError("Argument event_name should not be a filtered event, "
-                            "please use event without any event filtering")
+        if (
+            isinstance(event_name, CallableEventWithFilter)
+            and event_name.filter != CallableEventWithFilter.default_event_filter
+        ):
+            raise TypeError(
+                "Argument event_name should not be a filtered event, " "please use event without any event filtering"
+            )
 
     def has_event_handler(self, handler: Callable, event_name: Optional[str] = None):
         """Check if the specified event has the specified handler.

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -7,10 +7,7 @@ from types import DynamicClassAttribute
 
 from ignite.engine.utils import _check_signature
 
-__all__ = [
-    'Events',
-    'State'
-]
+__all__ = ["Events", "State"]
 
 
 class CallableEventWithFilter:
@@ -26,16 +23,15 @@ class CallableEventWithFilter:
 
     """
 
-    def __init__(self, value: str, event_filter: Optional[Callable] = None,
-                 name=None):
+    def __init__(self, value: str, event_filter: Optional[Callable] = None, name=None):
         if event_filter is None:
             event_filter = CallableEventWithFilter.default_event_filter
         self.filter = event_filter
 
-        if not hasattr(self, '_value_'):
+        if not hasattr(self, "_value_"):
             self._value_ = value
 
-        if not hasattr(self, '_name_') and name is not None:
+        if not hasattr(self, "_name_") and name is not None:
             self._name_ = name
 
     # copied to be compatible to enum
@@ -50,8 +46,9 @@ class CallableEventWithFilter:
         return self._value_
 
     # Will return CallableEventWithFilter but can't annotate that way due to python <= 3.7
-    def __call__(self, event_filter: Optional[Callable] = None,
-                 every: Optional[int] = None, once: Optional[int] = None) -> Any:
+    def __call__(
+        self, event_filter: Optional[Callable] = None, every: Optional[int] = None, once: Optional[int] = None
+    ) -> Any:
         """
         Makes the event class callable and accepts either an arbitrary callable as filter
         (which must take in the engine and current event value and return a boolean) or an every or once value

--- a/tests/ignite/contrib/handlers/test_time_profilers.py
+++ b/tests/ignite/contrib/handlers/test_time_profilers.py
@@ -77,7 +77,7 @@ def test_event_handler_started():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['STARTED']
+    event_results = results["event_handlers_stats"]["STARTED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -99,7 +99,7 @@ def test_event_handler_completed():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['COMPLETED']
+    event_results = results["event_handlers_stats"]["COMPLETED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -121,7 +121,7 @@ def test_event_handler_epoch_started():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['EPOCH_STARTED']
+    event_results = results["event_handlers_stats"]["EPOCH_STARTED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -145,7 +145,7 @@ def test_event_handler_epoch_completed():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['EPOCH_COMPLETED']
+    event_results = results["event_handlers_stats"]["EPOCH_COMPLETED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -169,7 +169,7 @@ def test_event_handler_iteration_started():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['ITERATION_STARTED']
+    event_results = results["event_handlers_stats"]["ITERATION_STARTED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -193,7 +193,7 @@ def test_event_handler_iteration_completed():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['ITERATION_COMPLETED']
+    event_results = results["event_handlers_stats"]["ITERATION_COMPLETED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -217,7 +217,7 @@ def test_event_handler_get_batch_started():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['GET_BATCH_STARTED']
+    event_results = results["event_handlers_stats"]["GET_BATCH_STARTED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -241,7 +241,7 @@ def test_event_handler_get_batch_completed():
 
     dummy_trainer.run(range(true_num_iters), max_epochs=true_max_epochs)
     results = profiler.get_results()
-    event_results = results['event_handlers_stats']['GET_BATCH_COMPLETED']
+    event_results = results["event_handlers_stats"]["GET_BATCH_COMPLETED"]
 
     assert event_results["min/index"][0] == approx(true_event_handler_time, abs=1e-1)
     assert event_results["max/index"][0] == approx(true_event_handler_time, abs=1e-1)
@@ -361,7 +361,7 @@ def test_write_results():
 
 
 def test_print_results(capsys):
-    true_event_handler_time = 0.
+    true_event_handler_time = 0.0
     true_max_epochs = 1
     true_num_iters = 1
 

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -365,7 +365,7 @@ def test_pbar_wrong_events_order():
     with pytest.raises(ValueError, match="should be called before closing event"):
         pbar.attach(engine, event_name=Events.ITERATION_COMPLETED, closing_event_name=Events.ITERATION_STARTED)
 
-    with pytest.raises(ValueError, match='should not be a filtered event'):
+    with pytest.raises(ValueError, match="should not be a filtered event"):
         pbar.attach(engine, event_name=Events.ITERATION_STARTED, closing_event_name=Events.EPOCH_COMPLETED(every=10))
 
 

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -39,7 +39,6 @@ def test_custom_events():
 
 
 def test_custom_events_with_event_to_attr():
-
     class CustomEvents(EventEnum):
         TEST_EVENT = "test_event"
 


### PR DESCRIPTION
Fixes #823 

Description:

`create_supervised_trainer` with default `output_transform` is not compatible with `setup_common_training_handlers` and `output_names` :
```python
trainer = create_supervised_trainer(model=model,
                                    optimizer=optimizer,
                                    loss_fn=loss_fn)  

setup_common_training_handlers(trainer=trainer, output_names=['loss'])
```
is ko because default `output_transform` :
```python
output_transform: Callable = lambda x, y, y_pred, loss: loss.item()
```
Fix using `numbers` in `common.py` line 128
```python
def output_transform(x, index, name):
  if isinstance(x, Mapping):
    return x[name]
  elif isinstance(x, Sequence):
    return x[index]
  elif isinstance(x, (torch.Tensor, numbers.Number)):
    return x
  else:
    raise ValueError(
      "Unhandled type of update_function's output. "
      "It should either mapping or sequence, but given {}".format(type(x))
    )
``` 
NB: Some files were modfied due to black.

Check list:
* [x] New tests are added (if a new feature is added) [Not Necessary]
* [x] New doc strings: description and/or example code are in RST format [Not Necessary]
* [x] Documentation is updated (if required) [Not Necessary]
