### PR TITLE
add time in state.

### DIFF
--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -101,8 +101,9 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
 
     @trainer.on(Events.EPOCH_COMPLETED | Events.COMPLETED)
     def log_time(engine):
-        tqdm.write("{} took {} seconds"
-                   .format(trainer.last_event_name.name, trainer.state.times[trainer.last_event_name.name]))
+        tqdm.write(
+            "{} took {} seconds".format(trainer.last_event_name.name, trainer.state.times[trainer.last_event_name.name])
+        )
 
     trainer.run(train_loader, max_epochs=epochs)
     pbar.close()

--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -99,6 +99,10 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
 
         pbar.n = pbar.last_print_n = 0
 
+    @trainer.on(Events.EPOCH_COMPLETED | Events.COMPLETED)
+    def log_time(engine):
+        tqdm.write(f"{trainer.last_event_name.name} took {trainer.state.times[trainer.last_event_name.name]} seconds")
+
     trainer.run(train_loader, max_epochs=epochs)
     pbar.close()
 

--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -101,7 +101,8 @@ def run(train_batch_size, val_batch_size, epochs, lr, momentum, log_interval):
 
     @trainer.on(Events.EPOCH_COMPLETED | Events.COMPLETED)
     def log_time(engine):
-        tqdm.write(f"{trainer.last_event_name.name} took {trainer.state.times[trainer.last_event_name.name]} seconds")
+        tqdm.write("{} took {} seconds"
+                   .format(trainer.last_event_name.name, trainer.state.times[trainer.last_event_name.name]))
 
     trainer.run(train_loader, max_epochs=epochs)
     pbar.close()

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -776,7 +776,7 @@ class Engine:
         le = self._dataloader_len if self._dataloader_len is not None else 1
         self._manual_seed(self.state.seed, self.state.iteration // le)
 
-    def _internal_run(self) -> State:        
+    def _internal_run(self) -> State:
         self.should_terminate = self.should_terminate_single_epoch = False
         self._init_timers(self.state)
         try:

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -616,7 +616,8 @@ class Engine:
 
         Engine has a state and the following logic is applied in this function:
 
-        - At the first call, new state is defined by `max_epochs`, `epoch_length`, `seed` if provided.
+        - At the first call, new state is defined by `max_epochs`, `epoch_length`, `seed` if provided. A timer for
+            total and per-epoch time is initialized when Events.STARTED is handled.
         - If state is already defined such that there are iterations to run until `max_epochs` and no input arguments
             provided, state is kept and used in the function.
         - If state is defined and engine is "done" (no iterations to run until `max_epochs`), a new state is defined.

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -685,7 +685,15 @@ class Engine:
             )
 
         self.state.dataloader = data
+        self.add_event_handler(Events.STARTED, self._init_timers)
         return self._internal_run()
+
+
+    @staticmethod
+    def _init_timers(engine: "Engine"):
+        engine.state.times[Events.EPOCH_COMPLETED.name] = 0.0
+        engine.state.times[Events.COMPLETED.name] = 0.0
+
 
     def _setup_engine(self) -> None:
 

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -686,13 +686,12 @@ class Engine:
             )
 
         self.state.dataloader = data
-        self.add_event_handler(Events.STARTED, self._init_timers)
         return self._internal_run()
 
     @staticmethod
-    def _init_timers(engine: "Engine"):
-        engine.state.times[Events.EPOCH_COMPLETED.name] = 0.0
-        engine.state.times[Events.COMPLETED.name] = 0.0
+    def _init_timers(state: State):
+        state.times[Events.EPOCH_COMPLETED.name] = 0.0
+        state.times[Events.COMPLETED.name] = 0.0
 
     def _setup_engine(self) -> None:
 
@@ -777,8 +776,9 @@ class Engine:
         le = self._dataloader_len if self._dataloader_len is not None else 1
         self._manual_seed(self.state.seed, self.state.iteration // le)
 
-    def _internal_run(self) -> State:
+    def _internal_run(self) -> State:        
         self.should_terminate = self.should_terminate_single_epoch = False
+        self._init_timers(self.state)
         try:
             start_time = time.time()
             self._fire_event(Events.STARTED)

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -12,6 +12,7 @@ import torch
 
 from ignite.engine.events import Events, State, CallableEventWithFilter, RemovableEventHandle, EventsList
 from ignite.engine.utils import ReproducibleBatchSampler, _update_dataloader, _check_signature
+from ignite._utils import _to_hours_mins_secs
 
 __all__ = ["Engine"]
 
@@ -783,13 +784,17 @@ class Engine:
 
                 time_taken = self._run_once_on_dataset()
                 self.state.times[Events.EPOCH_COMPLETED.name] = time_taken
+                hours, mins, secs = _to_hours_mins_secs(time_taken)
+                self.logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.state.epoch, hours, mins, secs)
                 if self.should_terminate:
                     break
                 self._fire_event(Events.EPOCH_COMPLETED)
 
             time_taken = time.time() - start_time
+            hours, mins, secs = _to_hours_mins_secs(time_taken)
             self.state.times[Events.COMPLETED.name] = time_taken
             self._fire_event(Events.COMPLETED)
+            self.logger.info("Engine run complete. Time taken %02d:%02d:%02d" % (hours, mins, secs))
 
         except BaseException as e:
             self._dataloader_iter = self._dataloader_len = None

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -688,12 +688,10 @@ class Engine:
         self.add_event_handler(Events.STARTED, self._init_timers)
         return self._internal_run()
 
-
     @staticmethod
     def _init_timers(engine: "Engine"):
         engine.state.times[Events.EPOCH_COMPLETED.name] = 0.0
         engine.state.times[Events.COMPLETED.name] = 0.0
-
 
     def _setup_engine(self) -> None:
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -246,6 +246,8 @@ class State:
         state.batch             # batch passed to `process_function`
         state.output            # output of `process_function` after a single iteration
         state.metrics           # dictionary with defined metrics if any
+        state.times             # dictionary with total and per-epoch times fetched on 
+                                # keys: Events.EPOCH_COMPLETED.name and Events.COMPLETED.name
 
     """
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -270,10 +270,7 @@ class State:
         self.metrics = {}
         self.dataloader = None
         self.seed = None
-        self.times = {
-            Events.EPOCH_COMPLETED.name: 0.0,
-            Events.COMPLETED.name: 0.0
-        }
+        self.times = {Events.EPOCH_COMPLETED.name: 0.0, Events.COMPLETED.name: 0.0}
 
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -246,7 +246,7 @@ class State:
         state.batch             # batch passed to `process_function`
         state.output            # output of `process_function` after a single iteration
         state.metrics           # dictionary with defined metrics if any
-        state.times             # dictionary with total and per-epoch times fetched on 
+        state.times             # dictionary with total and per-epoch times fetched on
                                 # keys: Events.EPOCH_COMPLETED.name and Events.COMPLETED.name
 
     """

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -270,6 +270,10 @@ class State:
         self.metrics = {}
         self.dataloader = None
         self.seed = None
+        self.times = {
+            Events.EPOCH_COMPLETED.name: 0.0,
+            Events.COMPLETED.name: 0.0
+        }
 
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -270,7 +270,7 @@ class State:
         self.metrics = {}
         self.dataloader = None
         self.seed = None
-        self.times = {Events.EPOCH_COMPLETED.name: 0.0, Events.COMPLETED.name: 0.0}
+        self.times = {Events.EPOCH_COMPLETED.name: None, Events.COMPLETED.name: None}
 
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -379,20 +379,14 @@ def test_time_stored_in_state():
         lower_bound_time = num_examples / epoch_length / max_epochs
         upper_bound_time = 1.1 * lower_bound_time
 
-        def init(engine):
-            engine.state.times = {Events.EPOCH_COMPLETED.name: 0.0, Events.COMPLETED.name: 0.0}
-
         def check_epoch_time(engine):
-            assert lower_bound_time < engine.state.times[Events.EPOCH_COMPLETED.name] < upper_bound_time
+            # TODO: can we make this test more meaningful?
+            assert engine.state.times[Events.EPOCH_COMPLETED.name] != 0
 
         def check_completed_time(engine):
-            assert (
-                max_epochs * lower_bound_time
-                < engine.state.times[Events.COMPLETED.name]
-                < max_epochs * upper_bound_time
-            )
+            # TODO: can we make this test more meaningful?
+            assert engine.state.times[Events.COMPLETED.name] != 0
 
-        engine.add_event_handler(Events.STARTED, lambda e: init(e))
         engine.add_event_handler(Events.EPOCH_COMPLETED, lambda e: check_epoch_time(e))
         engine.add_event_handler(Events.COMPLETED, lambda e: check_completed_time(e))
 

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -369,26 +369,21 @@ def test_state_get_event_attrib_value():
 
 def test_time_stored_in_state():
     def _test(data, max_epochs, epoch_length):
-
-        engine = Engine(lambda e, b: time.sleep(0.01))
-
-        num_examples = len(data)
-
-        engine.run(data, max_epochs=max_epochs, epoch_length=epoch_length)
-
-        lower_bound_time = num_examples / epoch_length / max_epochs
-        upper_bound_time = 1.1 * lower_bound_time
+        sleep_time = 0.01
+        engine = Engine(lambda e, b: time.sleep(sleep_time))
 
         def check_epoch_time(engine):
             # TODO: can we make this test more meaningful?
-            assert engine.state.times[Events.EPOCH_COMPLETED.name] != 0
+            assert engine.state.times[Events.EPOCH_COMPLETED.name] >= sleep_time * epoch_length
 
         def check_completed_time(engine):
             # TODO: can we make this test more meaningful?
-            assert engine.state.times[Events.COMPLETED.name] != 0
+            assert engine.state.times[Events.COMPLETED.name] >= sleep_time * epoch_length * max_epochs
 
         engine.add_event_handler(Events.EPOCH_COMPLETED, lambda e: check_epoch_time(e))
         engine.add_event_handler(Events.COMPLETED, lambda e: check_completed_time(e))
+
+        engine.run(data, max_epochs=max_epochs, epoch_length=epoch_length)
 
     _test(list(range(100)), max_epochs=2, epoch_length=100)
     _test(list(range(200)), max_epochs=2, epoch_length=100)

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -373,11 +373,9 @@ def test_time_stored_in_state():
         engine = Engine(lambda e, b: time.sleep(sleep_time))
 
         def check_epoch_time(engine):
-            # TODO: can we make this test more meaningful?
             assert engine.state.times[Events.EPOCH_COMPLETED.name] >= sleep_time * epoch_length
 
         def check_completed_time(engine):
-            # TODO: can we make this test more meaningful?
             assert engine.state.times[Events.COMPLETED.name] >= sleep_time * epoch_length * max_epochs
 
         engine.add_event_handler(Events.EPOCH_COMPLETED, lambda e: check_epoch_time(e))

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -380,17 +380,17 @@ def test_time_stored_in_state():
         upper_bound_time = 1.1 * lower_bound_time
 
         def init(engine):
-            engine.state.times = {
-                Events.EPOCH_COMPLETED.name: 0.0,
-                Events.COMPLETED.name: 0.0
-            }
+            engine.state.times = {Events.EPOCH_COMPLETED.name: 0.0, Events.COMPLETED.name: 0.0}
 
         def check_epoch_time(engine):
             assert lower_bound_time < engine.state.times[Events.EPOCH_COMPLETED.name] < upper_bound_time
 
         def check_completed_time(engine):
-            assert max_epochs * lower_bound_time < engine.state.times[
-                Events.COMPLETED.name] < max_epochs * upper_bound_time
+            assert (
+                max_epochs * lower_bound_time
+                < engine.state.times[Events.COMPLETED.name]
+                < max_epochs * upper_bound_time
+            )
 
         engine.add_event_handler(Events.STARTED, lambda e: init(e))
         engine.add_event_handler(Events.EPOCH_COMPLETED, lambda e: check_epoch_time(e))
@@ -399,6 +399,7 @@ def test_time_stored_in_state():
     _test(list(range(100)), max_epochs=2, epoch_length=100)
     _test(list(range(200)), max_epochs=2, epoch_length=100)
     _test(list(range(200)), max_epochs=5, epoch_length=100)
+
 
 def _test_run_check_triggered_events():
     def _test(data, max_epochs, epoch_length):


### PR DESCRIPTION
Fixes #916

Description: Adds timing info for epoch completion and run completion to the engine's state.


Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)

I'm feeling a bit sketchy about the tests, so I'd love another pair of eyes on them.