### PR TITLE
Update Circle CI docker image to pytorch 1.6. Closes #1225

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ parameters:
   pytorch_stable_image:
     type: string
     # https://hub.docker.com/r/pytorch/pytorch/tags
-    default: "pytorch/pytorch:1.5.1-cuda10.1-cudnn7-runtime"
+    default: "pytorch/pytorch:1.6-cuda10.1-cudnn7-runtime"
   pytorch_stable_image_devel:
     type: string
     # https://hub.docker.com/r/pytorch/pytorch/tags
-    default: "pytorch/pytorch:1.5.1-cuda10.1-cudnn7-devel"
+    default: "pytorch/pytorch:1.6-cuda10.1-cudnn7-devel"
   workingdir:
     type: string
     default: "/tmp/ignite"

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-        pytorch-version: [1.4.0, 1.3.1]
+        pytorch-version: [1.5.1, 1.4.0, 1.3.1]
         exclude:
           - pytorch-version: 1.3.1
             python-version: 3.8


### PR DESCRIPTION
Fixes #1225

Description:

- Update Circle CI docker image to pytorch 1.6.
- Add 1.5.1 version to pytorch compatibilty versions checking
- Closes issue #1225

Check list:
* [N/A] New tests are added (if a new feature is added)
* [N/A] New doc strings: description and/or example code are in RST format
* [N/A] Documentation is updated (if required)
