### PR TITLE
Fix MLflowLogger docstring: remove double asterics (#898)

### DIFF
--- a/ignite/contrib/handlers/mlflow_logger.py
+++ b/ignite/contrib/handlers/mlflow_logger.py
@@ -199,7 +199,7 @@ class MLflowLogger(BaseLogger):
             mlflow_logger = MLflowLogger()
 
             # Log experiment parameters:
-            mlflow_logger.log_params(**{
+            mlflow_logger.log_params({
                 "seed": seed,
                 "batch_size": batch_size,
                 "model": model.__class__.__name__,


### PR DESCRIPTION
Fixes #898 

Description:
Remove double asterics from MLflowLogger docstring

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
