### PR TITLE
Use global_step as priority, if it exists

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -111,7 +111,7 @@ class Checkpoint:
         setup by attached engine's current iteration. The filename will be
         `{filename_prefix}_{name}_{engine.state.iteration}.{ext}`.
 
-        If only ``global_step_transform`` is defined, then suffix is setup using its return value. 
+        If only ``global_step_transform`` is defined, then suffix is setup using its return value.
         The filename will be `{filename_prefix}_{name}_{global_step}.{ext}`.
 
         If defined a ``score_function``, but without ``score_name``, then suffix is defined by provided score.

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -111,6 +111,9 @@ class Checkpoint:
         setup by attached engine's current iteration. The filename will be
         `{filename_prefix}_{name}_{engine.state.iteration}.{ext}`.
 
+        If only ``global_step_transform`` is defined, then suffix is setup using its return value. 
+        The filename will be `{filename_prefix}_{name}_{global_step}.{ext}`.
+
         If defined a ``score_function``, but without ``score_name``, then suffix is defined by provided score.
         The filename will be `{filename_prefix}_{name}_{global_step}_{score}.pt`.
 
@@ -269,7 +272,10 @@ class Checkpoint:
             if not isinstance(priority, numbers.Number):
                 raise ValueError("Output of score_function should be a number")
         else:
-            priority = engine.state.get_event_attrib_value(Events.ITERATION_COMPLETED)
+            if self.global_step_transform is not None:
+                priority = global_step
+            else:
+                priority = engine.state.get_event_attrib_value(Events.ITERATION_COMPLETED)
 
         if self._check_lt_n_saved() or self._saved[0].priority < priority:
 

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -263,6 +263,7 @@ class Checkpoint:
     def __call__(self, engine: Engine) -> None:
 
         suffix = ""
+        global_step = None
         if self.global_step_transform is not None:
             global_step = self.global_step_transform(engine, engine.last_event_name)
             suffix = "{}".format(global_step)
@@ -272,7 +273,7 @@ class Checkpoint:
             if not isinstance(priority, numbers.Number):
                 raise ValueError("Output of score_function should be a number")
         else:
-            if self.global_step_transform is not None:
+            if global_step is not None:
                 priority = global_step
             else:
                 priority = engine.state.get_event_attrib_value(Events.ITERATION_COMPLETED)

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -141,7 +141,7 @@ def test_checkpoint_with_global_step_transform():
         )
 
         trainer = Engine(lambda e, b: None)
-        trainer.state = State(epoch=1, iteration=1)
+        trainer.state = State(epoch=2, iteration=1)
 
         checkpointer(trainer)
         assert save_handler.call_count == 1
@@ -149,17 +149,17 @@ def test_checkpoint_with_global_step_transform():
         if len(filename_prefix) > 0:
             filename_prefix += "_"
 
-        metadata = {"basename": "{}{}".format(filename_prefix, name), "score_name": None, "priority": 1}
-        save_handler.assert_called_with(obj, "{}{}_1.pt".format(filename_prefix, name), metadata)
+        metadata = {"basename": "{}{}".format(filename_prefix, name), "score_name": None, "priority": 2}
+        save_handler.assert_called_with(obj, "{}{}_2.pt".format(filename_prefix, name), metadata)
 
         trainer.state.epoch = 12
         trainer.state.iteration = 1234
         checkpointer(trainer)
         assert save_handler.call_count == 2
-        metadata["priority"] = 1234
+        metadata["priority"] = 12
         save_handler.assert_called_with(obj, "{}{}_12.pt".format(filename_prefix, name), metadata)
         assert save_handler.remove.call_count == 1
-        save_handler.remove.assert_called_with("{}{}_1.pt".format(filename_prefix, name))
+        save_handler.remove.assert_called_with("{}{}_2.pt".format(filename_prefix, name))
         assert checkpointer.last_checkpoint == "{}{}_12.pt".format(filename_prefix, name)
 
     for prefix in ["", "dummytask"]:


### PR DESCRIPTION
Fixes #1148

Description:

Use `global_step` as the `priority` inside of `Checkpoint`, when it is available. Fall back to the iteration count. This synchronizes the filename of the checkpoint and its priority, when `global_step_transform` is provided without `score_*`.

Check list:
* [X] New tests are added (if a new feature is added)
* [] New doc strings: description and/or example code are in RST format
* [X] Documentation is updated (if required)
