### PR TITLE
Fix collections DeprecationWarning

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
 import torch
@@ -28,7 +28,7 @@ __all__ = [
 
 def _prepare_batch(
     batch: Sequence[torch.Tensor], device: Optional[Union[str, torch.device]] = None, non_blocking: bool = False
-) -> Tuple[Union[torch.Tensor, collections.Sequence, collections.Mapping, str, bytes], ...]:
+) -> Tuple[Union[torch.Tensor, Sequence, Mapping, str, bytes], ...]:
     """Prepare batch for training: pass to a device with options.
 
     """


### PR DESCRIPTION
Description:
Fixed the accidental usage of `collections.Mapping` instead of `collections.abc.Mapping`, which resulted from the PR #1379 
