### PR TITLE
add tolerance for tpu in r2 and canberra tests

### DIFF
--- a/tests/ignite/contrib/metrics/regression/test_canberra_metric.py
+++ b/tests/ignite/contrib/metrics/regression/test_canberra_metric.py
@@ -63,7 +63,7 @@ def test_compute():
     assert canberra.pairwise([v1, v2])[0][1] == pytest.approx(np_sum)
 
 
-def _test_distrib_compute(device):
+def _test_distrib_compute(device, tol=1e-4):
     rank = idist.get_rank()
 
     canberra = DistanceMetric.get_metric("canberra")
@@ -85,7 +85,7 @@ def _test_distrib_compute(device):
         np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
         res = m.compute()
-        assert canberra.pairwise([np_y_pred, np_y])[0][1] == pytest.approx(res)
+        assert canberra.pairwise([np_y_pred, np_y])[0][1] == pytest.approx(res, abs=tol)
 
     for _ in range(3):
         _test("cpu")
@@ -141,12 +141,12 @@ def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distrib_compute(device, tol=1.e-3)
 
 
 def _test_distrib_xla_nprocs(index):
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distrib_compute(device, tol=1.e-3)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/regression/test_canberra_metric.py
+++ b/tests/ignite/contrib/metrics/regression/test_canberra_metric.py
@@ -63,7 +63,7 @@ def test_compute():
     assert canberra.pairwise([v1, v2])[0][1] == pytest.approx(np_sum)
 
 
-def _test_distrib_compute(device, tol=1e-4):
+def _test_distrib_compute(device):
     rank = idist.get_rank()
 
     canberra = DistanceMetric.get_metric("canberra")
@@ -85,7 +85,7 @@ def _test_distrib_compute(device, tol=1e-4):
         np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
         res = m.compute()
-        assert canberra.pairwise([np_y_pred, np_y])[0][1] == pytest.approx(res, abs=tol)
+        assert canberra.pairwise([np_y_pred, np_y])[0][1] == pytest.approx(res)
 
     for _ in range(3):
         _test("cpu")
@@ -141,12 +141,12 @@ def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
     device = idist.device()
-    _test_distrib_compute(device, tol=1.0e-3)
+    _test_distrib_compute(device)
 
 
 def _test_distrib_xla_nprocs(index):
     device = idist.device()
-    _test_distrib_compute(device, tol=1.0e-3)
+    _test_distrib_compute(device)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/regression/test_canberra_metric.py
+++ b/tests/ignite/contrib/metrics/regression/test_canberra_metric.py
@@ -141,12 +141,12 @@ def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
     device = idist.device()
-    _test_distrib_compute(device, tol=1.e-3)
+    _test_distrib_compute(device, tol=1.0e-3)
 
 
 def _test_distrib_xla_nprocs(index):
     device = idist.device()
-    _test_distrib_compute(device, tol=1.e-3)
+    _test_distrib_compute(device, tol=1.0e-3)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/regression/test_r2_score.py
+++ b/tests/ignite/contrib/metrics/regression/test_r2_score.py
@@ -91,7 +91,7 @@ def test_integration_r2_score_with_output_transform():
     assert r2_score(np_y, np_y_pred) == pytest.approx(r_squared)
 
 
-def _test_distrib_compute(device, tol=1e-4):
+def _test_distrib_compute(device, tol=1e-8):
     rank = idist.get_rank()
 
     def _test(metric_device):
@@ -167,12 +167,12 @@ def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
     device = idist.device()
-    _test_distrib_compute(device, tol=1.0e-3)
+    _test_distrib_compute(device, tol=1e-3)
 
 
 def _test_distrib_xla_nprocs(index):
     device = idist.device()
-    _test_distrib_compute(device, tol=1.0e-3)
+    _test_distrib_compute(device, tol=1e-3)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/regression/test_r2_score.py
+++ b/tests/ignite/contrib/metrics/regression/test_r2_score.py
@@ -91,7 +91,7 @@ def test_integration_r2_score_with_output_transform():
     assert r2_score(np_y, np_y_pred) == pytest.approx(r_squared)
 
 
-def _test_distrib_compute(device, tol=1e-8):
+def _test_distrib_compute(device, tol=1e-6):
     rank = idist.get_rank()
 
     def _test(metric_device):

--- a/tests/ignite/contrib/metrics/regression/test_r2_score.py
+++ b/tests/ignite/contrib/metrics/regression/test_r2_score.py
@@ -91,7 +91,7 @@ def test_integration_r2_score_with_output_transform():
     assert r2_score(np_y, np_y_pred) == pytest.approx(r_squared)
 
 
-def _test_distrib_compute(device):
+def _test_distrib_compute(device, tol=1e-4):
     rank = idist.get_rank()
 
     def _test(metric_device):
@@ -111,7 +111,7 @@ def _test_distrib_compute(device):
         np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
         res = m.compute()
-        assert r2_score(np_y, np_y_pred) == pytest.approx(res)
+        assert r2_score(np_y, np_y_pred) == pytest.approx(res, abs=tol)
 
     for _ in range(3):
         _test("cpu")
@@ -167,12 +167,12 @@ def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distrib_compute(device, tol=1.e-3)
 
 
 def _test_distrib_xla_nprocs(index):
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distrib_compute(device, tol=1.e-3)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/regression/test_r2_score.py
+++ b/tests/ignite/contrib/metrics/regression/test_r2_score.py
@@ -167,12 +167,12 @@ def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
     device = idist.device()
-    _test_distrib_compute(device, tol=1.e-3)
+    _test_distrib_compute(device, tol=1.0e-3)
 
 
 def _test_distrib_xla_nprocs(index):
     device = idist.device()
-    _test_distrib_compute(device, tol=1.e-3)
+    _test_distrib_compute(device, tol=1.0e-3)
 
 
 @pytest.mark.tpu


### PR DESCRIPTION
Fixes #1318 #1314 

Description:
Add tolerance for test of metrics r2 and canberra for TPU

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
