### PR TITLE
Improve setup_logger for multiple calls

### DIFF
--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -65,7 +65,7 @@ def setup_logger(
     level: int = logging.INFO,
     format: str = "%(asctime)s %(name)s %(levelname)s: %(message)s",
     filepath: Optional[str] = None,
-    distributed_rank: int = None,
+    distributed_rank: Optional[int] = None,
 ) -> logging.Logger:
     """Setups logger: name, level, format etc.
 

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -61,7 +61,7 @@ def to_onehot(indices: torch.Tensor, num_classes: int) -> torch.Tensor:
 
 
 def setup_logger(
-    name: str = None,
+    name: Optional[str] = None,
     level: int = logging.INFO,
     format: str = "%(asctime)s %(name)s %(levelname)s: %(message)s",
     filepath: Optional[str] = None,
@@ -70,11 +70,12 @@ def setup_logger(
     """Setups logger: name, level, format etc.
 
     Args:
-        name (str): new name for the logger. If None, the standard logger is used.
+        name (str, optional): new name for the logger. If None, the standard logger is used.
         level (int): logging level, e.g. CRITICAL, ERROR, WARNING, INFO, DEBUG
         format (str): logging format. By default, `%(asctime)s %(name)s %(levelname)s: %(message)s`
         filepath (str, optional): Optional logging file path. If not None, logs are written to the file.
         distributed_rank (int, optional): Optional, rank in distributed configuration to avoid logger setup for workers.
+        If None, distributed_rank is initialized to the rank of process.
 
     Returns:
         logging.Logger

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -61,16 +61,16 @@ def to_onehot(indices: torch.Tensor, num_classes: int) -> torch.Tensor:
 
 
 def setup_logger(
-    name: str,
+    name: str = None,
     level: int = logging.INFO,
     format: str = "%(asctime)s %(name)s %(levelname)s: %(message)s",
     filepath: Optional[str] = None,
-    distributed_rank: int = 0,
+    distributed_rank: int = None,
 ) -> logging.Logger:
     """Setups logger: name, level, format etc.
 
     Args:
-        name (str): new name for the logger.
+        name (str): new name for the logger. If None, the standard logger is used.
         level (int): logging level, e.g. CRITICAL, ERROR, WARNING, INFO, DEBUG
         format (str): logging format. By default, `%(asctime)s %(name)s %(levelname)s: %(message)s`
         filepath (str, optional): Optional logging file path. If not None, logs are written to the file.
@@ -109,6 +109,12 @@ def setup_logger(
             logger.removeHandler(h)
 
     formatter = logging.Formatter(format)
+
+    if distributed_rank is None:
+        if dist.is_available() and dist.is_initialized():
+            distributed_rank = dist.get_rank()
+        else:
+            distributed_rank = 0
 
     if distributed_rank > 0:
         logger.addHandler(logging.NullHandler())

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -60,11 +60,6 @@ def to_onehot(indices: torch.Tensor, num_classes: int) -> torch.Tensor:
     return onehot.scatter_(1, indices.unsqueeze(1), 1)
 
 
-class _NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-
-
 def setup_logger(
     name: str,
     level: int = logging.INFO,
@@ -116,7 +111,7 @@ def setup_logger(
     formatter = logging.Formatter(format)
 
     if distributed_rank > 0:
-        logger.addHandler(_NullHandler())
+        logger.addHandler(logging.NullHandler())
     else:
         logger.setLevel(level)
 


### PR DESCRIPTION
Related to #705 and #712 

Description:

Improve `setup_logger` for multiple calls in distributed context 

```python
setup_logger(name=None)

logging.info(...) # all processes print the msg

init_process_group(...)

setup_logger(name=None, distributed_rank=dist.get_rank())

logging.info(...) # master proc 0 prints the msg
```

Check list:
* [ ] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
