### PR TITLE
Added required_output_keys public attribute (1289)

### DIFF
--- a/ignite/metrics/accumulation.py
+++ b/ignite/metrics/accumulation.py
@@ -37,7 +37,7 @@ class VariableAccumulation(Metric):
 
     """
 
-    _required_output_keys = None
+    required_output_keys = None
 
     def __init__(
         self,

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -32,7 +32,7 @@ class Loss(Metric):
 
     """
 
-    _required_output_keys = None
+    required_output_keys = None
 
     def __init__(
         self,

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -55,6 +55,9 @@ class EpochWise(MetricUsage):
     - :meth:`~ignite.metrics.Metric.started` on every ``EPOCH_STARTED`` (See :class:`~ignite.engine.events.Events`).
     - :meth:`~ignite.metrics.Metric.iteration_completed` on every ``ITERATION_COMPLETED``.
     - :meth:`~ignite.metrics.Metric.completed` on every ``EPOCH_COMPLETED``.
+
+    Attributes:
+        usage_name (str): usage name string
     """
 
     usage_name = "epoch_wise"
@@ -76,6 +79,9 @@ class BatchWise(MetricUsage):
     - :meth:`~ignite.metrics.Metric.started` on every ``ITERATION_STARTED`` (See :class:`~ignite.engine.events.Events`).
     - :meth:`~ignite.metrics.Metric.iteration_completed` on every ``ITERATION_COMPLETED``.
     - :meth:`~ignite.metrics.Metric.completed` on every ``ITERATION_COMPLETED``.
+
+    Attributes:
+        usage_name (str): usage name string
     """
 
     usage_name = "batch_wise"
@@ -126,57 +132,60 @@ class Metric(metaclass=ABCMeta):
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
 
-    Class Attributes:
-        required_output_keys (dict): dictionary defines required keys to be found in ``engine.state.output`` if the
-            latter is a dictionary. This is useful with custom metrics that can require other arguments than
-            predictions ``y_pred`` and targets ``y``. See notes below for an example.
+    Attributes:
+        required_output_keys (tuple): dictionary defines required keys to be found in ``engine.state.output`` if the
+            latter is a dictionary. Default, ``("y_pred", "y")``. This is useful with custom metrics that can require
+            other arguments than predictions ``y_pred`` and targets ``y``. See notes below for an example.
 
     Note:
 
-    .. code-block:: python
+        Let's implement a custom metric that requires ``y_pred``, ``y`` and ``x`` as input for ``update`` function.
+        In the example below we show how to setup standard metric like Accuracy and the custom metric using by an
+        ``evaluator`` created with :meth:`~ignite.engine.create_supervised_evaluator` method.
 
-        # https://discuss.pytorch.org/t/how-access-inputs-in-custom-ignite-metric/91221/5
-        # Let's implement a custom metric that requires ``y_pred``, ``y`` and ``x``
+        .. code-block:: python
 
-        import torch
-        import torch.nn as nn
+            # https://discuss.pytorch.org/t/how-access-inputs-in-custom-ignite-metric/91221/5
 
-        from ignite.metrics import Metric, Accuracy
-        from ignite.engine import create_supervised_evaluator
+            import torch
+            import torch.nn as nn
 
-        class CustomMetric(Metric):
+            from ignite.metrics import Metric, Accuracy
+            from ignite.engine import create_supervised_evaluator
 
-            required_output_keys = ("y_pred", "y", "x")
+            class CustomMetric(Metric):
 
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
+                required_output_keys = ("y_pred", "y", "x")
 
-            def update(self, output):
-                y_pred, y, x = output
-                # ...
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
 
-            def reset(self):
-                # ...
-                pass
+                def update(self, output):
+                    y_pred, y, x = output
+                    # ...
 
-            def compute(self):
-                # ...
-                pass
+                def reset(self):
+                    # ...
+                    pass
 
-        model = ...
+                def compute(self):
+                    # ...
+                    pass
 
-        metrics = {
-            "Accuracy": Accuracy(),
-            "CustomMetric": CustomMetric()
-        }
+            model = ...
 
-        evaluator = create_supervised_evaluator(
-            model,
-            metrics=metrics,
-            output_transform=lambda x, y, y_pred: {"x": x, "y": y, "y_pred": y_pred}
-        )
+            metrics = {
+                "Accuracy": Accuracy(),
+                "CustomMetric": CustomMetric()
+            }
 
-        res = evaluator.run(data)
+            evaluator = create_supervised_evaluator(
+                model,
+                metrics=metrics,
+                output_transform=lambda x, y, y_pred: {"x": x, "y": y, "y_pred": y_pred}
+            )
+
+            res = evaluator.run(data)
 
     """
 
@@ -321,7 +330,8 @@ class Metric(metaclass=ABCMeta):
             engine (Engine): the engine to which the metric must be attached
             name (str): the name of the metric to attach
             usage (str or MetricUsage, optional): the usage of the metric. Valid string values should be
-                'EpochWise.usage_name' (default) or 'BatchWise.usage_name'.
+                :attr:`ignite.metrics.EpochWise.usage_name` (default) or
+                :attr:`ignite.metrics.BatchWise.usage_name`.
 
         Example:
 

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -44,7 +44,7 @@ class RunningAverage(Metric):
 
     """
 
-    _required_output_keys = None
+    required_output_keys = None
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes #1289 

Description:
- Promoted _required_output_keys to be public as user would like to override it.


Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
