### PR TITLE
Rename Epoch to Iterations when using epoch_length with max_epochs=1

### DIFF
--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -49,7 +49,11 @@ class _OutputHandler(BaseOutputHandler):
         if logger.pbar is None:
             logger._reset(pbar_total=pbar_total)
 
-        desc = self.tag
+        state_dict = engine.state_dict()
+        max_epochs = state_dict["max_epochs"] if "max_epochs" in state_dict else None
+        default_desc = "Iterations" if max_epochs and max_epochs == 1 else "Epoch"
+
+        desc = self.tag or default_desc
         max_num_of_closing_events = self.get_max_number_events(self.closing_event_name, engine)
         if max_num_of_closing_events > 1:
             global_step = engine.state.get_event_attrib_value(self.closing_event_name)

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -49,9 +49,8 @@ class _OutputHandler(BaseOutputHandler):
         if logger.pbar is None:
             logger._reset(pbar_total=pbar_total)
 
-        state_dict = engine.state_dict()
-        max_epochs = state_dict["max_epochs"] if "max_epochs" in state_dict else None
-        default_desc = "Iterations" if max_epochs and max_epochs == 1 else "Epoch"
+        max_epochs = engine.state.max_epochs
+        default_desc = "Iterations" if max_epochs == 1 else "Epoch"
 
         desc = self.tag or default_desc
         max_num_of_closing_events = self.get_max_number_events(self.closing_event_name, engine)

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -98,8 +98,8 @@ class ProgressBar(BaseLogger):
             formatting, see `tqdm docs <https://tqdm.github.io/docs/tqdm/>`_.
         **tqdm_kwargs: kwargs passed to tqdm progress bar.
             By default, progress bar description displays "Epoch [5/10]" where 5 is the current epoch and 10 is the
-            number of epochs; however, if max_epochs are set to 1, the progress bar instead displays
-            "Iteration [5/10]". If tqdm_kwargs defines `desc`, e.g. "Predictions", than the description is
+            number of epochs; however, if ``max_epochs`` are set to 1, the progress bar instead displays
+            "Iteration: [5/10]". If tqdm_kwargs defines `desc`, e.g. "Predictions", than the description is
             "Predictions [5/10]" if number of epochs is more than one otherwise it is simply "Predictions".
 
     Examples:

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -50,7 +50,7 @@ class _OutputHandler(BaseOutputHandler):
             logger._reset(pbar_total=pbar_total)
 
         max_epochs = engine.state.max_epochs
-        default_desc = "Iterations" if max_epochs == 1 else "Epoch"
+        default_desc = "Iteration" if max_epochs == 1 else "Epoch"
 
         desc = self.tag or default_desc
         max_num_of_closing_events = self.get_max_number_events(self.closing_event_name, engine)

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -250,7 +250,7 @@ class ProgressBar(BaseLogger):
         Note: accepted output value types are numbers, 0d and 1d torch tensors and strings
 
         """
-        desc = self.tqdm_kwargs.get("desc", "Epoch")
+        desc = self.tqdm_kwargs.get("desc", None)
 
         if event_name not in engine._allowed_events:
             raise ValueError("Logging event {} is not in allowed events for this engine".format(event_name.name))

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -98,7 +98,8 @@ class ProgressBar(BaseLogger):
             formatting, see `tqdm docs <https://tqdm.github.io/docs/tqdm/>`_.
         **tqdm_kwargs: kwargs passed to tqdm progress bar.
             By default, progress bar description displays "Epoch [5/10]" where 5 is the current epoch and 10 is the
-            number of epochs. If tqdm_kwargs defines `desc`, e.g. "Predictions", than the description is
+            number of epochs; however, if max_epochs are set to 1, the progress bar instead displays
+            "Iteration [5/10]". If tqdm_kwargs defines `desc`, e.g. "Predictions", than the description is
             "Predictions [5/10]" if number of epochs is more than one otherwise it is simply "Predictions".
 
     Examples:

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -141,7 +141,7 @@ def test_pbar_with_metric(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Iterations: [1/2]  50%|█████     , batchloss=0.5 [00:00<00:00]"
+    expected = "Iteration: [1/2]  50%|█████     , batchloss=0.5 [00:00<00:00]"
     assert actual == expected
 
 
@@ -172,7 +172,7 @@ def test_pbar_with_all_metric(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Iterations: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<00:00]"
+    expected = "Iteration: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<00:00]"
     assert actual == expected
 
 
@@ -363,7 +363,7 @@ def test_pbar_with_max_epochs_set_to_one(capsys):
     err = captured.err.split("\r")
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = "Iterations: [1/2]  50%|█████     , a=1 [00:00<00:00]"
+    expected = "Iteration: [1/2]  50%|█████     , a=1 [00:00<00:00]"
     assert err[-1] == expected
 
 
@@ -434,7 +434,7 @@ def test_pbar_on_callable_events(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Iterations: [90/100]  90%|█████████  [00:00<00:00]"
+    expected = "Iteration: [90/100]  90%|█████████  [00:00<00:00]"
     assert actual == expected
 
 
@@ -450,7 +450,7 @@ def test_tqdm_logger_epoch_length(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Epoch: [50/50] 100%|██████████ [00:00<00:00]"
+    expected = "Iteration: [50/50] 100%|██████████ [00:00<00:00]"
     assert actual == expected
 
 

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -363,7 +363,7 @@ def test_pbar_with_max_epochs_set_to_one(capsys):
     err = captured.err.split("\r")
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = "Iterations [1/1]: [1/2]  50%|█████     , a=1 [00:00<00:00]"
+    expected = "Iterations: [1/2]  50%|█████     , a=1 [00:00<00:00]"
     assert err[-1] == expected
 
 

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -349,6 +349,24 @@ def test_pbar_on_epochs(capsys):
     assert actual == expected
 
 
+def test_pbar_with_max_epochs_set_to_one(capsys):
+    n_epochs = 1
+    loader = [1, 2]
+    engine = Engine(update_fn)
+
+    pbar = ProgressBar()
+    pbar.attach(engine, ["a"])
+
+    engine.run(loader, max_epochs=n_epochs)
+
+    captured = capsys.readouterr()
+    err = captured.err.split("\r")
+    err = list(map(lambda x: x.strip(), err))
+    err = list(filter(None, err))
+    expected = "Iterations [1/1]: [1/2]  50%|█████     , a=1 [00:00<00:00]"
+    assert err[-1] == expected
+
+
 def test_pbar_wrong_events_order():
 
     engine = Engine(update_fn)

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -141,7 +141,7 @@ def test_pbar_with_metric(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Epoch: [1/2]  50%|█████     , batchloss=0.5 [00:00<00:00]"
+    expected = "Iterations: [1/2]  50%|█████     , batchloss=0.5 [00:00<00:00]"
     assert actual == expected
 
 
@@ -172,7 +172,7 @@ def test_pbar_with_all_metric(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Epoch: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<00:00]"
+    expected = "Iterations: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<00:00]"
     assert actual == expected
 
 
@@ -434,7 +434,7 @@ def test_pbar_on_callable_events(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Epoch: [90/100]  90%|█████████  [00:00<00:00]"
+    expected = "Iterations: [90/100]  90%|█████████  [00:00<00:00]"
     assert actual == expected
 
 


### PR DESCRIPTION
Fixes #1276

Description:
Per the discussion in #1263, we'd like to ensure that the progress bar uses the name "Iterations" instead of "Epoch" when the epoch_length is passed to the trainer for max_epochs=1.

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
