### PR TITLE
Save model with same filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 
-[![image](https://travis-ci.org/pytorch/ignite.svg?branch=master)](https://travis-ci.org/pytorch/ignite)
+[![image](https://travis-ci.com/pytorch/ignite.svg?branch=master)](https://travis-ci.org/pytorch/ignite)
 [![image](https://github.com/pytorch/ignite/workflows/.github/workflows/unittests.yml/badge.svg?branch=master)](https://github.com/pytorch/ignite/actions)
 [![image](https://img.shields.io/badge/-GPU%20tests-black?style=flat-square)](https://circleci.com/gh/pytorch/ignite)[![image](https://circleci.com/gh/pytorch/ignite.svg?style=svg)](https://circleci.com/gh/pytorch/ignite)
 [![image](https://codecov.io/gh/pytorch/ignite/branch/master/graph/badge.svg)](https://codecov.io/gh/pytorch/ignite)

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -356,13 +356,12 @@ class Checkpoint(Serializable):
                 "priority": priority,
             }
 
-            filename_already_exists = any(item.filename == filename for item in self._saved)
+            saved = [item for item in self._saved if item.filename != filename]
 
-            if filename_already_exists:
+            if self._saved != saved:
                 if isinstance(self.save_handler, BaseSaveHandler):
                     self.save_handler.remove(filename)
-                # list is purged
-                self._saved = [item for item in self._saved if item.filename != filename]
+                self._saved = saved
             elif not self._check_lt_n_saved():
                 item = self._saved.pop(0)
                 if isinstance(self.save_handler, BaseSaveHandler):

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -363,11 +363,10 @@ class Checkpoint(Serializable):
                     self.save_handler.remove(filename)
                 # list is purged
                 self._saved = [item for item in self._saved if item.filename != filename]
-            else:
-                if not self._check_lt_n_saved():
-                    item = self._saved.pop(0)
-                    if isinstance(self.save_handler, BaseSaveHandler):
-                        self.save_handler.remove(item.filename)
+            elif not self._check_lt_n_saved():
+                item = self._saved.pop(0)
+                if isinstance(self.save_handler, BaseSaveHandler):
+                    self.save_handler.remove(item.filename)
 
             self._saved.append(Checkpoint.Item(priority, filename))
             self._saved.sort(key=lambda item: item[0])

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -148,7 +148,7 @@ class Checkpoint(Serializable):
 
         **Warning:** Please, keep in mind that if filename collide with already used one to saved a checkpoint,
         new checkpoint will replace the older one. This means that filename like ``checkpoint.pt`` will be saved
-        every call and will always be overwrittDiskSaveren by newer checkpoints.
+        every call and will always be overwritten by newer checkpoints.
 
     Note:
         To get the last stored filename, handler exposes attribute ``last_checkpoint``:
@@ -350,6 +350,12 @@ class Checkpoint(Serializable):
             }
             filename = filename_pattern.format(**filename_dict)
 
+            metadata = {
+                "basename": "{}{}{}".format(self.filename_prefix, "_" * int(len(self.filename_prefix) > 0), name),
+                "score_name": self.score_name,
+                "priority": priority,
+            }
+
             filename_already_exists = any(item.filename == filename for item in self._saved)
 
             if filename_already_exists:
@@ -365,12 +371,6 @@ class Checkpoint(Serializable):
 
             self._saved.append(Checkpoint.Item(priority, filename))
             self._saved.sort(key=lambda item: item[0])
-
-            metadata = {
-                "basename": "{}{}{}".format(self.filename_prefix, "_" * int(len(self.filename_prefix) > 0), name),
-                "score_name": self.score_name,
-                "priority": priority,
-            }
 
             if self.include_self:
                 # Now that we've updated _saved, we can add our own state_dict.

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -356,19 +356,20 @@ class Checkpoint(Serializable):
                 "priority": priority,
             }
 
-            saved = [item for item in self._saved if item.filename != filename]
+            try:
+                index = list(map(lambda it: it.filename == filename, self._saved)).index(True)
+                to_remove = True
+            except ValueError:
+                index = 0
+                to_remove = not self._check_lt_n_saved()
 
-            if self._saved != saved:
-                if isinstance(self.save_handler, BaseSaveHandler):
-                    self.save_handler.remove(filename)
-                self._saved = saved
-            elif not self._check_lt_n_saved():
-                item = self._saved.pop(0)
+            if to_remove:
+                item = self._saved.pop(index)
                 if isinstance(self.save_handler, BaseSaveHandler):
                     self.save_handler.remove(item.filename)
 
             self._saved.append(Checkpoint.Item(priority, filename))
-            self._saved.sort(key=lambda item: item[0])
+            self._saved.sort(key=lambda it: it[0])
 
             if self.include_self:
                 # Now that we've updated _saved, we can add our own state_dict.

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -1464,7 +1464,7 @@ def test_checkpoint_fixed_filename():
         for i in range(10):
             trainer.state = State(epoch=i, iteration=i)
             checkpointer(trainer)
-            assert save_handler.call_count == i+1
+            assert save_handler.call_count == i + 1
             metadata = {"basename": "model", "score_name": None, "priority": i}
             save_handler.assert_called_with(model.state_dict(), "model.pt", metadata)
 


### PR DESCRIPTION
Fixes #1421 

Description:

This solves the problem to do not save model with an existing filename. Now, filename is overwritten.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
