### PR TITLE
Issue 974 : add barriers after init_process_group

### DIFF
--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -150,4 +150,3 @@ def distributed_context_multi_node_nccl(multi_node_conf):
     dist.barrier()
 
     dist.destroy_process_group()
-

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -41,6 +41,9 @@ def distributed_context_single_node_nccl(local_rank):
     }
 
     dist.init_process_group(**dist_info)
+
+    dist.barrier()
+
     torch.cuda.device(local_rank)
 
     yield {"local_rank": local_rank}
@@ -66,6 +69,8 @@ def distributed_context_single_node_gloo(local_rank):
     }
 
     dist.init_process_group(**dist_info)
+
+    dist.barrier()
 
     yield {"local_rank": local_rank}
 
@@ -110,6 +115,8 @@ def distributed_context_multi_node_gloo(multi_node_conf):
 
     dist.init_process_group(**dist_info)
 
+    dist.barrier()
+
     yield multi_node_conf
 
     dist.barrier()
@@ -133,6 +140,9 @@ def distributed_context_multi_node_nccl(multi_node_conf):
     }
 
     dist.init_process_group(**dist_info)
+
+    dist.barrier()
+
     torch.cuda.device(multi_node_conf["local_rank"])
 
     yield multi_node_conf

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -150,3 +150,4 @@ def distributed_context_multi_node_nccl(multi_node_conf):
     dist.barrier()
 
     dist.destroy_process_group()
+


### PR DESCRIPTION
Fixes #974 

Description:

Add `dist.barrier()` after `init_process_group`. Hope that helps CI !

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
