### PR TITLE
Docs update and auto_model change

### DIFF
--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -139,6 +139,15 @@ def auto_model(model: nn.Module) -> nn.Module:
 
         model = idist.auto_model(model)
 
+    In addition with NVidia/Apex, it can be used in the following way:
+
+    .. code-block:: python
+
+        import ignite.distribted as idist
+
+        model, optimizer = amp.initialize(model, optimizer, opt_level="O1")
+        model = idist.auto_optim(model)
+
     Args:
         model (torch.nn.Module): model to adapt.
 
@@ -150,7 +159,10 @@ def auto_model(model: nn.Module) -> nn.Module:
     """
     logger = setup_logger(__name__ + ".auto_model")
 
-    model.to(idist.device())
+    # Put model's parameters to device if its parameters are not on the device
+    device = idist.device()
+    if not all([p.device == device for p in model.parameters()]):
+        model.to(device)
 
     # distributed data parallel model
     if idist.get_world_size() > 1:

--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -127,8 +127,8 @@ def auto_model(model: nn.Module) -> nn.Module:
 
     Internally, we perform to following:
 
-    - send model to current :meth:`~ignite.distributed.utils.device()`.
-    - wrap the model to `torch DistributedDataParallel`_ for native torch distributed if world size is larger than 1
+    - send model to current :meth:`~ignite.distributed.utils.device()` if model's parameters are not on the device.
+    - wrap the model to `torch DistributedDataParallel`_ for native torch distributed if world size is larger than 1.
     - wrap the model to `torch DataParallel`_ if no distributed context found and more than one CUDA devices available.
 
     Examples:

--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -145,8 +145,8 @@ def auto_model(model: nn.Module) -> nn.Module:
 
         import ignite.distribted as idist
 
-        model, optimizer = amp.initialize(model, optimizer, opt_level="O1")
-        model = idist.auto_optim(model)
+        model, optimizer = amp.initialize(model, optimizer, opt_level=opt_level)
+        model = idist.auto_model(model)
 
     Args:
         model (torch.nn.Module): model to adapt.


### PR DESCRIPTION

Fixes #1174 

Description:
- Updated docs
- Now `auto_model` puts params on device if they are not the device


Check list:
* [ ] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
