### PR TITLE
Fixes #1071

### DIFF
--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -1,12 +1,13 @@
 import numbers
+import warnings
 import weakref
 from enum import Enum
 from types import DynamicClassAttribute
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Optional, Union
 
 from ignite.engine.utils import _check_signature
 
-__all__ = ["Events", "State"]
+__all__ = ["CallableEventWithFilter", "EventEnum", "Events", "State"]
 
 
 class CallableEventWithFilter:
@@ -127,6 +128,17 @@ class CallableEventWithFilter:
 
     def __or__(self, other):
         return EventsList() | self | other
+
+
+class CallableEvents(CallableEventWithFilter):
+    # For backward compatibility
+    def __init__(self, *args, **kwargs):
+        super(CallableEvents, self).__init__(*args, **kwargs)
+        warnings.warn(
+            "Class ignite.engine.events.CallableEvents is deprecated. It will be removed in 0.5.0. "
+            "Please, use ignite.engine.EventEnum instead",
+            DeprecationWarning,
+        )
 
 
 class EventEnum(CallableEventWithFilter, Enum):

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -5,7 +5,18 @@ import pytest
 import torch
 
 from ignite.engine import Engine, Events
-from ignite.engine.events import CallableEventWithFilter, EventEnum, EventsList
+from ignite.engine.events import CallableEvents, CallableEventWithFilter, EventEnum, EventsList
+
+
+def test_deprecated_callable_events_class():
+    engine = Engine(lambda engine, batch: 0)
+
+    with pytest.warns(DeprecationWarning, match=r"Class ignite\.engine\.events\.CallableEvents is deprecated"):
+
+        class CustomEvents(CallableEvents, Enum):
+            TEST_EVENT = "test_event"
+
+        engine.register_events(*CustomEvents)
 
 
 def test_custom_events():


### PR DESCRIPTION
Fixes #1071 

Description:
- backported and deprecated `CallableEvents` for backward compatibility with v0.3.0

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
