### PR TITLE
Fixed wrong IoU computation in Pascal VOC

### DIFF
--- a/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
+++ b/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
@@ -179,7 +179,7 @@ def training(local_rank, config, logger=None):
 
     # Setup evaluators
     num_classes = config.num_classes
-    cm_metric = ConfusionMatrix(num_classes=num_classes, average="recall")
+    cm_metric = ConfusionMatrix(num_classes=num_classes)
 
     val_metrics = {
         "IoU": IoU(cm_metric),
@@ -246,7 +246,9 @@ def training(local_rank, config, logger=None):
 
         @trainer.on(Events.COMPLETED)
         def compute_and_log_cm():
-            cm = cm_metric.compute().cpu().numpy()
+            cm = cm_metric.compute()
+            # CM: values are normalized such that diagonal values represent class recalls
+            cm = ConfusionMatrix.normalize(cm, "recall").cpu().numpy()
 
             if idist.get_rank() == 0:
                 from trains import Task

--- a/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
+++ b/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
@@ -245,7 +245,7 @@ def training(local_rank, config, logger=None):
         def custom_event_filter(_, val_iteration):
             c1 = val_iteration == len(val_loader) // 2
             c2 = trainer.state.epoch % (getattr(config, "val_interval", 1) * 3) == 0
-            c2 |= (trainer.state.epoch == config.num_epochs)
+            c2 |= trainer.state.epoch == config.num_epochs
             return c1 and c2
 
         tb_logger.attach(

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -39,6 +39,9 @@ def test_multiclass_wrong_inputs():
     with pytest.raises(ValueError, match=r"Argument average can None or one of"):
         ConfusionMatrix(num_classes=10, average="abc")
 
+    with pytest.raises(ValueError, match=r"Argument average one of 'samples', 'recall', 'precision'"):
+        ConfusionMatrix.normalize(None, None)
+
 
 def test_multiclass_input_N():
     # Multiclass input data of shape (N, )
@@ -295,37 +298,46 @@ def test_iou_wrong_input():
 
 def test_iou():
 
-    y_true, y_pred = get_y_true_y_pred()
-    th_y_true, th_y_logits = compute_th_y_true_y_logits(y_true, y_pred)
+    def _test(average=None):
 
-    true_res = [0, 0, 0]
-    for index in range(3):
-        bin_y_true = y_true == index
-        bin_y_pred = y_pred == index
-        intersection = bin_y_true & bin_y_pred
-        union = bin_y_true | bin_y_pred
-        true_res[index] = intersection.sum() / union.sum()
+        y_true, y_pred = get_y_true_y_pred()
+        th_y_true, th_y_logits = compute_th_y_true_y_logits(y_true, y_pred)
 
-    cm = ConfusionMatrix(num_classes=3)
-    iou_metric = IoU(cm)
+        true_res = [0, 0, 0]
+        for index in range(3):
+            bin_y_true = y_true == index
+            bin_y_pred = y_pred == index
+            intersection = bin_y_true & bin_y_pred
+            union = bin_y_true | bin_y_pred
+            true_res[index] = intersection.sum() / union.sum()
 
-    # Update metric
-    output = (th_y_logits, th_y_true)
-    cm.update(output)
+        cm = ConfusionMatrix(num_classes=3, average=average)
+        iou_metric = IoU(cm)
 
-    res = iou_metric.compute().numpy()
-
-    assert np.all(res == true_res)
-
-    for ignore_index in range(3):
-        cm = ConfusionMatrix(num_classes=3)
-        iou_metric = IoU(cm, ignore_index=ignore_index)
         # Update metric
         output = (th_y_logits, th_y_true)
         cm.update(output)
+
         res = iou_metric.compute().numpy()
-        true_res_ = true_res[:ignore_index] + true_res[ignore_index + 1 :]
-        assert np.all(res == true_res_), "{}: {} vs {}".format(ignore_index, res, true_res_)
+
+        assert np.all(res == true_res)
+
+        for ignore_index in range(3):
+            cm = ConfusionMatrix(num_classes=3)
+            iou_metric = IoU(cm, ignore_index=ignore_index)
+            # Update metric
+            output = (th_y_logits, th_y_true)
+            cm.update(output)
+            res = iou_metric.compute().numpy()
+            true_res_ = true_res[:ignore_index] + true_res[ignore_index + 1 :]
+            assert np.all(res == true_res_), "{}: {} vs {}".format(ignore_index, res, true_res_)
+
+    _test()
+    _test(average="samples")
+
+    with pytest.raises(ValueError, match=r"ConfusionMatrix should have average attribute either"):
+        cm = ConfusionMatrix(num_classes=3, average="precision")
+        IoU(cm)
 
 
 def test_miou():

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -297,7 +297,6 @@ def test_iou_wrong_input():
 
 
 def test_iou():
-
     def _test(average=None):
 
         y_true, y_pred = get_y_true_y_pred()


### PR DESCRIPTION
Description:
- Fixed IoU computation that should be based on Confusion Matrix with average
- Added `ConfusionMatrix.normalize` method to normalize values as recall/precision on diag. 

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
