### PR TITLE
Fixed failing cifar10 test

### DIFF
--- a/examples/contrib/cifar10/main.py
+++ b/examples/contrib/cifar10/main.py
@@ -348,7 +348,7 @@ def get_save_handler(config):
 
         return TrainsSaver(dirname=config["output_path"])
 
-    return DiskSaver(config["output_path"])
+    return DiskSaver(config["output_path"], require_empty=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Description:
- Fixed failing cifar10 test (missing `require_empty` in `DiskSaver`)

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
