### PR TITLE
Allow passing keyword arguments to save function on checkpoint.

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -526,7 +526,7 @@ class DiskSaver(BaseSaveHandler):
         create_dir (bool, optional): if True, will create directory ``dirname`` if it doesnt exist.
         require_empty (bool, optional): If True, will raise exception if there are any files in the
             directory ``dirname``.
-        **kwargs: Keyword arguments accepted for `torch.save` or `xm.save`.
+        **kwargs: Accepted keyword arguments for `torch.save` or `xm.save`.
     """
 
     def __init__(
@@ -655,7 +655,7 @@ class ModelCheckpoint(Checkpoint):
         archived (bool, optional): Deprecated argument as models saved by `torch.save` are already compressed.
         include_self (bool): Whether to include the `state_dict` of this object in the checkpoint. If `True`, then
             there must not be another object in ``to_save`` with key ``checkpointer``.
-        **kwargs: Keyword arguments accepted for `torch.save` or `xm.save` in `DiskSaver`.
+        **kwargs: Accepted keyword arguments for `torch.save` or `xm.save` in `DiskSaver`.
 
     Examples:
         >>> import os

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -526,14 +526,16 @@ class DiskSaver(BaseSaveHandler):
         create_dir (bool, optional): if True, will create directory ``dirname`` if it doesnt exist.
         require_empty (bool, optional): If True, will raise exception if there are any files in the
             directory ``dirname``.
+        **kwargs: Keyword arguments accepted for `torch.save` or `xm.save`.
     """
 
     def __init__(
-        self, dirname: str, atomic: bool = True, create_dir: bool = True, require_empty: bool = True,
+        self, dirname: str, atomic: bool = True, create_dir: bool = True, require_empty: bool = True, **kwargs
     ):
         self.dirname = os.path.expanduser(dirname)
         self._atomic = atomic
         self._check_and_setup(dirname, create_dir, require_empty)
+        self.kwargs = kwargs
 
     @staticmethod
     @idist.one_rank_only()
@@ -575,7 +577,7 @@ class DiskSaver(BaseSaveHandler):
 
     def _save_func(self, checkpoint: Mapping, path: str, func: Callable, rank: int = 0):
         if not self._atomic:
-            func(checkpoint, path)
+            func(checkpoint, path, **self.kwargs)
         else:
             tmp_file = None
             tmp_name = None
@@ -585,7 +587,7 @@ class DiskSaver(BaseSaveHandler):
                 tmp_file = tmp.file
                 tmp_name = tmp.name
             try:
-                func(checkpoint, tmp_file)
+                func(checkpoint, tmp_file, **self.kwargs)
             except BaseException:
                 if tmp is not None:
                     tmp.close()
@@ -653,6 +655,7 @@ class ModelCheckpoint(Checkpoint):
         archived (bool, optional): Deprecated argument as models saved by `torch.save` are already compressed.
         include_self (bool): Whether to include the `state_dict` of this object in the checkpoint. If `True`, then
             there must not be another object in ``to_save`` with key ``checkpointer``.
+        **kwargs: Keyword arguments accepted for `torch.save` or `xm.save` in `DiskSaver`.
 
     Examples:
         >>> import os
@@ -685,6 +688,7 @@ class ModelCheckpoint(Checkpoint):
         global_step_transform: Optional[Callable] = None,
         archived: bool = False,
         include_self: bool = False,
+        **kwargs
     ):
 
         if not save_as_state_dict:
@@ -704,7 +708,7 @@ class ModelCheckpoint(Checkpoint):
                 # No choice
                 raise ValueError(msg)
 
-        disk_saver = DiskSaver(dirname, atomic=atomic, create_dir=create_dir, require_empty=require_empty,)
+        disk_saver = DiskSaver(dirname, atomic=atomic, create_dir=create_dir, require_empty=require_empty, **kwargs)
 
         super(ModelCheckpoint, self).__init__(
             to_save=None,

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -608,14 +608,14 @@ def test_disk_saver_zipfile_serialization_keyword(dirname):
     saver.remove(fname)
 
 
-@pytest.mark.xfail
 def test_disk_saver_unknown_keyword(dirname):
     model = DummyModel()
     to_save = {"model": model}
 
     saver = DiskSaver(dirname, create_dir=False, unknown_keyword="")
     fname = "test.pt"
-    saver(to_save, fname)
+    with pytest.raises(TypeError, match=r"got an unexpected keyword argument 'unknown_keyword'"):
+        saver(to_save, fname)
 
 
 def test_last_k(dirname):

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -1,12 +1,12 @@
 import os
 import warnings
 from collections import OrderedDict
-from pkg_resources import parse_version
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 import torch.nn as nn
+from pkg_resources import parse_version
 
 import ignite.distributed as idist
 from ignite.engine import Engine, Events, State


### PR DESCRIPTION
Fixes #1244 

Description:
Changes are motivated to deal with backwards compability issue first raised in #1244. 

Now, additional keyword arguments can be passed to the constructor of `DiskSaver`, which are then during the call passed to the save functions to have more control there.
Both, the XLA and the standard torch.save function have keyword arguments.

https://pytorch.org/xla/release/1.5/index.html#torch_xla.core.xla_model.save
https://pytorch.org/docs/stable/generated/torch.save.html

ModelCheckpoint is also extended for the same reason.

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
