### PR TITLE
Issue 1249 : fix ParamGroupScheduler with schedulers based on different optimizers

### DIFF
--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -380,8 +380,8 @@ class CosineAnnealingScheduler(CyclicalScheduler):
 
         optimizer = SGD(
             [
-                {"params": model.base.parameters(), 'lr': 0.001),
-                {"params": model.fc.parameters(), 'lr': 0.01),
+                {"params": model.base.parameters(), 'lr': 0.001},
+                {"params": model.fc.parameters(), 'lr': 0.01},
             ]
         )
 

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -640,7 +640,7 @@ class LRScheduler(ParamScheduler):
         trainer.add_event_handler(Events.ITERATION_COMPLETED, scheduler)
     """
 
-    def __init__(self, lr_scheduler, save_history=False, **kwargs):
+    def __init__(self, lr_scheduler, save_history=False):
 
         if not isinstance(lr_scheduler, _LRScheduler):
             raise TypeError(

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -477,22 +477,18 @@ class ConcatScheduler(ParamScheduler):
         if len(optimizer) != 1:
             raise ValueError("schedulers should be related to same optimizer")
 
-        self.optimizer = optimizer[0]
-
         param_names = [s.param_name for s in param_schedulers]
-        param_group_names = [n for sc in param_group_schedulers for n in sc.names]
+        param_group_names = [s.param_name for sc in param_group_schedulers for s in sc.schedulers]
         param_name = list(set(param_names + param_group_names))
         if len(param_name) != 1:
             raise ValueError("schedulers should be related to same param_name")
-
-        self.param_name = param_name[0]
 
         # schedulers should have save_history sync with ParamGroupScheduler
         for s in schedulers:
             s.save_history = save_history
 
         super(ConcatScheduler, self).__init__(
-            optimizer=self.optimizer, param_name=self.param_name, save_history=save_history
+            optimizer=optimizer[0], param_name=param_name[0], save_history=save_history
         )
 
         self._scheduler_index = 0

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -491,7 +491,9 @@ class ConcatScheduler(ParamScheduler):
         for s in schedulers:
             s.save_history = save_history
 
-        super(ConcatScheduler, self).__init__(optimizer=self.optimizer, param_name=self.param_name, save_history=save_history)
+        super(ConcatScheduler, self).__init__(
+            optimizer=self.optimizer, param_name=self.param_name, save_history=save_history
+        )
 
         self._scheduler_index = 0
         self._current_scheduler = None

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -1,7 +1,7 @@
+import itertools
 import math
 import numbers
 import tempfile
-import itertools
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -1156,13 +1156,6 @@ def test_param_group_scheduler_asserts():
     ):
         scheduler.load_state_dict({"schedulers": [("a", lr_scheduler1.state_dict()), ("bad_name", {})]})
 
-    optimizer2 = torch.optim.SGD([{"params": t1, "lr": 0.1}, {"params": t2, "lr": 0.1}])
-    lr_scheduler3 = LinearCyclicalScheduler(
-        optimizer2, "lr", param_group_index=0, start_value=1.0, end_value=0.0, cycle_size=10
-    )
-    with pytest.raises(ValueError, match=r"schedulers should be related to same optimizer"):
-        ParamGroupScheduler(schedulers=[lr_scheduler1, lr_scheduler3])
-
 
 def test_param_group_scheduler():
     def _test(lr_schedulers, optimizer):

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -1204,12 +1204,8 @@ def test_param_group_scheduler():
     t2 = torch.zeros([1], requires_grad=True)
     optimizer_2 = torch.optim.SGD(params=[t2], lr=0.1)
 
-    lr_scheduler1 = LinearCyclicalScheduler(
-        optimizer_1, "lr", start_value=1.0, end_value=0.0, cycle_size=10
-    )
-    lr_scheduler2 = LinearCyclicalScheduler(
-        optimizer_2, "lr", start_value=1.0, end_value=0.0, cycle_size=10
-    )
+    lr_scheduler1 = LinearCyclicalScheduler(optimizer_1, "lr", start_value=1.0, end_value=0.0, cycle_size=10)
+    lr_scheduler2 = LinearCyclicalScheduler(optimizer_2, "lr", start_value=1.0, end_value=0.0, cycle_size=10)
 
     def save_lr_mutliple_optimizers(engine, lrs):
         lrs.append((optimizer_1.param_groups[0]["lr"], optimizer_2.param_groups[0]["lr"]))

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -339,6 +339,14 @@ def test_concat_scheduler_asserts():
     with pytest.raises(ValueError, match=r"schedulers should be related to same optimizer"):
         ConcatScheduler([scheduler_1, scheduler_3], durations=[30,])
 
+    scheduler_4 = CosineAnnealingScheduler(optimizer, "lr2", start_value=0.0, end_value=1.0, cycle_size=10)
+
+    with pytest.raises(ValueError, match=r"schedulers should be related to same param_name"):
+        ConcatScheduler([scheduler_1, scheduler_4], durations=[30,])
+
+    with pytest.raises(ValueError, match=r"schedulers should be related to same optimizer"):
+        ConcatScheduler.simulate_values(3, [scheduler_1, scheduler_3], durations=[30,])
+
 
 def test_concat_scheduler_state_dict():
     tensor = torch.zeros([1], requires_grad=True)

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -1158,7 +1158,7 @@ def test_param_group_scheduler_asserts():
 
 
 def test_param_group_scheduler():
-    def _test(lr_schedulers, optimizer):
+    def _test(lr_schedulers, save_lr):
         num_iterations = 10
         max_epochs = 20
 
@@ -1167,17 +1167,15 @@ def test_param_group_scheduler():
 
         trainer = Engine(lambda engine, batch: None)
 
-        @trainer.on(Events.ITERATION_COMPLETED)
-        def save_lr(engine):
-            lrs.append((optimizer.param_groups[0]["lr"], optimizer.param_groups[1]["lr"]))
-
         trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
 
         data = [0] * num_iterations
 
         for _ in range(2):
             lrs = []
+            trainer.add_event_handler(Events.ITERATION_COMPLETED, save_lr, lrs)
             trainer.run(data, max_epochs=max_epochs)
+            trainer.remove_event_handler(save_lr, Events.ITERATION_COMPLETED)
             assert [lr[0] for lr in lrs] == pytest.approx([lr[1] for lr in lrs])
             scheduler.load_state_dict(state_dict)
 
@@ -1195,7 +1193,28 @@ def test_param_group_scheduler():
     lr_scheduler2 = LinearCyclicalScheduler(
         optimizer, "lr", param_group_index=1, start_value=1.0, end_value=0.0, cycle_size=10
     )
-    _test([lr_scheduler1, lr_scheduler2], optimizer)
+
+    def save_lr_one_optimizer(engine, lrs):
+        lrs.append((optimizer.param_groups[0]["lr"], optimizer.param_groups[1]["lr"]))
+
+    _test([lr_scheduler1, lr_scheduler2], save_lr_one_optimizer)
+
+    t1 = torch.zeros([1], requires_grad=True)
+    optimizer_1 = torch.optim.SGD(params=[t1], lr=0.1)
+    t2 = torch.zeros([1], requires_grad=True)
+    optimizer_2 = torch.optim.SGD(params=[t2], lr=0.1)
+
+    lr_scheduler1 = LinearCyclicalScheduler(
+        optimizer_1, "lr", start_value=1.0, end_value=0.0, cycle_size=10
+    )
+    lr_scheduler2 = LinearCyclicalScheduler(
+        optimizer_2, "lr", start_value=1.0, end_value=0.0, cycle_size=10
+    )
+
+    def save_lr_mutliple_optimizers(engine, lrs):
+        lrs.append((optimizer_1.param_groups[0]["lr"], optimizer_2.param_groups[0]["lr"]))
+
+    _test([lr_scheduler1, lr_scheduler2], save_lr_mutliple_optimizers)
 
 
 def test_scheduler_with_param_groups():

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -814,8 +814,7 @@ def test_simulate_and_plot_values():
         optimizer = None
         event = Events.ITERATION_STARTED
         if scheduler_cls == LRScheduler:
-            scheduler_kwargs["optimizer"] = scheduler_kwargs["lr_scheduler"].optimizer
-            optimizer = scheduler_kwargs["optimizer"]
+            optimizer = scheduler_kwargs["lr_scheduler"].optimizer
             event = Events.ITERATION_COMPLETED
         elif scheduler_cls == ConcatScheduler:
             optimizer = scheduler_kwargs["optimizer"]


### PR DESCRIPTION
Fixes #1249  

Description:

Revert past modifications of `ParamGroupScheduler` to allow schedulers with multiple optimizers
Fix `ConcatScheduler` to handle `ParamGroupScheduler`

Check list:
* [x] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
