### PR TITLE
Set tqdm version in CI as <=4.48.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest-cov
 pytest-xdist
 dill
 # Test contrib dependencies
-tqdm
+tqdm<=4.48.0
 scikit-learn
 matplotlib
 tensorboardX


### PR DESCRIPTION
Fixes #1287

Description:
These changes is to just set `tqdm` to be `v4.48.0` only.


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
