### PR TITLE
fix cifar10 model : num_classes missing

### DIFF
--- a/examples/contrib/cifar10/utils.py
+++ b/examples/contrib/cifar10/utils.py
@@ -36,4 +36,4 @@ def get_model(name):
     else:
         raise RuntimeError("Unknown model name {}".format(name))
 
-    return fn()
+    return fn(num_classes=10)


### PR DESCRIPTION
Description:

model of `examples/contrib/cifar10` is `torchvision.resnet.resnet18` : default is 1000 classes for imagenet. 

Missing `num_classes = 10`

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
