### PR TITLE
Reduced exec time of frequency tests

### DIFF
--- a/tests/ignite/metrics/test_frequency.py
+++ b/tests/ignite/metrics/test_frequency.py
@@ -23,7 +23,7 @@ def test_nondistributed_average():
 def _test_frequency_with_engine(device, workers, lower_bound_factor=0.8, every=1):
 
     artificial_time = 1.0 / workers  # seconds
-    total_tokens = 1200 // workers
+    total_tokens = 400 // workers
     batch_size = 128 // workers
 
     estimated_wps = batch_size * workers / artificial_time


### PR DESCRIPTION
Description:
- Reduced exec time of frequency tests

Test of Frequency `test_frequency_with_engine_*` take a lot of time, around 61.41s
This PR reduces `total_tokens = 1200 // workers` -> `total_tokens = 400 // workers`
Hope it does make tests flaky again...

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
