### PR TITLE
Remove TrainsLogger histogram frequency args from logger interface

### DIFF
--- a/ignite/contrib/handlers/trains_logger.py
+++ b/ignite/contrib/handlers/trains_logger.py
@@ -403,11 +403,6 @@ class TrainsLogger(BaseLogger):
             - ``TaskTypes.train``
             - ``TaskTypes.testing``
             - ``TaskTypes.inference``
-        report_freq (int): Optional. Histogram processing frequency (handle hist values every X calls to the handler).
-           Affects ``GradsHistHandler`` and ``WeightsHistHandler``. Default value is 100.
-        histogram_update_freq_multiplier (int): Optional. Histogram report frequency (report first X histograms and
-           once every X reports afterwards). Default value is 10.
-        histogram_granularity (int): Optional. Histogram sampling granularity. Default is 50.
 
     Examples:
 
@@ -475,9 +470,6 @@ class TrainsLogger(BaseLogger):
                 "project_name",
                 "task_name",
                 "task_type",
-                "report_freq",
-                "histogram_update_freq_multiplier",
-                "histogram_granularity",
             )
         }
 
@@ -509,9 +501,6 @@ class TrainsLogger(BaseLogger):
 
         self.grad_helper = trains.binding.frameworks.tensorflow_bind.WeightsGradientHistHelper(
             logger=self.trains_logger,
-            report_freq=kwargs.get("report_freq", 100),
-            histogram_update_freq_multiplier=kwargs.get("histogram_update_freq_multiplier", 10),
-            histogram_granularity=kwargs.get("histogram_granularity", 50),
         )
 
     @classmethod

--- a/ignite/contrib/handlers/trains_logger.py
+++ b/ignite/contrib/handlers/trains_logger.py
@@ -462,16 +462,7 @@ class TrainsLogger(BaseLogger):
                 "You may install trains using: \n pip install trains \n"
             )
 
-        experiment_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if k
-            not in (
-                "project_name",
-                "task_name",
-                "task_type",
-            )
-        }
+        experiment_kwargs = {k: v for k, v in kwargs.items() if k not in ("project_name", "task_name", "task_type",)}
 
         if self.bypass_mode():
             warnings.warn("TrainsSaver: running in bypass mode")


### PR DESCRIPTION
Description:
A fix to the original PR - remove redundant histogram frequency-related arguments from the logger interface and documentation.

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
