### PR TITLE
Fix canberra docstring :  reference already in namespace

### DIFF
--- a/ignite/contrib/metrics/regression/canberra_metric.py
+++ b/ignite/contrib/metrics/regression/canberra_metric.py
@@ -19,7 +19,6 @@ class CanberraMetric(_BaseRegression):
     - ``update`` must receive output of the form ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``.
     - `y` and `y_pred` must be of same shape `(N, )` or `(N, 1)`.
 
-    .. _Botchkarev 2018: https://arxiv.org/abs/1809.03006
     .. _scikit-learn distance metrics:
         https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.DistanceMetric.html
 


### PR DESCRIPTION
Fixes #1329

Description:

Reference `Botchkarev 2018` already in namespace. 

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
