### PR TITLE
Add --color=yes in pytest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,5 @@ markers =
     distributed: mark a test with distributed option
     multinode_distributed: mark a test with multi-node distributed option
     tpu: mark a test as requiring XLA
+addopts =
+    --color=yes


### PR DESCRIPTION


Description: Add --color=yes in pytest config for easier to find FAILED tests


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
