### PR TITLE
Make torch.argmax optional : callable from logits to labels

### DIFF
--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -15,6 +15,7 @@ class _BasePrecisionRecall(_BaseClassification):
     def __init__(
         self,
         output_transform: Callable = lambda x: x,
+        logit_to_label_fn: Callable = lambda x: torch.argmax(x, dim=1),
         average: bool = False,
         is_multilabel: bool = False,
         device: Optional[Union[str, torch.device]] = None,
@@ -33,7 +34,8 @@ class _BasePrecisionRecall(_BaseClassification):
         self._positives = None
         self.eps = 1e-20
         super(_BasePrecisionRecall, self).__init__(
-            output_transform=output_transform, is_multilabel=is_multilabel, device=device
+            output_transform=output_transform, logit_to_label_fn=logit_to_label_fn,
+            is_multilabel=is_multilabel, device=device
         )
 
     @reinit__is_reduced
@@ -149,7 +151,8 @@ class Precision(_BasePrecisionRecall):
                     " and element in y has invalid class = {}.".format(num_classes, y.max().item() + 1)
                 )
             y = to_onehot(y.view(-1), num_classes=num_classes)
-            indices = torch.argmax(y_pred, dim=1).view(-1)
+            # indices = torch.argmax(y_pred, dim=1).view(-1)
+            indices = self._logit_to_label_fn(y_pred).view(-1)
             y_pred = to_onehot(indices, num_classes=num_classes)
         elif self._type == "multilabel":
             # if y, y_pred shape is (N, C, ...) -> (C, N x ...)

--- a/ignite/metrics/recall.py
+++ b/ignite/metrics/recall.py
@@ -70,12 +70,14 @@ class Recall(_BasePrecisionRecall):
     def __init__(
         self,
         output_transform: Callable = lambda x: x,
+        logit_to_label_fn: Callable = lambda x: torch.argmax(x, dim=1),
         average: bool = False,
         is_multilabel: bool = False,
         device: Optional[Union[str, torch.device]] = None,
     ):
         super(Recall, self).__init__(
-            output_transform=output_transform, average=average, is_multilabel=is_multilabel, device=device
+            output_transform=output_transform, logit_to_label_fn=logit_to_label_fn,
+            average=average, is_multilabel=is_multilabel, device=device
         )
 
     @reinit__is_reduced
@@ -95,7 +97,8 @@ class Recall(_BasePrecisionRecall):
                     " and element in y has invalid class = {}.".format(num_classes, y.max().item() + 1)
                 )
             y = to_onehot(y.view(-1), num_classes=num_classes)
-            indices = torch.argmax(y_pred, dim=1).view(-1)
+            # indices = torch.argmax(y_pred, dim=1).view(-1)
+            indices = self._logit_to_label_fn(y_pred).view(-1)
             y_pred = to_onehot(indices, num_classes=num_classes)
         elif self._type == "multilabel":
             # if y, y_pred shape is (N, C, ...) -> (C, N x ...)


### PR DESCRIPTION
Fixes #822 

Description:

Make torch.argmax optional. I don't use output_transform but introduce a new callable dedicated to transform from logits to labels. Notice that to do binary, it's preferable to use this new feature rather than output_transform. (output_transform should be used to transform outputs of models to a conform input for metrics, i.e. [y_pred, y] in logits).
 
For review, tests neither docs are not yet done. 

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
