### PR TITLE
Update common.py

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -152,6 +152,8 @@ def _setup_common_training_handlers(
         ProgressBar(persist=True, bar_format="").attach(
             trainer, event_name=Events.EPOCH_STARTED, closing_event_name=Events.COMPLETED
         )
+        
+    return trainer
 
 
 def _setup_common_distrib_training_handlers(

--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -77,7 +77,7 @@ def setup_common_training_handlers(
         device=device,
     )
     if dist.is_available() and dist.is_initialized():
-        return _setup_common_distrib_training_handlers(trainer, train_sampler=train_sampler, **kwargs)
+        _setup_common_distrib_training_handlers(trainer, train_sampler=train_sampler, **kwargs)
     else:
         if train_sampler is not None:
             warnings.warn(
@@ -85,7 +85,7 @@ def setup_common_training_handlers(
                 "started event, but no distributed setting detected",
                 UserWarning,
             )
-        return _setup_common_training_handlers(trainer, **kwargs)
+        _setup_common_training_handlers(trainer, **kwargs)
 
 
 setup_common_distrib_training_handlers = setup_common_training_handlers
@@ -153,8 +153,6 @@ def _setup_common_training_handlers(
             trainer, event_name=Events.EPOCH_STARTED, closing_event_name=Events.COMPLETED
         )
         
-    return trainer
-
 
 def _setup_common_distrib_training_handlers(
     trainer,
@@ -199,8 +197,6 @@ def _setup_common_distrib_training_handlers(
                 raise ValueError("If to_save argument is provided then output_path argument should be also defined")
             checkpoint_handler = ModelCheckpoint(dirname=output_path, filename_prefix="training")
             trainer.add_event_handler(Events.ITERATION_COMPLETED(every=save_every_iters), checkpoint_handler, to_save)
-
-    return trainer
 
 
 def empty_cuda_cache(_):

--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -152,7 +152,7 @@ def _setup_common_training_handlers(
         ProgressBar(persist=True, bar_format="").attach(
             trainer, event_name=Events.EPOCH_STARTED, closing_event_name=Events.COMPLETED
         )
-        
+
 
 def _setup_common_distrib_training_handlers(
     trainer,


### PR DESCRIPTION
I think `_setup_common_training_handlers(...)` is missing its `return trainer` statement at the end of it. I've added it here.

If this is in error, please just reject and close this.

Fixes # 

Description:


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
