### PR TITLE
Fixes #1022

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ ignore = E402, E721
 max_line_length = 120
 
 [isort]
-known_third_party=matplotlib,numpy,pytest,setuptools,sklearn,torch
+known_third_party=dill,matplotlib,numpy,pytest,setuptools,sklearn,torch,trains
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/ignite/contrib/handlers/test_trains_logger.py
+++ b/tests/ignite/contrib/handlers/test_trains_logger.py
@@ -3,8 +3,8 @@ from unittest.mock import ANY, MagicMock, call
 
 import pytest
 import torch
-
 import trains
+
 from ignite.contrib.handlers.trains_logger import *
 from ignite.engine import Engine, Events, State
 from ignite.handlers import Checkpoint

--- a/tests/ignite/metrics/test_dill.py
+++ b/tests/ignite/metrics/test_dill.py
@@ -1,4 +1,5 @@
 import dill
+
 from ignite.metrics import Metric
 
 


### PR DESCRIPTION
Fixes #1022 

Description:
- Fixes usage of `_dataset_kind` attribute of dataloader introduced since pytorch v1.3.0
- minor fixes:
-> use `from torch.utils.data import DataLoader`
-> use `from torch.utils.data.sampler import BatchSampler`
--> why ? to fix compatibility with pytorch<1.3.0 : https://github.com/pytorch/ignite/actions/runs/100264859
- updated setup.cfg known 3rd parties


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
