### PR TITLE
Fix frequency tests

### DIFF
--- a/tests/ignite/metrics/test_frequency.py
+++ b/tests/ignite/metrics/test_frequency.py
@@ -21,9 +21,9 @@ def test_nondistributed_average():
     assert average_lower_bound < average < average_upper_bound
 
 
-def _test_frequency_with_engine(device, workers, every=1):
+def _test_frequency_with_engine(device, workers, lower_bound_factor=0.8, every=1):
 
-    artificial_time = 0.1 / workers  # seconds
+    artificial_time = 1.0 / workers  # seconds
     total_tokens = 1200 // workers
     batch_size = 128 // workers
 
@@ -41,8 +41,8 @@ def _test_frequency_with_engine(device, workers, every=1):
     @engine.on(event)
     def assert_wps(e):
         wps = e.state.metrics["wps"]
-        assert estimated_wps * 0.80 < wps < estimated_wps, "{}: {} < {} < {}".format(
-            e.state.iteration, estimated_wps * 0.80, wps, estimated_wps
+        assert estimated_wps * lower_bound_factor < wps < estimated_wps, "{}: {} < {} < {}".format(
+            e.state.iteration, estimated_wps * lower_bound_factor, wps, estimated_wps
         )
 
     data = [[i] * batch_size for i in range(0, total_tokens, batch_size)]


### PR DESCRIPTION
Fixes #1017

Description: because the sleeps in the frequency tests are so short, any issues that cause a delay become effectively extra sleeps. Since we compute expected times in terms of expected total sleep time, that makes it a very sensitive factor. This test increases the sleep times to make them slightly more robust.


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
