### PR TITLE
ValueError -> TypeError

### DIFF
--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -259,7 +259,7 @@ class EventsList:
 
     def _append(self, event: Union[Events, CallableEventWithFilter]):
         if not isinstance(event, (Events, CallableEventWithFilter)):
-            raise ValueError("Argument event should be Events or CallableEventWithFilter, got: {}".format(type(event)))
+            raise TypeError("Argument event should be Events or CallableEventWithFilter, got: {}".format(type(event)))
         self._events.append(event)
 
     def __getitem__(self, item):

--- a/tests/ignite/engine/test_event_handlers.py
+++ b/tests/ignite/engine/test_event_handlers.py
@@ -313,7 +313,7 @@ def test_events_list_removable_handle():
 
 def test_eventslist__append_raises():
     ev_list = EventsList()
-    with pytest.raises(ValueError, match=r"Argument event should be Events or CallableEventWithFilter"):
+    with pytest.raises(TypeError, match=r"Argument event should be Events or CallableEventWithFilter"):
         ev_list._append("abc")
 
 


### PR DESCRIPTION
Fixes # 

Description:
>`TypeError` may be raised when an operation or function is applied to an object of an inappropriate type, while `ValueError` may be raised when an operation or function receives an argument that has the right type but an inappropriate value.
>
> @ python at https://docs.python.org/3/library/exceptions.html

Thus, `TypeError` is preferred over `ValueError` here.

Check list:
* [ ] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
