### PR TITLE
Update common.py

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -117,7 +117,7 @@ def _setup_common_training_handlers(
     if to_save is not None:
         if output_path is None:
             raise ValueError("If to_save argument is provided then output_path argument should be also defined")
-        checkpoint_handler = ModelCheckpoint(dirname=output_path, filename_prefix="training")
+        checkpoint_handler = ModelCheckpoint(dirname=output_path, filename_prefix="training", require_empty=False)
         trainer.add_event_handler(Events.ITERATION_COMPLETED(every=save_every_iters), checkpoint_handler, to_save)
 
     if with_gpu_stats:
@@ -195,7 +195,7 @@ def _setup_common_distrib_training_handlers(
         if to_save is not None:
             if output_path is None:
                 raise ValueError("If to_save argument is provided then output_path argument should be also defined")
-            checkpoint_handler = ModelCheckpoint(dirname=output_path, filename_prefix="training")
+            checkpoint_handler = ModelCheckpoint(dirname=output_path, filename_prefix="training", require_empty=False)
             trainer.add_event_handler(Events.ITERATION_COMPLETED(every=save_every_iters), checkpoint_handler, to_save)
 
 


### PR DESCRIPTION
Description:

Set `require_empty=False` to `ModelCheckpoint` in `setup_common_training_handlers`.
Thus, we can have a possibility to restore from a checkpoint in a folder and continue write in the same folder (even it could look strange in TensorBoard) 

