### PR TITLE
Propagate spawn kwargs from parallel to model's spawn

### DIFF
--- a/ignite/distributed/comp_models/xla.py
+++ b/ignite/distributed/comp_models/xla.py
@@ -113,9 +113,7 @@ if has_xla_support:
             backend: str = XLA_TPU,
             **kwargs
         ):
-            import os
-
-            if "COLAB_TPU_ADDR" in os.environ:
+            if "start_method" not in kwargs:
                 kwargs["start_method"] = "fork"
 
             xmp.spawn(

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -161,7 +161,7 @@ class Parallel:
         node_rank: Optional[int] = None,
         master_addr: Optional[str] = None,
         master_port: Optional[str] = None,
-        **spawn_kwargs,
+        **spawn_kwargs
     ):
         if backend is not None:
             if backend not in idist.available_backends():


### PR DESCRIPTION
Fixes #1199 

Description:
- Updated code to propagate spawn kwargs
- start_method is fork by default


Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
