### PR TITLE
Fixes #1153

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -38,8 +38,9 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install pytorch torchvision cpuonly -c ${{ matrix.pytorch-channel }}
-        # Keep fix in case of problem with torchvision nightly releases
         pip install -r requirements-dev.txt
+        # Fixes #1153
+        pip install --upgrade scipy==1.4.1
         python setup.py install
 
     - name: Run Tests


### PR DESCRIPTION
Fixes #1153

Description:
- temporary downgrade of scipy to 1.4.1 instead of 1.5.0 for all OS (even if it fails only on Win32)

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
