### PR TITLE
Added DeterministicEngine

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -363,3 +363,154 @@ We can then restore the training from the last checkpoint.
 
 It is also possible to store checkpoints every N iterations and continue the training from one of these checkpoints, i.e
 from iteration.
+
+
+Dataflow synchronization
+````````````````````````
+
+Previous approach, however, does not synchronize the dataflow and the model does not see the same data samples when
+resuming from a checkpoint. Therefore, training curves will not be exactly the same.
+
+Ignite provides an option to control the dataflow by synchronizing random state on epochs. In this way, for a given
+iteration/epoch the dataflow can be the same for a given seed. More precisely it is roughly looks like:
+
+.. code-block:: python
+
+    for e in range(num_epochs):
+        set_seed(seed + e)
+        do_single_epoch_iterations(dataloader)
+
+
+In addition, if data provider is `torch.utils.data.DataLoader`, batch data indices can be made completely deterministic.
+Here is a trivial example of usage:
+
+.. code-block:: python
+
+    import torch
+    from torch.utils.data import DataLoader
+    from ignite.engine import DeterministicEngine, Events
+    from ignite.utils import manual_seed
+
+
+    def random_train_data_loader(size):
+        data = torch.arange(0, size)
+        return DataLoader(data, batch_size=4, shuffle=True)
+
+
+    def print_train_data(engine, batch):
+        i = engine.state.iteration
+        e = engine.state.epoch
+        print("train", e, i, batch.tolist())
+
+    trainer = DeterministicEngine(print_train_data)
+
+    print("Original Run")
+    manual_seed(56)
+    trainer.run(random_train_data_loader(40), max_epochs=2, epoch_length=5)
+
+    print("Resumed Run")
+    # Resume from 2nd epoch
+    trainer.load_state_dict({"epoch": 1, "epoch_length": 5, "max_epochs": 2, "rng_states": None})
+    manual_seed(56)
+    trainer.run(random_train_data_loader(40))
+
+.. code-block:: text
+
+    Original Run
+    train 1 1 [31, 13, 3, 4]
+    train 1 2 [23, 18, 6, 16]
+    train 1 3 [10, 8, 33, 36]
+    train 1 4 [1, 37, 19, 9]
+    train 1 5 [20, 30, 14, 26]
+    train 2 6 [29, 35, 38, 34]
+    train 2 7 [7, 22, 12, 17]
+    train 2 8 [25, 21, 24, 15]
+    train 2 9 [39, 5, 2, 28]
+    train 2 10 [27, 11, 32, 0]
+    Resumed Run
+    train 2 6 [29, 35, 38, 34]
+    train 2 7 [7, 22, 12, 17]
+    train 2 8 [25, 21, 24, 15]
+    train 2 9 [39, 5, 2, 28]
+    train 2 10 [27, 11, 32, 0]
+
+
+We can see that the data samples are exactly the same between original and resumed runs.
+
+Complete examples that simulates a crash on a defined iteration and resumes the training from a checkpoint can be found
+here:
+
+- `save/resume MNIST <https://github.com/pytorch/ignite/tree/master/examples/mnist#training-save--resume>`_
+- `save/resume Distributed CIFAR10 <https://github.com/pytorch/ignite/tree/master/examples/contrib/cifar10#check-resume-training>`_
+
+
+.. Note ::
+
+    In case when input data is `torch.utils.data.DataLoader`, previous batches are skipped and the first provided batch
+    corresponds to the batch after the checkpoint iteration. Internally, while resuming, previous datapoint indices are just
+    skipped without fetching the data.
+
+.. warning::
+
+    However, while resuming from iteration, random data augmentations are not synchronized in the middle of the epoch and
+    thus batches remaining until the end of the epoch can be different of those from the initial run.
+
+.. warning::
+
+    However, please, keep in mind that there can be an issue with dataflow synchronization on every epoch
+    if user's handler synchronizes the random state, for example, by calling periodically `torch.manual_seed(seed)` during
+    the run. This can have an impact on the dataflow:
+
+    .. code-block:: python
+
+        def random_train_data_generator():
+            while True:
+                yield torch.randint(0, 100, size=(1, ))
+
+        trainer = DeterministicEngine(print_train_data)
+
+        @trainer.on(Events.ITERATION_COMPLETED(every=3))
+        def user_handler(_):
+            # handler synchronizes the random state
+            torch.manual_seed(12)
+            a = torch.rand(1)
+
+        trainer.run(random_train_data_generator(), max_epochs=3, epoch_length=5);
+
+    .. code-block:: text
+
+        train 1 1 [32]
+        train 1 2 [29]
+        train 1 3 [40]
+        train 1 4 [3]  <---
+        train 1 5 [22]
+        train 2 6 [77]
+        train 2 7 [3]  <---
+        train 2 8 [22]
+        train 2 9 [77]
+        train 2 10 [3] <---
+        train 3 11 [22]
+        train 3 12 [77]
+        train 3 13 [3] <---
+        train 3 14 [22]
+        train 3 15 [77]
+
+    Initially, the function `random_train_data_generator()` generates randomly data batches using the random state set
+    up by `trainer`. This is intended behaviour until `user_handler()` is called.
+    After `user_handler()` execution, random state is altered and thus `random_train_data_generator()` will produce
+    random batches based on altered random state.
+
+    We provide helper decorator :meth:`~ignite.engine.deterministic.keep_random_state` to save and restore random states for
+    `torch`, `numpy` and `random`. Therefore, we can deal with described issue using this decorator:
+
+    .. code-block:: python
+
+        from ignite.engine.deterministic import keep_random_state
+
+        @trainer.on(Events.ITERATION_COMPLETED(every=3))
+        @keep_random_state
+        def user_handler(_):
+            # handler synchronizes the random state
+            torch.manual_seed(12)
+            a = torch.rand(1)
+

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -5,12 +5,15 @@ from ignite.engine.engine import Engine
 from ignite.engine.events import State, Events, EventEnum, CallableEventWithFilter
 from ignite.utils import convert_tensor
 from ignite.metrics import Metric
+from ignite.engine.deterministic import DeterministicEngine
+
 
 __all__ = [
     "State",
     "create_supervised_trainer",
     "create_supervised_evaluator",
     "Engine",
+    "DeterministicEngine",
     "Events",
     "EventEnum",
     "CallableEventWithFilter",
@@ -38,10 +41,10 @@ def create_supervised_trainer(
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
     output_transform: Callable = lambda x, y, y_pred, loss: loss.item(),
+    deterministic: bool = False,
 ) -> Engine:
     """
     Factory function for creating a trainer for supervised models.
-
     Args:
         model (`torch.nn.Module`): the model to train.
         optimizer (`torch.optim.Optimizer`): the optimizer to use.
@@ -54,22 +57,19 @@ def create_supervised_trainer(
             tuple of tensors `(batch_x, batch_y)`.
         output_transform (callable, optional): function that receives 'x', 'y', 'y_pred', 'loss' and returns value
             to be assigned to engine's state.output after each iteration. Default is returning `loss.item()`.
-
+        deterministic (bool, optional): if True, returns deterministic engine of type
+            :class:`~ignite.engine.deterministic.DeterministicEngine`, otherwise :class:`~ignite.engine.Engine`
+            (default: False).
     Note:
-        `engine.state.output` for this engine is defind by `output_transform` parameter and is the loss
+        `engine.state.output` for this engine is defined by `output_transform` parameter and is the loss
         of the processed batch by default.
-
     .. warning::
-
         The internal use of `device` has changed.
         `device` will now *only* be used to move the input data to the correct device.
         The `model` should be moved by the user before creating an optimizer.
-
         For more information see:
-
         * `PyTorch Documentation <https://pytorch.org/docs/stable/optim.html#constructing-it>`_
         * `PyTorch's Explanation <https://github.com/pytorch/pytorch/issues/7844#issuecomment-503713840>`_
-
     Returns:
         Engine: a trainer engine with supervised update function.
     """
@@ -84,7 +84,7 @@ def create_supervised_trainer(
         optimizer.step()
         return output_transform(x, y, y_pred, loss)
 
-    trainer = Engine(_update)
+    trainer = Engine(_update) if not deterministic else DeterministicEngine(_update)
 
     return trainer
 

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import random
 from unittest.mock import patch
@@ -5,16 +6,19 @@ from unittest.mock import patch
 import numpy as np
 
 import torch
+import torch.nn as nn
 
 from ignite.engine.deterministic import (
     ReproducibleBatchSampler,
     update_dataloader,
     keep_random_state,
+    DeterministicEngine,
 )
 
+from ignite.engine import Events
 from ignite.utils import manual_seed
 
-from tests.ignite.engine import setup_sampler
+from tests.ignite.engine import setup_sampler, BatchChecker
 
 
 def test_update_dataloader():
@@ -162,3 +166,633 @@ def test_keep_random_state():
 def test_keep_random_state_without_numpy():
     with patch.dict("sys.modules", {"numpy": None}):
         _test_keep_random_state(with_numpy=False)
+
+
+def test_strict_resume_from_iter():
+    def _test(epoch_length=None):
+
+        max_epochs = 5
+        num_iters = 21
+        torch.manual_seed(0)
+        data = torch.randint(0, 1000, size=(num_iters,))
+        if epoch_length is None:
+            epoch_length = num_iters
+
+        for resume_iteration in range(2, min(num_iters * max_epochs, epoch_length * max_epochs), 4):
+            print("\n----", resume_iteration, epoch_length)
+            batch_checker = BatchChecker(data, init_counter=resume_iteration)
+
+            def update_fn(_, batch):
+                assert batch_checker.check(batch), "{} | {}: {} vs {}".format(
+                    resume_iteration, batch_checker.counter, batch_checker.true_batch, batch
+                )
+
+            engine = DeterministicEngine(update_fn)
+
+            @engine.on(Events.EPOCH_COMPLETED)
+            def check_iteration(engine):
+                assert engine.state.iteration == batch_checker.counter
+
+            resume_state_dict = dict(
+                iteration=resume_iteration, max_epochs=max_epochs, epoch_length=epoch_length, rng_states=None
+            )
+            engine.load_state_dict(resume_state_dict)
+            engine.run(data)
+            assert engine.state.epoch == max_epochs
+            assert engine.state.iteration == epoch_length * max_epochs
+
+    _test()
+    _test(60)
+    _test(15)
+
+
+def test_strict_resume_from_epoch():
+    def _test(epoch_length=None):
+        max_epochs = 10
+        num_iters = 21
+        torch.manual_seed(0)
+        data = torch.randint(0, 1000, size=(num_iters,))
+        if epoch_length is None:
+            epoch_length = num_iters
+
+        for resume_epoch in range(1, max_epochs):
+            batch_checker = BatchChecker(data, init_counter=resume_epoch * epoch_length)
+
+            def update_fn(_, batch):
+                assert batch_checker.check(batch), "{} | {}: {} vs {}".format(
+                    resume_epoch, batch_checker.counter, batch_checker.true_batch, batch
+                )
+
+            engine = DeterministicEngine(update_fn)
+
+            resume_state_dict = dict(
+                epoch=resume_epoch, max_epochs=max_epochs, epoch_length=epoch_length, rng_states=None
+            )
+            engine.load_state_dict(resume_state_dict)
+            engine.run(data)
+            assert engine.state.epoch == max_epochs
+            assert engine.state.iteration == epoch_length * max_epochs
+
+    _test()
+    _test(60)
+    _test(15)
+
+
+def _test_resume_random_dataloader_from_epoch(device, _setup_sampler, sampler_type=None):
+    def _test(epoch_length=None):
+
+        max_epochs = 5
+        batch_size = 4
+        num_iters = 21
+        torch.manual_seed(0)
+        data = torch.randint(0, 1000, size=(num_iters * batch_size,))
+
+        if epoch_length is None:
+            epoch_length = num_iters
+
+        for resume_epoch in range(1, max_epochs):
+
+            for num_workers in [0, 4]:
+                sampler = _setup_sampler(sampler_type, num_iters, batch_size)
+                orig_dataloader = torch.utils.data.DataLoader(
+                    data,
+                    batch_size=batch_size,
+                    num_workers=num_workers,
+                    pin_memory="cuda" in device,
+                    sampler=sampler,
+                    drop_last=True,
+                    shuffle=sampler is None,
+                )
+
+                seen_batchs = []
+
+                def update_fn(_, batch):
+                    batch_to_device = batch.to(device)
+                    seen_batchs.append(batch)
+
+                engine = DeterministicEngine(update_fn)
+
+                if sampler_type == "distributed":
+
+                    @engine.on(Events.EPOCH_STARTED)
+                    def _(engine):
+                        sampler.set_epoch(engine.state.epoch - 1)
+
+                torch.manual_seed(87)
+                engine.run(
+                    orig_dataloader, max_epochs=max_epochs, epoch_length=epoch_length,
+                )
+
+                batch_checker = BatchChecker(seen_batchs, init_counter=resume_epoch * epoch_length)
+
+                sampler = _setup_sampler(sampler_type, num_iters, batch_size)
+                resume_dataloader = torch.utils.data.DataLoader(
+                    data,
+                    batch_size=batch_size,
+                    num_workers=num_workers,
+                    pin_memory="cuda" in device,
+                    sampler=sampler,
+                    drop_last=True,
+                    shuffle=sampler is None,
+                )
+
+                def update_fn(_, batch):
+                    batch_to_device = batch.to(device)
+                    assert batch_checker.check(batch), "{} {} | {}: {} vs {}".format(
+                        num_workers, resume_epoch, batch_checker.counter, batch_checker.true_batch, batch
+                    )
+
+                engine = DeterministicEngine(update_fn)
+
+                if sampler_type == "distributed":
+
+                    @engine.on(Events.EPOCH_STARTED)
+                    def _(engine):
+                        sampler.set_epoch(engine.state.epoch - 1)
+
+                resume_state_dict = dict(
+                    epoch=resume_epoch, max_epochs=max_epochs, epoch_length=epoch_length, rng_states=None
+                )
+                engine.load_state_dict(resume_state_dict)
+                torch.manual_seed(87)
+                engine.run(resume_dataloader)
+                assert engine.state.epoch == max_epochs
+                assert engine.state.iteration == epoch_length * max_epochs
+
+    _test()
+    if sampler_type != "distributed":
+        _test(60)
+        _test(15)
+
+
+def test_resume_random_dataloader_from_epoch():
+    _test_resume_random_dataloader_from_epoch("cpu", setup_sampler)
+    _test_resume_random_dataloader_from_epoch("cpu", setup_sampler, sampler_type="weighted")
+    _test_resume_random_dataloader_from_epoch("cpu", setup_sampler, sampler_type="distributed")
+
+
+class AugmentedData:
+    def __init__(self, data, enabled=True):
+        self.data = data
+        self.enabled = enabled
+
+    def __getitem__(self, i):
+        dp = self.data[i]
+        r = torch.randint_like(dp, -100, 100) if self.enabled else 0.0
+        return dp + r * 0.01
+
+    def __len__(self):
+        return len(self.data)
+
+
+def _test_resume_random_dataloader_from_iter(device, _setup_sampler, sampler_type=None):
+    def _test(epoch_length=None):
+        max_epochs = 3
+        batch_size = 4
+        num_iters = 17
+        torch.manual_seed(0)
+        data = torch.randint(0, 1000, size=(num_iters * batch_size,))
+
+        if epoch_length is None:
+            epoch_length = num_iters
+
+        for resume_iteration in range(2, min(num_iters * max_epochs, epoch_length * max_epochs), 7):
+
+            for num_workers in [0, 4]:
+
+                sampler = _setup_sampler(sampler_type, num_iters, batch_size)
+                orig_dataloader = torch.utils.data.DataLoader(
+                    data,
+                    batch_size=batch_size,
+                    num_workers=num_workers,
+                    pin_memory="cuda" in device,
+                    sampler=sampler,
+                    drop_last=True,
+                    shuffle=sampler is None,
+                )
+                seen_batchs = []
+
+                def update_fn(engine, batch):
+                    batch_to_device = batch.to(device)
+                    seen_batchs.append(batch)
+
+                engine = DeterministicEngine(update_fn)
+
+                if sampler_type == "distributed":
+
+                    @engine.on(Events.EPOCH_STARTED)
+                    def _(engine):
+                        sampler.set_epoch(engine.state.epoch)
+
+                torch.manual_seed(12)
+                engine.run(
+                    orig_dataloader, max_epochs=max_epochs, epoch_length=epoch_length,
+                )
+
+                batch_checker = BatchChecker(seen_batchs, init_counter=resume_iteration)
+
+                sampler = _setup_sampler(sampler_type, num_iters, batch_size)
+                resume_dataloader = torch.utils.data.DataLoader(
+                    data,
+                    batch_size=batch_size,
+                    num_workers=num_workers,
+                    pin_memory="cuda" in device,
+                    sampler=sampler,
+                    drop_last=True,
+                    shuffle=sampler is None,
+                )
+
+                def update_fn(engine, batch):
+                    batch_to_device = batch.to(device)
+                    assert batch_checker.check(batch), "{} {} | {}: {} vs {}".format(
+                        num_workers, resume_iteration, batch_checker.counter, batch_checker.true_batch, batch
+                    )
+
+                engine = DeterministicEngine(update_fn)
+
+                if sampler_type == "distributed":
+
+                    @engine.on(Events.EPOCH_STARTED)
+                    def _(engine):
+                        sampler.set_epoch(engine.state.epoch)
+
+                resume_state_dict = dict(
+                    iteration=resume_iteration, max_epochs=max_epochs, epoch_length=epoch_length, rng_states=None
+                )
+                engine.load_state_dict(resume_state_dict)
+                torch.manual_seed(12)
+                engine.run(resume_dataloader)
+                assert engine.state.epoch == max_epochs
+                assert engine.state.iteration == epoch_length * max_epochs, "{}, {} | {} vs {}".format(
+                    num_workers, resume_iteration, engine.state.iteration, epoch_length * max_epochs
+                )
+
+    _test()
+    if sampler_type != "distributed":
+        _test(40)
+        _test(11)
+
+
+def test_resume_random_dataloader_from_iter():
+    _test_resume_random_dataloader_from_iter("cpu", setup_sampler)
+    _test_resume_random_dataloader_from_iter("cpu", setup_sampler, sampler_type="weighted")
+    _test_resume_random_dataloader_from_iter("cpu", setup_sampler, sampler_type="distributed")
+
+
+def _test_resume_random_data_iterator_from_epoch(device):
+    def _test(epoch_length=None):
+        max_epochs = 5
+        batch_size = 4
+        num_iters = 21
+
+        def infinite_data_iterator():
+            while True:
+                for _ in range(num_iters):
+                    data = torch.randint(0, 1000, size=(batch_size,), device=device)
+                    yield data
+
+        if epoch_length is None:
+            epoch_length = num_iters
+
+        for resume_epoch in range(1, max_epochs):
+            seen_batchs = []
+
+            def update_fn(engine, batch):
+                # if there is a random op when using data batch etc, we can not resume correctly
+                # torch.rand(1)
+                seen_batchs.append(batch)
+
+            engine = DeterministicEngine(update_fn)
+            torch.manual_seed(121)
+            engine.run(
+                infinite_data_iterator(), max_epochs=max_epochs, epoch_length=epoch_length,
+            )
+
+            batch_checker = BatchChecker(seen_batchs, init_counter=resume_epoch * epoch_length)
+
+            def update_fn(engine, batch):
+                assert batch_checker.check(batch), "{} | {}: {} vs {}".format(
+                    resume_epoch, batch_checker.counter, batch_checker.true_batch, batch
+                )
+
+            engine = DeterministicEngine(update_fn)
+
+            resume_state_dict = dict(
+                epoch=resume_epoch, max_epochs=max_epochs, epoch_length=epoch_length, rng_states=None
+            )
+            engine.load_state_dict(resume_state_dict)
+            torch.manual_seed(121)
+            engine.run(infinite_data_iterator())
+            assert engine.state.epoch == max_epochs
+            assert engine.state.iteration == epoch_length * max_epochs
+
+    _test()
+    _test(60)
+    _test(15)
+
+
+def test_resume_random_data_iterator_from_epoch():
+    _test_resume_random_data_iterator_from_epoch("cpu")
+
+
+def _test_resume_random_data_iterator_from_iter(device):
+    def _test(epoch_length=None):
+        max_epochs = 3
+        batch_size = 4
+        num_iters = 17
+
+        def infinite_data_iterator():
+            while True:
+                for _ in range(num_iters):
+                    data = torch.randint(0, 1000, size=(batch_size,), device=device)
+                    yield data
+
+        if epoch_length is None:
+            epoch_length = num_iters
+
+        for resume_iteration in range(1, min(num_iters * max_epochs, epoch_length * max_epochs), 7):
+
+            seen_batchs = []
+
+            def update_fn(engine, batch):
+                seen_batchs.append(batch)
+
+            engine = DeterministicEngine(update_fn)
+
+            torch.manual_seed(24)
+            engine.run(
+                infinite_data_iterator(), max_epochs=max_epochs, epoch_length=epoch_length,
+            )
+
+            batch_checker = BatchChecker(seen_batchs, init_counter=resume_iteration)
+
+            def update_fn(engine, batch):
+                assert batch_checker.check(batch), "{} | {}: {} vs {}".format(
+                    resume_iteration, batch_checker.counter, batch_checker.true_batch, batch
+                )
+
+            engine = DeterministicEngine(update_fn)
+
+            resume_state_dict = dict(
+                iteration=resume_iteration, max_epochs=max_epochs, epoch_length=epoch_length, rng_states=None
+            )
+            engine.load_state_dict(resume_state_dict)
+            torch.manual_seed(24)
+            engine.run(infinite_data_iterator())
+            assert engine.state.epoch == max_epochs
+            assert engine.state.iteration == epoch_length * max_epochs, "{} | {} vs {}".format(
+                resume_iteration, engine.state.iteration, epoch_length * max_epochs
+            )
+
+    _test()
+    _test(50)
+    _test(11)
+
+
+def test_resume_random_data_iterator_from_iter():
+    _test_resume_random_data_iterator_from_iter("cpu")
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_gpu(distributed_context_single_node_nccl, setup_sampler):
+    device = "cuda:{}".format(distributed_context_single_node_nccl["local_rank"])
+    _test_resume_random_data_iterator_from_iter(device)
+    _test_resume_random_data_iterator_from_epoch(device)
+    _test_resume_random_dataloader_from_iter(device, setup_sampler)
+    _test_resume_random_dataloader_from_epoch(device, setup_sampler)
+
+
+@pytest.mark.distributed
+def test_distrib_cpu(distributed_context_single_node_gloo):
+    device = "cpu"
+    _test_resume_random_data_iterator_from_iter(device)
+    _test_resume_random_data_iterator_from_epoch(device)
+    _test_resume_random_dataloader_from_iter(device, setup_sampler)
+    _test_resume_random_dataloader_from_epoch(device, setup_sampler)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+    device = "cpu"
+    _test_resume_random_data_iterator_from_iter(device)
+    _test_resume_random_data_iterator_from_epoch(device)
+    _test_resume_random_dataloader_from_iter(device, setup_sampler)
+    _test_resume_random_dataloader_from_epoch(device, setup_sampler)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+    device = "cuda:{}".format(distributed_context_multi_node_nccl["local_rank"])
+    _test_resume_random_data_iterator_from_iter(device)
+    _test_resume_random_data_iterator_from_epoch(device)
+    _test_resume_random_dataloader_from_iter(device, setup_sampler)
+    _test_resume_random_dataloader_from_epoch(device, setup_sampler)
+
+
+def test_concepts_snippet_resume():
+
+    import torch
+    from torch.utils.data import DataLoader
+    from ignite.engine import DeterministicEngine, Events
+    from ignite.utils import manual_seed
+
+    seen_batches = []
+    manual_seed(seed=15)
+
+    def random_train_data_loader(size):
+        data = torch.arange(0, size)
+        return DataLoader(data, batch_size=4, shuffle=True)
+
+    def print_train_data(engine, batch):
+        i = engine.state.iteration
+        e = engine.state.epoch
+        print("train", e, i, batch.tolist())
+        seen_batches.append(batch)
+
+    trainer = DeterministicEngine(print_train_data)
+
+    print("Original Run")
+    manual_seed(56)
+    trainer.run(random_train_data_loader(40), max_epochs=2, epoch_length=5)
+
+    original_batches = list(seen_batches)
+    seen_batches = []
+
+    print("Resumed Run")
+    trainer.load_state_dict({"epoch": 1, "epoch_length": 5, "max_epochs": 2, "rng_states": None})
+    manual_seed(56)
+    trainer.run(random_train_data_loader(40))
+
+    resumed_batches = list(seen_batches)
+    seen_batches = []
+    for b1, b2 in zip(original_batches[5:], resumed_batches):
+        assert (b1 == b2).all()
+
+
+def test_concepts_snippet_warning():
+    def random_train_data_generator():
+        while True:
+            yield torch.randint(0, 100, size=(1,))
+
+    def print_train_data(engine, batch):
+        i = engine.state.iteration
+        e = engine.state.epoch
+        print("train", e, i, batch.tolist())
+
+    trainer = DeterministicEngine(print_train_data)
+
+    @trainer.on(Events.ITERATION_COMPLETED(every=3))
+    def user_handler(_):
+        # handler synchronizes the random state
+        torch.manual_seed(12)
+        a = torch.rand(1)
+
+    trainer.run(random_train_data_generator(), max_epochs=3, epoch_length=5)
+
+
+def _test_gradients_on_resume(dirname, device, with_dropout=True, with_dataaugs=True):
+
+    debug = False
+
+    from torch.utils.data import DataLoader
+    from torch.optim import SGD
+
+    def random_train_data_loader(size):
+        d = AugmentedData(torch.rand(size, 3, 32, 32), enabled=with_dataaugs)
+        return DataLoader(d, batch_size=4, shuffle=True, num_workers=4)
+
+    def _train(save_iter, sd=None):
+        w_norms = []
+        grad_norms = []
+        data = []
+        chkpt = []
+
+        manual_seed(12)
+        arch = [
+            nn.Conv2d(3, 10, 3),
+            nn.ReLU(),
+            nn.Conv2d(10, 10, 3),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool2d(1),
+            nn.Flatten(),
+            nn.Linear(10, 5),
+            nn.ReLU(),
+            nn.Linear(5, 2),
+        ]
+        if with_dropout:
+            arch.insert(2, nn.Dropout2d())
+            arch.insert(-2, nn.Dropout())
+
+        model = nn.Sequential(*arch).to(device)
+        opt = SGD(model.parameters(), lr=0.001)
+
+        def proc_fn(e, b):
+            from ignite.engine.deterministic import _repr_rng_state, _get_rng_states
+
+            s = _repr_rng_state(_get_rng_states())
+            model.train()
+            opt.zero_grad()
+            y = model(b.to(device))
+            y.sum().backward()
+            opt.step()
+            if debug:
+                print(
+                    trainer.state.iteration, trainer.state.epoch, "proc_fn - b.shape", b.shape, torch.norm(y).item(), s
+                )
+
+        trainer = DeterministicEngine(proc_fn)
+
+        @trainer.on(Events.ITERATION_COMPLETED(once=save_iter))
+        def save_chkpt(_):
+            if debug:
+                print(trainer.state.iteration, "save_chkpt")
+            fp = os.path.join(dirname, "test.pt")
+            from ignite.engine.deterministic import _repr_rng_state
+
+            tsd = trainer.state_dict()
+            if debug:
+                print("->", _repr_rng_state(tsd["rng_states"]))
+            torch.save([model.state_dict(), opt.state_dict(), tsd], fp)
+            chkpt.append(fp)
+
+        def log_event_filter(_, event):
+            if (event // save_iter == 1) and 1 <= (event % save_iter) <= 5:
+                return True
+            return False
+
+        @trainer.on(Events.ITERATION_COMPLETED(event_filter=log_event_filter))
+        def write_data_grads_weights(e):
+            x = e.state.batch
+            i = e.state.iteration
+            data.append([i, x.mean().item(), x.std().item()])
+
+            total = [0.0, 0.0]
+            out1 = []
+            out2 = []
+            for p in model.parameters():
+                n1 = torch.norm(p).item()
+                n2 = torch.norm(p.grad).item()
+                out1.append(n1)
+                out2.append(n2)
+                total[0] += n1
+                total[1] += n2
+            w_norms.append([i, total[0]] + out1)
+            grad_norms.append([i, total[1]] + out2)
+
+        if sd is not None:
+            sd = torch.load(sd)
+            model.load_state_dict(sd[0])
+            opt.load_state_dict(sd[1])
+            from ignite.engine.deterministic import _repr_rng_state
+
+            if debug:
+                print("-->", _repr_rng_state(sd[2]["rng_states"]))
+            trainer.load_state_dict(sd[2])
+
+        manual_seed(32)
+        trainer.run(random_train_data_loader(size=24), max_epochs=5)
+        return {"sd": chkpt, "data": data, "grads": grad_norms, "weights": w_norms}
+
+    save_iter = 25
+    out_original = _train(save_iter=save_iter)
+    assert len(out_original["sd"]) > 0
+
+    out_resumed = _train(save_iter=save_iter, sd=out_original["sd"][0])
+
+    if debug:
+        print("Original:")
+        print(" data:", out_original["data"])
+        print("grads:", out_original["grads"])
+        print("    W:", out_original["weights"])
+        print("Resume:")
+        print(" data:", out_resumed["data"])
+        print("grads:", out_resumed["grads"])
+        print("    W:", out_resumed["weights"])
+
+    # check data:
+    for d1, d2 in zip(out_original["data"], out_resumed["data"]):
+        assert d1 == d2
+
+    # check grads:
+    for d1, d2 in zip(out_original["grads"], out_resumed["grads"]):
+        assert d1 == d2
+
+    # check weights:
+    for d1, d2 in zip(out_original["weights"], out_resumed["weights"]):
+        assert d1 == d2
+
+
+def test_gradients_on_resume_cpu(dirname):
+    with pytest.raises(AssertionError):
+        _test_gradients_on_resume(dirname, "cpu", with_dataaugs=True)
+    _test_gradients_on_resume(dirname, "cpu", with_dataaugs=False)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU")
+def test_gradients_on_resume_gpu(dirname):
+    with pytest.raises(AssertionError):
+        _test_gradients_on_resume(dirname, "cuda", with_dataaugs=True)
+    _test_gradients_on_resume(dirname, "cuda", with_dataaugs=False)


### PR DESCRIPTION
Description:
PR (2/3) to that splits #895

- Idea is to keep approximatively backward-compat with v0.3.0: `Engine` -> `DeterministicEngine`
 
```python

    import torch
    from torch.utils.data import DataLoader
    from ignite.engine import DeterministicEngine, Events
    from ignite.utils import manual_seed


    def random_train_data_loader(size):
        data = torch.arange(0, size)
        return DataLoader(data, batch_size=4, shuffle=True)


    def print_train_data(engine, batch):
        i = engine.state.iteration
        e = engine.state.epoch
        print("train", e, i, batch.tolist())

    trainer = DeterministicEngine(print_train_data)

    print("Original Run")
    manual_seed(56)
    trainer.run(random_train_data_loader(40), max_epochs=2, epoch_length=5)

    print("Resumed Run")
    # Resume from 2nd epoch
    trainer.load_state_dict({"epoch": 1, "epoch_length": 5, "max_epochs": 2, "rng_states": None})
    manual_seed(56)
    trainer.run(random_train_data_loader(40))
```

Features on `DeterministicEngine`:
- Without dataaugs we can resume data, model weights, grads from iteration:
https://github.com/pytorch/ignite/pull/939/files#diff-d2f3986fdbdae7609cc4b65420fbb275R788




Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
