### PR TITLE
Issue 1123 - Improve usage of contrib common methods with other save handlers 

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -42,7 +42,7 @@ def setup_common_training_handlers(
     stop_on_nan=True,
     clear_cuda_cache=True,
     save_handler=None,
-    **kwargs,
+    **kwargs
 ):
     """Helper method to setup trainer with common handlers (it also supports distributed configuration):
         - :class:`~ignite.handlers.TerminateOnNan`
@@ -132,7 +132,7 @@ def _setup_common_training_handlers(
     stop_on_nan=True,
     clear_cuda_cache=True,
     save_handler=None,
-    **kwargs,
+    **kwargs
 ):
     if output_path is not None and save_handler is not None:
         raise ValueError(
@@ -214,7 +214,7 @@ def _setup_common_distrib_training_handlers(
     stop_on_nan=True,
     clear_cuda_cache=True,
     save_handler=None,
-    **kwargs,
+    **kwargs
 ):
 
     _setup_common_training_handlers(
@@ -475,12 +475,12 @@ def get_default_score_fn(metric_name):
     return wrapper
 
 
-def delegated_save_best_models_by_val_score(
+def gen_save_best_models_by_val_score(
     save_handler, evaluator, models, metric_name, n_saved=3, trainer=None, tag="val", **kwargs
 ):
     """Method adds a handler to ``evaluator`` to save ``n_saved`` of best models based on the metric
     (named by ``metric_name``) provided by ``evaluator`` (i.e. ``evaluator.state.metrics[metric_name]``).
-    The logic how to store objects is delegated to ``save_handler``.
+    The logic of how to store objects is delegated to ``save_handler``.
 
     Args:
         save_handler (callable or :class:`~ignite.handlers.checkpoint.BaseSaveHandler`): Method or callable class to
@@ -547,7 +547,7 @@ def save_best_model_by_val_score(
     Returns:
         A :class:`~ignite.handlers.checkpoint.Checkpoint` handler.
     """
-    return delegated_save_best_models_by_val_score(
+    return gen_save_best_models_by_val_score(
         save_handler=DiskSaver(dirname=output_path, require_empty=False),
         evaluator=evaluator,
         models=model,

--- a/tests/ignite/contrib/engines/test_common.py
+++ b/tests/ignite/contrib/engines/test_common.py
@@ -12,7 +12,7 @@ import ignite.distributed as idist
 from ignite.contrib.engines.common import (
     _setup_logging,
     add_early_stopping_by_val_score,
-    delegated_save_best_models_by_val_score,
+    gen_save_best_models_by_val_score,
     save_best_model_by_val_score,
     setup_any_logging,
     setup_common_training_handlers,
@@ -177,7 +177,7 @@ def test_setup_common_training_handlers(dirname, capsys):
     out = captured.err.split("\r")
     out = list(map(lambda x: x.strip(), out))
     out = list(filter(None, out))
-    assert "Epoch:" in out[-1] or "Epoch:" in out[-2], "{}, {}".format(out[-2], out[-1])
+    assert "Epoch" in out[-1] or "Epoch" in out[-2], "{}, {}".format(out[-2], out[-1])
 
 
 def test_setup_common_training_handlers_using_save_handler(dirname, capsys):
@@ -190,7 +190,7 @@ def test_setup_common_training_handlers_using_save_handler(dirname, capsys):
     out = captured.err.split("\r")
     out = list(map(lambda x: x.strip(), out))
     out = list(filter(None, out))
-    assert "Epoch:" in out[-1] or "Epoch:" in out[-2], "{}, {}".format(out[-2], out[-1])
+    assert "Epoch" in out[-1] or "Epoch" in out[-2], "{}, {}".format(out[-2], out[-1])
 
 
 def test_save_best_model_by_val_score(dirname):
@@ -216,7 +216,7 @@ def test_save_best_model_by_val_score(dirname):
     assert set(os.listdir(dirname)) == {"best_model_8_val_acc=0.6100.pt", "best_model_9_val_acc=0.7000.pt"}
 
 
-def test_delegated_save_best_models_by_val_score():
+def test_gen_save_best_models_by_val_score():
 
     trainer = Engine(lambda e, b: None)
     evaluator = Engine(lambda e, b: None)
@@ -234,7 +234,7 @@ def test_delegated_save_best_models_by_val_score():
 
     save_handler = MagicMock()
 
-    delegated_save_best_models_by_val_score(
+    gen_save_best_models_by_val_score(
         save_handler, evaluator, {"a": model, "b": model}, metric_name="acc", n_saved=2, trainer=trainer
     )
 


### PR DESCRIPTION
Fixes #1123  

Description:
- added save_handler arg to setup_common_training_handlers
- added method delegated_save_best_models_by_val_score

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)


Personally, I'm not really fan of the name `delegated_save_best_models_by_val_score`, if you have other better ideas ...