### PR TITLE
Improve docs for custom events

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -229,10 +229,33 @@ event filtering function:
     trainer.run(train_loader, max_epochs=100)
 
 
-.. Note ::
+The user can also define custom events. Events defined by user should inherit from :class:`~ignite.engine.events.EventEnum`
+and be registered with :meth:`~ignite.engine.engine.Engine.register_events` in an `engine`.
 
-   User can also register custom events with :meth:`~ignite.engine.engine.Engine.register_events`, attach handlers and fire custom events
-   calling :meth:`~ignite.engine.engine.Engine.fire_event` in any handler or `process_function`.
+.. code-block:: python
+
+    class CustomEvents(EventEnum):
+        """
+        Custom events defined by user
+        """
+        CUSTOM_STARTED = 'custom_started'
+        CUSTOM_COMPLETED = 'custom_completed'
+
+    engine.register_events(*CustomEvents)
+
+These events could be used to attach any handler and are fired using :meth:`~ignite.engine.engine.Engine.fire_event`.
+
+.. code-block:: python
+
+    @engine.on(CustomEvents.CUSTOM_STARTED)
+    def call_on_custom_event(engine):
+         # do something
+
+    @engine.on(Events.STARTED)
+    def fire_custom_events(engine):
+         engine.fire_event(CustomEvents.CUSTOM_STARTED)
+
+.. Note ::
 
    See the source code of :class:`~ignite.contrib.engines.create_supervised_tbptt_trainer` for an example of usage of
    custom events.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -76,6 +76,9 @@ flexibility to the user to allow for this:
     def function_before_backprop(engine):
         # insert custom function here
 
+.. Note ::
+
+    Events defined by user should inherit from :class:`~ignite.engine.events.EventEnum`
 
 More detailed implementation can be found in `TBPTT Trainer <_modules/ignite/contrib/engines/tbptt.html#create_supervised_tbptt_trainer>`_.
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -207,6 +207,13 @@ class Events(EventEnum):
         def call_on_events(engine):
             # do something
 
+    Since v0.4.0, custom events defined by user should inherit from :class:`~ignite.engine.events.EventEnum` :
+
+    .. code-block:: python
+
+        class CustomEvents(EventEnum):
+            FOO_EVENT = "foo_event"
+            BAR_EVENT = "bar_event"
     """
 
     EPOCH_STARTED = "epoch_started"


### PR DESCRIPTION
Fixes #1172 

Description:

Improve docs for custom events. Custom events defined by use must inherit from `EventEnum`.

Check list:
* [ ] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
