### PR TITLE
fix issue 831 : tensorboardx no longer mandatory if pytorch>=1.2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -64,8 +64,8 @@ jobs:
         sleep 10
         python examples/mnist/mnist_with_visdom.py --epochs=1
         kill %1
-        # 3) mnist_with_tensorboardx.py
-        python examples/mnist/mnist_with_tensorboardx.py --epochs=1
+        # 3) mnist_with_tensorboard.py
+        python examples/mnist/mnist_with_tensorboard.py --epochs=1
     - name: Run MNIST Example With Crash
       continue-on-error: true
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ script:
   - sleep 10
   - python examples/mnist/mnist_with_visdom.py --epochs=1
   - kill %1
-  # 3) mnist_with_tensorboardx.py
-  - python examples/mnist/mnist_with_tensorboardx.py --epochs=1
+  # 3) mnist_with_tensorboard.py
+  - python examples/mnist/mnist_with_tensorboard.py --epochs=1
   # 4) mnist_save_resume_engine.py
   - python examples/mnist/mnist_save_resume_engine.py --epochs=1 --crash_iteration 700
   - python examples/mnist/mnist_save_resume_engine.py --epochs=1 --resume_from=/tmp/mnist_save_resume/checkpoint_550.pth

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -14,7 +14,7 @@ Run the example:
 python mnist.py
 ```
 
-### Logging with TensorboardX
+### Logging with Tensorboard
 
 MNIST example with training and validation monitoring using Tensorboard. Notice 
 that if PyTorch version is less than 1.2, the module TensorboardX is required.
@@ -29,7 +29,7 @@ that if PyTorch version is less than 1.2, the module TensorboardX is required.
 
 Run the example:
 ```bash
-python mnist_with_tensorboardx.py --log_dir=/tmp/tensorboard_logs
+python mnist_with_tensorboard.py --log_dir=/tmp/tensorboard_logs
 ```
 
 Start tensorboard:

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -16,12 +16,13 @@ python mnist.py
 
 ### Logging with TensorboardX
 
-MNIST example with training and validation monitoring using TensorboardX and Tensorboard.
+MNIST example with training and validation monitoring using Tensorboard. Notice 
+that if PyTorch version is less than 1.2, the module TensorboardX is required.
 
 #### Requirements:
 
 - [torchvision](https://github.com/pytorch/vision/): `pip install torchvision`
-- [TensorboardX](https://github.com/lanpa/tensorboard-pytorch): `pip install tensorboardX`
+- [TensorboardX](https://github.com/lanpa/tensorboard-pytorch) (if and only if `PyTorch <= 1.2`): `pip install tensorboardX`
 - Tensorboard: `pip install tensorboard`
 
 #### Usage:

--- a/examples/mnist/mnist_with_tensorboard.py
+++ b/examples/mnist/mnist_with_tensorboard.py
@@ -11,7 +11,7 @@
     ```
     Run the example:
     ```bash
-    python mnist_with_tensorboardx.py --log_dir=/tmp/tensorboard_logs
+    python mnist_with_tensorboard.py --log_dir=/tmp/tensorboard_logs
     ```
 """
 

--- a/examples/mnist/mnist_with_tensorboardx.py
+++ b/examples/mnist/mnist_with_tensorboardx.py
@@ -1,7 +1,8 @@
 """
- MNIST example with training and validation monitoring using TensorboardX and Tensorboard.
+ MNIST example with training and validation monitoring using Tensorboard.
  Requirements:
     TensorboardX (https://github.com/lanpa/tensorboard-pytorch): `pip install tensorboardX`
+    or PyTorch >= 1.2 which supports Tensorboard
     Tensorboard: `pip install tensorflow` (or just install tensorboard without the rest of tensorflow)
  Usage:
     Start tensorboard:
@@ -26,7 +27,14 @@ from torchvision.transforms import Compose, ToTensor, Normalize
 try:
     from tensorboardX import SummaryWriter
 except ImportError:
-    raise RuntimeError("No tensorboardX package is found. Please install with the command: \npip install tensorboardX")
+    try:
+        from torch.utils.tensorboard import SummaryWriter
+    except ImportError:
+        raise RuntimeError(
+            "This module requires either tensorboardX or torch >= 1.2.0. "
+            "You may install tensorboardX with command: \n pip install tensorboardX \n"
+            "or upgrade PyTorch using your package manager of choice (pip or conda)."
+        )
 
 from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator
 from ignite.metrics import Accuracy, Loss


### PR DESCRIPTION
Fixes #831 

Description:

Tensorboardx no longer mandatory if pytorch>=1.2

TODO Use case file should be renamed `mnist_with_tensorboard.py` ? Should impact CI/CD.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
