### PR TITLE
#920 Fix doc for lr_finder

### DIFF
--- a/docs/source/contrib/handlers.rst
+++ b/docs/source/contrib/handlers.rst
@@ -20,6 +20,7 @@ lr_finder
 ---------
 
 .. automodule:: ignite.contrib.handlers.lr_finder
+   :members:
 
 
 time_profilers


### PR DESCRIPTION
Fixes #920 

Description:

Missing `:members:`

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
