### PR TITLE
Remove module members w/o docstrings from autolist toc tables

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -276,6 +276,9 @@ class BetterAutosummary(Autosummary):
                     if not names:
                         names = [name[0] for name in getmembers(module)]
 
+                # Filter out members w/o doc strings
+                names = [name for name in names if getattr(module, name).__doc__ is not None]
+
                 if auto == "autolist":
                     # Get list of all classes and functions inside module
                     names = [


### PR DESCRIPTION
Related to: #1393  
Fixes: https://github.com/pytorch/ignite/pull/1393#issuecomment-715636757

Description:

Filter out module members w/o doc strings from module autolist

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
