### PR TITLE
Minor optimization for idist.get_*

### DIFF
--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -49,16 +49,20 @@ _need_to_sync = True
 def _sync_model_wrapper(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if isinstance(_model, _SerialModel) and _need_to_sync:
-            sync()
+        if _need_to_sync and isinstance(_model, _SerialModel):
+            sync(temporary=True)
         return func(*args, **kwargs)
 
     return wrapper
 
 
-def sync():
+def sync(temporary=False):
     """Helper method to force this module to synchronize with current distributed context.
     This method should be used when distributed context is manually created or destroyed.
+
+    Args:
+        temporary (bool): If True, distributed model synchronization is done every call of ``idist.get_*`` methods.
+            This may have performance negative impact.
     """
     global _model
 
@@ -67,7 +71,7 @@ def sync():
             continue
         model = comp_model_cls.create_from_context()
         if model is not None:
-            _model = model
+            _set_model(model, temporary=temporary)
             return
 
     _model = _SerialModel()
@@ -356,11 +360,11 @@ def set_local_rank(index: int):
     ComputationModel._ext_local_rank = index
 
 
-def _set_model(model):
+def _set_model(model, temporary=False):
     global _model, _need_to_sync
     _model = model
     _need_to_sync = True
-    if not isinstance(_model, _SerialModel):
+    if not isinstance(_model, _SerialModel) and not temporary:
         _need_to_sync = False
 
 
@@ -408,7 +412,7 @@ def initialize(backend: str, **kwargs):
 
 
     """
-    if not (has_xla_support or dist.is_available()):
+    if not (has_xla_support or has_native_dist_support):
         # nothing to do => serial model
         # maybe warn about this
         return

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -4,7 +4,6 @@ from numbers import Number
 from typing import Callable, List, Mapping, Optional, Tuple, Union
 
 import torch
-import torch.distributed as dist
 
 from ignite.distributed.comp_models import (
     _SerialModel,
@@ -46,16 +45,6 @@ _model = _SerialModel()
 _need_to_sync = True
 
 
-def _sync_model_wrapper(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if _need_to_sync and isinstance(_model, _SerialModel):
-            sync(temporary=True)
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
 def sync(temporary=False):
     """Helper method to force this module to synchronize with current distributed context.
     This method should be used when distributed context is manually created or destroyed.
@@ -77,7 +66,6 @@ def sync(temporary=False):
     _model = _SerialModel()
 
 
-@_sync_model_wrapper
 def device() -> torch.device:
     """Returns current device according to current distributed configuration.
 
@@ -88,10 +76,12 @@ def device() -> torch.device:
     Returns:
         torch.device
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.device()
 
 
-@_sync_model_wrapper
 def backend() -> Optional[str]:
     """Returns computation model's backend.
 
@@ -102,6 +92,9 @@ def backend() -> Optional[str]:
     Returns:
         str or None
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.backend()
 
 
@@ -114,7 +107,6 @@ def available_backends() -> Tuple[str]:
     return out
 
 
-@_sync_model_wrapper
 def model_name() -> str:
     """Returns distributed configuration name (given by ignite)
 
@@ -123,51 +115,66 @@ def model_name() -> str:
     - `xla-dist` for XLA distributed configuration
 
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.name
 
 
-@_sync_model_wrapper
 def get_world_size() -> int:
     """Returns world size of current distributed configuration. Returns 1 if no distributed configuration.
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.get_world_size()
 
 
-@_sync_model_wrapper
 def get_rank() -> int:
     """Returns process rank within current distributed configuration. Returns 0 if no distributed configuration.
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.get_rank()
 
 
-@_sync_model_wrapper
 def get_local_rank() -> int:
     """Returns local process rank within current distributed configuration. Returns 0 if no distributed configuration.
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.get_local_rank()
 
 
-@_sync_model_wrapper
 def get_nproc_per_node() -> int:
     """Returns number of processes (or tasks) per node within current distributed configuration.
     Returns 1 if no distributed configuration.
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.get_nproc_per_node()
 
 
-@_sync_model_wrapper
 def get_nnodes() -> int:
     """Returns number of nodes within current distributed configuration.
     Returns 1 if no distributed configuration.
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.get_nnodes()
 
 
-@_sync_model_wrapper
 def get_node_rank() -> int:
     """Returns node rank within current distributed configuration.
     Returns 0 if no distributed configuration.
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.get_node_rank()
 
 
@@ -295,7 +302,6 @@ def spawn(
         )
 
 
-@_sync_model_wrapper
 def all_reduce(tensor: Union[torch.Tensor, Number], op: str = "SUM") -> Union[torch.Tensor, Number]:
     """Helper method to perform all reduce operation.
 
@@ -307,10 +313,12 @@ def all_reduce(tensor: Union[torch.Tensor, Number], op: str = "SUM") -> Union[to
         torch.Tensor or number
 
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.all_reduce(tensor, op)
 
 
-@_sync_model_wrapper
 def all_gather(tensor: Union[torch.Tensor, Number, str]) -> Union[torch.Tensor, Number, List[str]]:
     """Helper method to perform all gather operation.
 
@@ -322,13 +330,18 @@ def all_gather(tensor: Union[torch.Tensor, Number, str]) -> Union[torch.Tensor, 
         List of strings
 
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     return _model.all_gather(tensor)
 
 
-@_sync_model_wrapper
 def barrier():
     """Helper method to synchronize all processes.
     """
+    if _need_to_sync and isinstance(_model, _SerialModel):
+        sync(temporary=True)
+
     _model.barrier()
 
 

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -231,7 +231,9 @@ def _test_idist_methods_overhead(ok_factor):
 
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Do not want to run this test on Github or Travis, but CircleCI")
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Do not want to run this test on Github or Travis, but CircleCI"
+)
 def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
     _test_idist_methods_overhead(2.5)
 

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -243,7 +243,7 @@ def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
 
     assert isinstance(_model, _NativeDistModel)
 
-    _test_idist_methods_overhead(1.5)
+    _test_idist_methods_overhead(1.7)
 
 
 @pytest.mark.distributed

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -231,8 +231,7 @@ def _test_idist_methods_overhead(ok_factor):
 
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.skipif(torch.cuda.device_count() > 0, reason="Skip if has GPU")
-@pytest.mark.skipif(torch.cuda.is_available(), reason="Do not want to run this test on Github or Travis, but CircleCI")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Do not want to run this test on Github or Travis, but CircleCI")
 def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
     _test_idist_methods_overhead(2.5)
 
@@ -257,7 +256,7 @@ def test_idist_methods_overhead_nccl(distributed_context_single_node_nccl):
 
     assert isinstance(_model, _NativeDistModel)
 
-    _test_idist_methods_overhead(1.5)
+    _test_idist_methods_overhead(1.7)
 
 
 @pytest.mark.distributed

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -202,12 +202,18 @@ def test_idist_barrier_gloo(distributed_context_single_node_gloo):
     _test_distrib_barrier(device)
 
 
-@pytest.mark.distributed
-@pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
+def _test_idist_methods_overhead(ok_factor):
     import time
 
-    n = 100000
+    n = 1000000
+
+    start = time.time()
+    for _ in range(n):
+        _ = dist.get_world_size()
+        _ = dist.get_rank()
+    elapsed = time.time() - start
+    t2 = elapsed / n
+
     start = time.time()
     for _ in range(n):
         _ = idist.get_world_size()
@@ -215,38 +221,37 @@ def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
     elapsed = time.time() - start
     t1 = elapsed / n
 
-    start = time.time()
-    for _ in range(n):
-        _ = dist.get_world_size()
-        _ = idist.get_rank()
-    elapsed = time.time() - start
-    t2 = elapsed / n
+    overhead_factor = t1 / t2
+    assert overhead_factor < ok_factor, "{} vs {} | {} vs {}".format(overhead_factor, ok_factor, t2, t1)
 
-    assert t2 * 6 > t1, "{} * 6 vs {}".format(t2, t1)
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
+def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
+    _test_idist_methods_overhead(2.5)
+
+    idist.sync()
+    from ignite.distributed.utils import _model
+    from ignite.distributed.comp_models.native import _NativeDistModel
+
+    assert isinstance(_model, _NativeDistModel)
+
+    _test_idist_methods_overhead(1.6)
 
 
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
 def test_idist_methods_overhead_nccl(distributed_context_single_node_nccl):
-    import time
+    _test_idist_methods_overhead(2.5)
 
-    n = 100000
-    start = time.time()
-    for _ in range(n):
-        _ = idist.get_world_size()
-        _ = idist.get_rank()
-    elapsed = time.time() - start
-    t1 = elapsed / n
+    idist.sync()
+    from ignite.distributed.utils import _model
+    from ignite.distributed.comp_models.native import _NativeDistModel
 
-    start = time.time()
-    for _ in range(n):
-        _ = dist.get_world_size()
-        _ = idist.get_rank()
-    elapsed = time.time() - start
-    t2 = elapsed / n
+    assert isinstance(_model, _NativeDistModel)
 
-    assert t2 * 3 > t1, "{} * 3 vs {}".format(t2, t1)
+    _test_idist_methods_overhead(1.6)
 
 
 @pytest.mark.distributed

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -227,20 +227,6 @@ def _test_idist_methods_overhead(ok_factor):
 
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
-    _test_idist_methods_overhead(2.5)
-
-    idist.sync()
-    from ignite.distributed.utils import _model
-    from ignite.distributed.comp_models.native import _NativeDistModel
-
-    assert isinstance(_model, _NativeDistModel)
-
-    _test_idist_methods_overhead(1.9)
-
-
-@pytest.mark.distributed
-@pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
 def test_idist_methods_overhead_nccl(distributed_context_single_node_nccl):
     _test_idist_methods_overhead(2.5)

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -205,24 +205,44 @@ def test_idist_barrier_gloo(distributed_context_single_node_gloo):
 def _test_idist_methods_overhead(ok_factor):
     import time
 
-    n = 1000000
+    n = 100000
+    m = 5
 
-    start = time.time()
-    for _ in range(n):
-        _ = dist.get_world_size()
-        _ = dist.get_rank()
-    elapsed = time.time() - start
-    t2 = elapsed / n
+    t2 = 0.0
+    t1 = 0.0
+    for j in range(m):
+        start = time.time()
+        for _ in range(n):
+            _ = dist.get_world_size()
+            _ = dist.get_rank()
+        elapsed = time.time() - start
+        t2 += elapsed / n / m
 
-    start = time.time()
-    for _ in range(n):
-        _ = idist.get_world_size()
-        _ = idist.get_rank()
-    elapsed = time.time() - start
-    t1 = elapsed / n
+        start = time.time()
+        for _ in range(n):
+            _ = idist.get_world_size()
+            _ = idist.get_rank()
+        elapsed = time.time() - start
+        t1 += elapsed / n / m
 
     overhead_factor = t1 / t2
     assert overhead_factor < ok_factor, "{} vs {} | {} vs {}".format(overhead_factor, ok_factor, t2, t1)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() > 0, reason="Skip if has GPU")
+@pytest.mark.skipif(torch.cuda.is_available(), reason="Do not want to run this test on Github or Travis, but CircleCI")
+def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
+    _test_idist_methods_overhead(2.5)
+
+    idist.sync()
+    from ignite.distributed.utils import _model
+    from ignite.distributed.comp_models.native import _NativeDistModel
+
+    assert isinstance(_model, _NativeDistModel)
+
+    _test_idist_methods_overhead(1.5)
 
 
 @pytest.mark.distributed
@@ -237,7 +257,7 @@ def test_idist_methods_overhead_nccl(distributed_context_single_node_nccl):
 
     assert isinstance(_model, _NativeDistModel)
 
-    _test_idist_methods_overhead(1.9)
+    _test_idist_methods_overhead(1.5)
 
 
 @pytest.mark.distributed

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -236,7 +236,7 @@ def test_idist_methods_overhead_gloo(distributed_context_single_node_gloo):
 
     assert isinstance(_model, _NativeDistModel)
 
-    _test_idist_methods_overhead(1.6)
+    _test_idist_methods_overhead(1.9)
 
 
 @pytest.mark.distributed
@@ -251,7 +251,7 @@ def test_idist_methods_overhead_nccl(distributed_context_single_node_nccl):
 
     assert isinstance(_model, _NativeDistModel)
 
-    _test_idist_methods_overhead(1.6)
+    _test_idist_methods_overhead(1.9)
 
 
 @pytest.mark.distributed


### PR DESCRIPTION
Description:
- Changes of dist model's synchronization to reduce the overhead of idist.get_*
- Test overhead on CircleCI with NCCL/Gloo backends
-  Removed `_sync_model_wrapper` to implicitly check if we need to sync model. This also reduces time of `idist.get_*` method calls vs native calls.


Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
