### PR TITLE
Fixes #1198 - bug with CM in PascalVOC example

### DIFF
--- a/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
+++ b/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
@@ -179,7 +179,7 @@ def training(local_rank, config, logger=None):
 
     # Setup evaluators
     num_classes = config.num_classes
-    cm_metric = ConfusionMatrix(num_classes=num_classes)
+    cm_metric = ConfusionMatrix(num_classes=num_classes, average="recall")
 
     val_metrics = {
         "IoU": IoU(cm_metric),
@@ -249,8 +249,7 @@ def training(local_rank, config, logger=None):
 
             @trainer.on(Events.COMPLETED)
             def log_cm():
-                cm = cm_metric.compute().numpy()
-                cm = cm / (cm.sum(axis=1)[:, None] + 1e-15)
+                cm = cm_metric.compute().cpu().numpy()
                 trains_logger.report_confusion_matrix(
                     title="Final Confusion Matrix",
                     series="cm-preds-gt",


### PR DESCRIPTION
Fixes #1198 

Description:
- put CM to cpu before converting to numpy
- removed manual recall computation, put into CM definition
- refactored CM computation = explicit compute by all proc.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
