### PR TITLE
disable propagation of loggers to ancestrors

### DIFF
--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -105,6 +105,12 @@ def setup_logger(
     """
     logger = logging.getLogger(name)
 
+    # don't propagate to ancestors
+    # the problem here is to attach handlers to loggers
+    # should we provide a default configuration less open ?
+    if name is not None:
+        logger.propagate = False
+
     # Remove previous handlers
     if logger.hasHandlers():
         for h in list(logger.handlers):


### PR DESCRIPTION
Fixes #1012 

Description:

Disable propagation of loggers to ancestrors
```python
# logger without propagation
logger = setup_logger("logger")
logger.info("message 1 from test logger") 

# logging creates root ancestor of all loggers excluded one above 
logging.info("message from default logging, a root logger is defined !")

# only logger dump because no longer propagation
logger.info("message 2 from test logger")
```
Result is
```
> 2020-05-05 09:24:27,583 logger INFO: message 1 from test logger
> 2020-05-05 09:24:27,583 logger INFO: message 2 from test logger
```


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
