### PR TITLE
Fixed incorrect log position. (#1098)

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -698,11 +698,18 @@ class Engine(Serializable):
                 time_taken = self._run_once_on_dataset()
                 self.state.times[Events.EPOCH_COMPLETED.name] = time_taken
                 hours, mins, secs = _to_hours_mins_secs(time_taken)
+                elapsed_time_message = "Epoch[%s] Complete. Time taken: %02d:%02d:%02d" % (
+                    self.state.epoch,
+                    hours,
+                    mins,
+                    secs,
+                )
                 if self.should_terminate:
                     self._fire_event(Events.TERMINATE)
+                    self.logger.info(elapsed_time_message)
                     break
                 self._fire_event(Events.EPOCH_COMPLETED)
-                self.logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.state.epoch, hours, mins, secs)
+                self.logger.info(elapsed_time_message)
 
             time_taken = time.time() - start_time
             hours, mins, secs = _to_hours_mins_secs(time_taken)

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -698,11 +698,11 @@ class Engine(Serializable):
                 time_taken = self._run_once_on_dataset()
                 self.state.times[Events.EPOCH_COMPLETED.name] = time_taken
                 hours, mins, secs = _to_hours_mins_secs(time_taken)
-                self.logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.state.epoch, hours, mins, secs)
                 if self.should_terminate:
                     self._fire_event(Events.TERMINATE)
                     break
                 self._fire_event(Events.EPOCH_COMPLETED)
+                self.logger.info("Epoch[%s] Complete. Time taken: %02d:%02d:%02d", self.state.epoch, hours, mins, secs)
 
             time_taken = time.time() - start_time
             hours, mins, secs = _to_hours_mins_secs(time_taken)

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -112,4 +112,4 @@ def test_setup_logger(capsys, dirname):
 
     for source in [err, data]:
         assert "trainer INFO: Engine run starting with max_epochs=5." in source[0]
-        assert "evaluator INFO: Engine run starting with max_epochs=1." in source[2]
+        assert "evaluator INFO: Engine run starting with max_epochs=1." in source[1]


### PR DESCRIPTION
Fixes #1098

Description:

Fire all events before logging time usages to prevent incorrect log position.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
