### PR TITLE
Set isort version to 4.3.21

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,7 +9,7 @@ jobs:
       with:
         python-version: '3.7'
     - run: |
-        python -m pip install autopep8 black isort
+        python -m pip install autopep8 black "isort==4.3.21"
         isort -rc .
         autopep8 --recursive --in-place --aggressive --aggressive .
         black .

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     - stage: Lint check
       python: "3.7"
       before_install: # Nothing to do
-      install: pip install flake8 black isort
+      install: pip install flake8 black "isort==4.3.21"
       script:
         - flake8 .
         - black --check .


### PR DESCRIPTION

Description:
- Set isort to 4.3.21 as it fails on 5.0

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
