### PR TITLE
fix issue 918

### DIFF
--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -230,7 +230,7 @@ def _test_every_event_filter_with_engine(device="cpu"):
             num_calls[0] += 1
 
         @engine.on(event_name(every=every))
-        def assert_every():
+        def assert_every_no_engine():
             assert getattr(engine.state, event_attr) % every == 0
             assert counter_every[0] == getattr(engine.state, event_attr)
 
@@ -240,7 +240,7 @@ def _test_every_event_filter_with_engine(device="cpu"):
             assert getattr(engine.state, event_attr) == counter[0]
 
         @engine.on(event_name)
-        def assert_():
+        def assert_no_engine():
             assert getattr(engine.state, event_attr) == counter[0]
 
         engine.run(data, max_epochs=5)

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -229,9 +229,18 @@ def _test_every_event_filter_with_engine(device="cpu"):
             assert counter_every[0] == getattr(engine.state, event_attr)
             num_calls[0] += 1
 
+        @engine.on(event_name(every=every))
+        def assert_every():
+            assert getattr(engine.state, event_attr) % every == 0
+            assert counter_every[0] == getattr(engine.state, event_attr)
+
         @engine.on(event_name)
         def assert_(engine):
             counter[0] += 1
+            assert getattr(engine.state, event_attr) == counter[0]
+
+        @engine.on(event_name)
+        def assert_():
             assert getattr(engine.state, event_attr) == counter[0]
 
         engine.run(data, max_epochs=5)


### PR DESCRIPTION
Fixes #918 

Description:

`handlers` could have optional `engine` argument. Events with filters use wrapper around handler. Signature of handler is used to check if `engine` is optional. However, wrappers wasn't built wrt handler signature. 

Remark : I don't understand why that was working so far. There are plenty of tests using event filters...

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
