### PR TITLE
Save only one checkpoint per priority

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -217,6 +217,9 @@ class Checkpoint:
                 checkpoint = checkpoint[name]
             filename = "{}{}_{}{}".format(self._fname_prefix, name, suffix, self._ext)
 
+            if any(item.filename == filename for item in self._saved):
+                return
+
             self.save_handler(checkpoint, filename)
 
             self._saved.append(Checkpoint.Item(priority, filename))

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -571,6 +571,28 @@ def test_best_k_with_suffix(dirname):
     assert sorted(os.listdir(dirname)) == expected
 
 
+def test_removes_each_score_at_most_once(dirname):
+    scores = [0, 1, 1, 2, 3]
+    scores_iter = iter(scores)
+
+    def score_function(_):
+        return next(scores_iter)
+
+    h = ModelCheckpoint(dirname, _PREFIX, create_dir=False, n_saved=2, score_function=score_function)
+
+    engine = Engine(lambda e, b: None)
+    engine.state = State(epoch=0, iteration=0)
+
+    model = DummyModel()
+    to_save = {"model": model}
+    for _ in range(len(scores)):
+        h(engine, to_save)
+
+    # If a score was removed multiple times, the code above would have raise a
+    # FileNotFoundError. So this just tests the absence of such a failure
+    # without futher assertions.
+
+
 def test_with_engine(dirname):
     def update_fn(_1, _2):
         pass


### PR DESCRIPTION
Fixes `FileNotFoundError` during checkpointing

Description: The previous behavior would save two `Item`s for the same priority if `n_saved >= 2` but would store them in the same path. If you then store more checkpoints with higher priorities such that the first two of same priority drop out, the second one dropping out will raise a `FileNotFoundError` because its file has already been removed by the first `Item`.

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
