### PR TITLE
Update tqdm_logger tests to fit novel format_meter output

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest-cov
 pytest-xdist
 dill
 # Test contrib dependencies
-tqdm<=4.48.0
+tqdm
 scikit-learn
 matplotlib
 tensorboardX

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -36,7 +36,7 @@ def test_pbar(capsys):
     err = captured.err.split("\r")
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = "Epoch [2/2]: [1/2]  50%|█████     , a=1 [00:00<00:00]"
+    expected = "Epoch [2/2]: [1/2]  50%|█████     , a=1 [00:00<?]"
     assert err[-1] == expected
 
 
@@ -57,7 +57,7 @@ def test_pbar_file(tmp_path):
     file = open(str(file_path), "r")
     lines = file.readlines()
 
-    expected = "Epoch [2/2]: [1/2]  50%|█████     , a=1 [00:00<00:00]\n"
+    expected = "Epoch [2/2]: [1/2]  50%|█████     , a=1 [00:00<?]\n"
     assert lines[-2] == expected
 
 
@@ -141,7 +141,7 @@ def test_pbar_with_metric(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Iteration: [1/2]  50%|█████     , batchloss=0.5 [00:00<00:00]"
+    expected = "Iteration: [1/2]  50%|█████     , batchloss=0.5 [00:00<?]"
     assert actual == expected
 
 
@@ -172,7 +172,7 @@ def test_pbar_with_all_metric(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Iteration: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<00:00]"
+    expected = "Iteration: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<?]"
     assert actual == expected
 
 
@@ -192,7 +192,7 @@ def test_pbar_no_metric_names(capsys):
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
     actual = err[-1]
-    expected = "Epoch [2/2]: [1/2]  50%|█████      [00:00<00:00]"
+    expected = "Epoch [2/2]: [1/2]  50%|█████      [00:00<?]"
     assert actual == expected
 
 
@@ -210,7 +210,7 @@ def test_pbar_with_output(capsys):
     err = captured.err.split("\r")
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = "Epoch [2/2]: [1/2]  50%|█████     , a=1 [00:00<00:00]"
+    expected = "Epoch [2/2]: [1/2]  50%|█████     , a=1 [00:00<?]"
     assert err[-1] == expected
 
 
@@ -236,7 +236,7 @@ def test_pbar_with_scalar_output(capsys):
     err = captured.err.split("\r")
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = "Epoch [2/2]: [1/2]  50%|█████     , output=1 [00:00<00:00]"
+    expected = "Epoch [2/2]: [1/2]  50%|█████     , output=1 [00:00<?]"
     assert err[-1] == expected
 
 
@@ -254,7 +254,7 @@ def test_pbar_with_str_output(capsys):
     err = captured.err.split("\r")
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = "Epoch [2/2]: [1/2]  50%|█████     , output=red [00:00<00:00]"
+    expected = "Epoch [2/2]: [1/2]  50%|█████     , output=red [00:00<?]"
     assert err[-1] == expected
 
 
@@ -363,7 +363,7 @@ def test_pbar_with_max_epochs_set_to_one(capsys):
     err = captured.err.split("\r")
     err = list(map(lambda x: x.strip(), err))
     err = list(filter(None, err))
-    expected = "Iteration: [1/2]  50%|█████     , a=1 [00:00<00:00]"
+    expected = "Iteration: [1/2]  50%|█████     , a=1 [00:00<?]"
     assert err[-1] == expected
 
 


### PR DESCRIPTION
Fixes #1316 

Description:

Novel tqdm's `format_meter` classmethod now uses tqdm `initial` parameter; by default it is set up to `initial=0`, but in tqdm_logger.py it overrides defaults to `initial=1`, that's why now we expect "?" instead of "00:00", since now we need to consider yet another parameter

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
