### PR TITLE
Added reinit__is_reduced and sync_all_reduce docs in metrics doc

### DIFF
--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -261,8 +261,6 @@ Complete list of metrics
     - :class:`~ignite.metrics.SSIM`
     - :class:`~ignite.metrics.TopKCategoricalAccuracy`
     - :class:`~ignite.metrics.VariableAccumulation`
-    - :meth:`~ignite.metrics.metric.reinit__is_reduced`
-    - :meth:`~ignite.metrics.metric.sync_all_reduce`
 
 
 .. currentmodule:: ignite.metrics

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -256,13 +256,13 @@ Complete list of metrics
     - :class:`~ignite.metrics.MetricsLambda`
     - :class:`~ignite.metrics.Precision`
     - :class:`~ignite.metrics.Recall`
-    - :meth:`~ignite.metrics.metric.reinit__is_reduced`
     - :class:`~ignite.metrics.RootMeanSquaredError`
     - :class:`~ignite.metrics.RunningAverage`
     - :class:`~ignite.metrics.SSIM`
-    - :meth:`~ignite.metrics.metric.sync_all_reduce`
     - :class:`~ignite.metrics.TopKCategoricalAccuracy`
     - :class:`~ignite.metrics.VariableAccumulation`
+    - :meth:`~ignite.metrics.metric.reinit__is_reduced`
+    - :meth:`~ignite.metrics.metric.sync_all_reduce`
 
 
 .. currentmodule:: ignite.metrics
@@ -323,6 +323,7 @@ Complete list of metrics
 
 .. currentmodule:: ignite.metrics.metric
 
+.. autofunction:: reinit__is_reduced
+
 .. autofunction:: sync_all_reduce
 
-.. autofunction:: reinit__is_reduced

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -230,7 +230,7 @@ Metrics and distributed computations
 ------------------------------------
 
 In the above example, ``CustomAccuracy`` has ``reset``, ``update``, ``compute`` methods decorated
-with :meth:`~ignite.metrics.metric.reinit__is_reduced`, :meth:`ignite.metrics.metric.sync_all_reduce`. The purpose of these features is to adapt metrics in distributed
+with :meth:`~ignite.metrics.metric.reinit__is_reduced`, :meth:`~ignite.metrics.metric.sync_all_reduce`. The purpose of these features is to adapt metrics in distributed
 computations on supported backend and devices (see :doc:`distributed` for more details). More precisely, in the above
 example we added ``@sync_all_reduce("_num_examples", "_num_correct")`` over ``compute`` method. This means that when ``compute``
 method is called, metric's interal variables ``self._num_examples`` and ``self._num_correct`` are summed up over all participating

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -229,11 +229,11 @@ Complete list of usages
 Metrics and distributed computations
 ------------------------------------
 
-In the above example, ``CustomAccuracy`` has ``reset``, ``update``, ``compute`` methods
-decorated with ``reinit__is_reduced``, ``sync_all_reduce``. The purpose of these features is to adapt metrics in distributed
-computations on supported backend and devices (:doc:`distributed`). More precisely, in the above example we
-added ``@sync_all_reduce("_num_examples", "_num_correct")`` over ``compute`` method. This means that when ``compute`` method
-is called, metric's interal variables ``self._num_examples`` and ``self._num_correct`` are summed up over all participating
+In the above example, ``CustomAccuracy`` has ``reset``, ``update``, ``compute`` methods decorated
+with :meth:`~ignite.metrics.metric.reinit__is_reduced`, :meth:`ignite.metrics.metric.sync_all_reduce`. The purpose of these features is to adapt metrics in distributed
+computations on supported backend and devices (see :doc:`distributed` for more details). More precisely, in the above
+example we added ``@sync_all_reduce("_num_examples", "_num_correct")`` over ``compute`` method. This means that when ``compute``
+method is called, metric's interal variables ``self._num_examples`` and ``self._num_correct`` are summed up over all participating
 devices. Therefore, once collected, these internal variables can be used to compute the final metric value.
 
 Complete list of metrics
@@ -256,11 +256,14 @@ Complete list of metrics
     - :class:`~ignite.metrics.MetricsLambda`
     - :class:`~ignite.metrics.Precision`
     - :class:`~ignite.metrics.Recall`
+    - :meth:`~ignite.metrics.metric.reinit__is_reduced`
     - :class:`~ignite.metrics.RootMeanSquaredError`
     - :class:`~ignite.metrics.RunningAverage`
     - :class:`~ignite.metrics.SSIM`
+    - :meth:`~ignite.metrics.metric.sync_all_reduce`
     - :class:`~ignite.metrics.TopKCategoricalAccuracy`
     - :class:`~ignite.metrics.VariableAccumulation`
+
 
 .. currentmodule:: ignite.metrics
 


### PR DESCRIPTION

Fixes #1315  

Description:
Added links to `reinit__is_reduced` and `sync_all_reduce` decorators into `ignite.metrics` documentation.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
