### PR TITLE
Disable cross-ref links for type annotations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -192,3 +192,16 @@ intersphinx_mapping = {"https://docs.python.org/": None}
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Type hints configs ------------------------------------------------------
+
+autodoc_typehints = "signature"
+
+# -- A patch that turns-off cross refs for type annotations ------------------
+
+import sphinx.domains.python
+from docutils import nodes
+from sphinx import addnodes
+
+# replaces pending_xref node with desc_type for type annotations
+sphinx.domains.python.type_to_xref = lambda t, e=None: addnodes.desc_type("", nodes.Text(t))


### PR DESCRIPTION
Fixes #1369 

Description:

This will patch built-in type annotation parser and disable cross-ref links. This should fix issue signature rendering and [source]. At least for now, this patch works with `sphins` `3.1` and the latest one.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
