### PR TITLE
Re-added missing tests on GPU

### DIFF
--- a/tests/ignite/contrib/metrics/test_gpu_info.py
+++ b/tests/ignite/contrib/metrics/test_gpu_info.py
@@ -76,7 +76,7 @@ def _test_gpu_info(device="cpu"):
 
 
 @pytest.mark.skipif(python_below_36 or not (torch.cuda.is_available()), reason="No pynvml for python < 3.6 and no GPU")
-def test_gpu_info():
+def test_gpu_info_on_cuda():
     _test_gpu_info(device="cuda")
 
 

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -800,13 +800,14 @@ def test_gradients_on_resume_cpu(dirname):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU")
-def test_gradients_on_resume_gpu(dirname):
+def test_gradients_on_resume_on_cuda(dirname):
     with pytest.raises(AssertionError):
-        _test_gradients_on_resume(dirname, "cuda", with_dataaugs=True)
-    _test_gradients_on_resume(dirname, "cuda", with_dataaugs=False)
+        _test_gradients_on_resume(dirname, "cuda", with_dataaugs=True, save_iter=25)
+    with pytest.raises(AssertionError):
+        _test_gradients_on_resume(dirname, "cuda", with_dataaugs=False, save_iter=25)
     # resume from epoch
-    _test_gradients_on_resume(dirname, "cuda", with_dataaugs=True, save_iter=30)
-    _test_gradients_on_resume(dirname, "cuda", with_dataaugs=False, save_iter=30)
+    _test_gradients_on_resume(dirname, "cuda", with_dataaugs=True, save_epoch=3)
+    _test_gradients_on_resume(dirname, "cuda", with_dataaugs=False, save_epoch=3)
 
 
 def test_engine_with_dataloader_no_auto_batching():


### PR DESCRIPTION
Description:
- Re-added missing tests on GPU

Context:
Single GPU tests are run with the command
```
 py.test -vvv tests/ -k on_cuda
```
and this tests do not contain the keyword `on_cuda`. 
If we add tests with `-k _gpu` we will get all `distrib_gpu` tests...


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
