### PR TITLE
Improved device and setup_common_training_handlers

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -83,12 +83,11 @@ def setup_common_training_handlers(
         log_every_iters=log_every_iters,
         stop_on_nan=stop_on_nan,
     )
-    from ignite.distributed.utils import _SerialModel
 
-    if idist.model_name() != _SerialModel.name:
+    if idist.get_world_size() > 1:
         _setup_common_distrib_training_handlers(trainer, train_sampler=train_sampler, **kwargs)
     else:
-        if train_sampler is not None:
+        if train_sampler is not None and hasattr(train_sampler, "set_epoch"):
             warnings.warn(
                 "Argument train_sampler distributed sampler used to call `set_epoch` method on epoch "
                 "started event, but no distributed setting detected",

--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -144,6 +144,8 @@ class _SerialModel(ComputationModel):
         return 0
 
     def device(self) -> torch.device:
+        if torch.cuda.is_available():
+            return torch.device("cuda")
         return torch.device("cpu")
 
     def backend(self) -> None:

--- a/tests/ignite/distributed/comp_models/test_base.py
+++ b/tests/ignite/distributed/comp_models/test_base.py
@@ -14,7 +14,10 @@ def test_serial_model():
     assert model.get_ntasks_per_node() == 1
     assert model.get_num_nodes() == 1
     assert model.get_node_rank() == 0
-    assert model.device() == torch.device("cpu")
+    if torch.cuda.is_available():
+        assert model.device().type == "cuda"
+    else:
+        assert model.device().type == "cpu"
     assert model.backend() is None
     model.finalize()
 

--- a/tests/ignite/distributed/test_utils.py
+++ b/tests/ignite/distributed/test_utils.py
@@ -26,7 +26,10 @@ def test_no_distrib(capsys):
     print("test_no_distrib : _model", type(_model))
 
     assert idist.backend() is None
-    assert idist.device().type == "cpu"
+    if torch.cuda.is_available():
+        assert idist.device().type == "cuda"
+    else:
+        assert idist.device().type == "cpu"
     assert idist.get_rank() == 0
     assert idist.get_world_size() == 1
     assert idist.get_local_rank() == 0
@@ -44,7 +47,10 @@ def test_no_distrib(capsys):
     out = list(filter(None, out))
     assert "ignite.distributed.utils INFO: distributed configuration: serial" in out[-1]
     assert "ignite.distributed.utils INFO: backend: None" in out[-1]
-    assert "ignite.distributed.utils INFO: device: cpu" in out[-1]
+    if torch.cuda.is_available():
+        assert "ignite.distributed.utils INFO: device: cuda" in out[-1]
+    else:
+        assert "ignite.distributed.utils INFO: device: cpu" in out[-1]
     assert "ignite.distributed.utils INFO: rank: 0" in out[-1]
     assert "ignite.distributed.utils INFO: local rank: 0" in out[-1]
     assert "ignite.distributed.utils INFO: world size: 1" in out[-1]


### PR DESCRIPTION
Description:

- idist.device() returns "torch.device('cuda')" if non-dist conf and cuda device is available
- Improved setup_common_training_handlers
    - no need to handle train_sampler if idist.model_name() is not serial, but train_sampler is not setup as distributed due to 1 proc.
    - Warn only if train_sampler has set_epoch

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
