### PR TITLE
enable extra flags for stricter type checking

### DIFF
--- a/ignite/contrib/metrics/gpu_info.py
+++ b/ignite/contrib/metrics/gpu_info.py
@@ -59,7 +59,9 @@ class GpuInfo(Metric):
         pass
 
     def compute(self) -> List[Dict[str, Any]]:
-        data = self.nvsmi.DeviceQuery("memory.used, memory.total, utilization.gpu")
+        data = self.nvsmi.DeviceQuery(
+            "memory.used, memory.total, utilization.gpu"
+        )  # type: Dict[str, List[Dict[str, Any]]]
         if len(data) == 0 or ("gpu" not in data):
             warnings.warn("No GPU information available")
             return []

--- a/ignite/distributed/comp_models/__init__.py
+++ b/ignite/distributed/comp_models/__init__.py
@@ -1,13 +1,22 @@
+from typing import TYPE_CHECKING, List, Tuple, Type, Union
+
 from ignite.distributed.comp_models.base import _SerialModel
 from ignite.distributed.comp_models.horovod import has_hvd_support
 from ignite.distributed.comp_models.native import has_native_dist_support
 from ignite.distributed.comp_models.xla import has_xla_support
 
+if TYPE_CHECKING:
+    from ignite.distributed.comp_models.horovod import _HorovodDistModel
+    from ignite.distributed.comp_models.native import _NativeDistModel
+    from ignite.distributed.comp_models.xla import _XlaDistModel
 
-def setup_available_computation_models():  # type: ignore # inhomogeneous Tuple types are not supported
+
+def setup_available_computation_models() -> Tuple[
+    Type[Union[_SerialModel, "_NativeDistModel", "_XlaDistModel", "_HorovodDistModel"]], ...
+]:
     models = [
         _SerialModel,
-    ]
+    ]  # type: List[Type[Union[_SerialModel, "_NativeDistModel", "_XlaDistModel", "_HorovodDistModel"]]]
     if has_native_dist_support:
         from ignite.distributed.comp_models.native import _NativeDistModel
 

--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -15,11 +15,11 @@ class ComputationModel(metaclass=ABCMeta):
     # this is an additional local rank storage used when idist is setup from existing native torch dist context
     _ext_local_rank = None  # type: Optional[int]
 
-    def __init__(self):
-        self._backend = None
-        self._nproc_per_node = None
-        self._nnodes = None
-        self._node = None
+    def __init__(self) -> None:
+        self._backend = None  # type: Optional[str]
+        self._nproc_per_node = None  # type: Optional[int]
+        self._nnodes = None  # type: Optional[int]
+        self._node = None  # type: Optional[int]
 
     def _setup_attrs(self) -> None:
         if self._nproc_per_node is None:

--- a/ignite/distributed/comp_models/horovod.py
+++ b/ignite/distributed/comp_models/horovod.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from typing import Any, Callable, Mapping, Optional, Tuple
+from typing import Any, Callable, Mapping, Optional, Tuple, cast
 
 import torch
 
@@ -62,7 +62,7 @@ if has_hvd_support:
             """This is a private method. Please, use `create_from_backend` or `create_from_context`
             """
             super(_HorovodDistModel, self).__init__()
-            self._backend = HOROVOD
+            self._backend = HOROVOD  # type: str
             if do_init:
                 comm = kwargs.get("comm", None)
                 hvd.init(comm=comm)
@@ -87,13 +87,13 @@ if has_hvd_support:
             return hvd.size()
 
         def get_nproc_per_node(self) -> int:
-            return self._nproc_per_node
+            return cast(int, self._nproc_per_node)
 
         def get_nnodes(self) -> int:
-            return self._nnodes
+            return cast(int, self._nnodes)
 
         def get_node_rank(self) -> int:
-            return self._node
+            return cast(int, self._node)
 
         def device(self) -> torch.device:
             if torch.cuda.is_available():

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import warnings
 from distutils.version import LooseVersion
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, cast
 
 import torch
 import torch.distributed as dist
@@ -214,13 +214,13 @@ if has_native_dist_support:
             return dist.get_world_size()
 
         def get_nproc_per_node(self) -> int:
-            return self._nproc_per_node
+            return cast(int, self._nproc_per_node)
 
         def get_nnodes(self) -> int:
-            return self._nnodes
+            return cast(int, self._nnodes)
 
         def get_node_rank(self) -> int:
-            return self._node
+            return cast(int, self._node)
 
         def device(self) -> torch.device:
             if self.backend() == dist.Backend.NCCL:

--- a/ignite/distributed/comp_models/xla.py
+++ b/ignite/distributed/comp_models/xla.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Mapping, Optional, Tuple
+from typing import Any, Callable, Mapping, Optional, Tuple, cast
 
 import torch
 
@@ -53,7 +53,7 @@ if has_xla_support:
         def _create_from_backend(self, backend: str, **kwargs: Any) -> None:
             xm.rendezvous("init")
 
-            self._backend = backend
+            self._backend = backend  # type: str
             self._setup_attrs()
 
         def _init_from_context(self) -> None:
@@ -75,13 +75,13 @@ if has_xla_support:
             return xm.xrt_world_size()
 
         def get_nproc_per_node(self) -> int:
-            return self._nproc_per_node
+            return cast(int, self._nproc_per_node)
 
         def get_nnodes(self) -> int:
-            return self._nnodes
+            return cast(int, self._nnodes)
 
         def get_node_rank(self) -> int:
-            return self._node
+            return cast(int, self._node)
 
         def device(self) -> torch.device:
             dev = torch_xla._XLAC._xla_get_default_device()

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -175,7 +175,7 @@ class Parallel:
 
     def __init__(
         self,
-        backend: str = None,
+        backend: Optional[str] = None,
         nproc_per_node: Optional[int] = None,
         nnodes: Optional[int] = None,
         node_rank: Optional[int] = None,

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -496,7 +496,7 @@ def initialize(backend: str, **kwargs: Any) -> None:
     for comp_model_cls in registered_computation_models:
         if backend not in comp_model_cls.available_backends:
             continue
-        _set_model(comp_model_cls(backend, **kwargs))
+        _set_model(comp_model_cls(backend, **kwargs))  # type: ignore[arg-type]
 
 
 def finalize() -> None:

--- a/ignite/handlers/__init__.py
+++ b/ignite/handlers/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Union
+from typing import Any, Callable, Optional, Union
 
 from ignite.engine import Engine
 from ignite.engine.events import Events
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 
-def global_step_from_engine(engine: Engine, custom_event_name=None) -> Callable:
+def global_step_from_engine(engine: Engine, custom_event_name: Optional[Events] = None) -> Callable:
     """Helper method to setup `global_step_transform` function using another engine.
     This can be helpful for logging trainer epoch/iteration while output handler is attached to an evaluator.
 
@@ -30,7 +30,7 @@ def global_step_from_engine(engine: Engine, custom_event_name=None) -> Callable:
         global step
     """
 
-    def wrapper(_: Any, event_name: Events):
+    def wrapper(_: Any, event_name: Events) -> int:
         if custom_event_name is not None:
             event_name = custom_event_name
         return engine.state.get_event_attrib_value(event_name)

--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -1,6 +1,6 @@
 import logging
 from collections import OrderedDict
-from typing import Callable, Mapping
+from typing import Callable, Mapping, Optional, cast
 
 from ignite.base import Serializable
 from ignite.engine import Engine
@@ -75,7 +75,7 @@ class EarlyStopping(Serializable):
         self.cumulative_delta = cumulative_delta
         self.trainer = trainer
         self.counter = 0
-        self.best_score = None
+        self.best_score = None  # type: Optional[float]
         self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
 
     def __call__(self, engine: Engine) -> None:
@@ -95,8 +95,8 @@ class EarlyStopping(Serializable):
             self.best_score = score
             self.counter = 0
 
-    def state_dict(self) -> OrderedDict:
-        return OrderedDict([("counter", self.counter), ("best_score", self.best_score)])
+    def state_dict(self) -> "OrderedDict[str, float]":
+        return OrderedDict([("counter", self.counter), ("best_score", cast(float, self.best_score))])
 
     def load_state_dict(self, state_dict: Mapping) -> None:
         super().load_state_dict(state_dict)

--- a/ignite/handlers/timing.py
+++ b/ignite/handlers/timing.py
@@ -1,5 +1,5 @@
 from time import perf_counter
-from typing import Optional
+from typing import Any, Optional
 
 from ignite.engine import Engine, Events
 
@@ -76,13 +76,10 @@ class Timer:
         ...              step=Events.ITERATION_COMPLETED)
     """
 
-    def __init__(self, average: bool = False):
+    def __init__(self, average: bool = False) -> None:
         self._average = average
-        self._t0 = perf_counter()
 
-        self.total = 0.0
-        self.step_count = 0.0
-        self.running = True
+        self.reset()
 
     def attach(
         self,
@@ -91,7 +88,7 @@ class Timer:
         pause: Events = Events.COMPLETED,
         resume: Optional[Events] = None,
         step: Optional[Events] = None,
-    ):
+    ) -> "Timer":
         """ Register callbacks to control the timer.
 
         Args:
@@ -122,16 +119,20 @@ class Timer:
 
         return self
 
-    def reset(self, *args):
-        self.__init__(self._average)
+    def reset(self, *args: Any) -> "Timer":
+        self._t0 = perf_counter()
+        self.total = 0.0
+        self.step_count = 0.0
+        self.running = True
+
         return self
 
-    def pause(self, *args) -> None:
+    def pause(self, *args: Any) -> None:
         if self.running:
             self.total += self._elapsed()
             self.running = False
 
-    def resume(self, *args) -> None:
+    def resume(self, *args: Any) -> None:
         if not self.running:
             self.running = True
             self._t0 = perf_counter()
@@ -148,7 +149,7 @@ class Timer:
 
         return total / denominator
 
-    def step(self, *args) -> None:
+    def step(self, *args: Any) -> None:
         self.step_count += 1.0
 
     def _elapsed(self) -> float:

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -166,7 +166,7 @@ def IoU(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> MetricsLambd
 
     # Increase floating point precision and pass to CPU
     cm = cm.type(torch.DoubleTensor)
-    iou = cm.diag() / (cm.sum(dim=1) + cm.sum(dim=0) - cm.diag() + 1e-15)
+    iou = cm.diag() / (cm.sum(dim=1) + cm.sum(dim=0) - cm.diag() + 1e-15)  # type: MetricsLambda
     if ignore_index is not None:
         ignore_idx = ignore_index  # type: int  # used due to typing issues with mympy
 
@@ -208,7 +208,8 @@ def mIoU(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> MetricsLamb
 
 
     """
-    return IoU(cm=cm, ignore_index=ignore_index).mean()
+    iou = IoU(cm=cm, ignore_index=ignore_index).mean()  # type: MetricsLambda
+    return iou
 
 
 def cmAccuracy(cm: ConfusionMatrix) -> MetricsLambda:
@@ -222,7 +223,8 @@ def cmAccuracy(cm: ConfusionMatrix) -> MetricsLambda:
     """
     # Increase floating point precision and pass to CPU
     cm = cm.type(torch.DoubleTensor)
-    return cm.diag().sum() / (cm.sum() + 1e-15)
+    accuracy = cm.diag().sum() / (cm.sum() + 1e-15)  # type: MetricsLambda
+    return accuracy
 
 
 def cmPrecision(cm: ConfusionMatrix, average: bool = True) -> MetricsLambda:
@@ -237,9 +239,10 @@ def cmPrecision(cm: ConfusionMatrix, average: bool = True) -> MetricsLambda:
 
     # Increase floating point precision and pass to CPU
     cm = cm.type(torch.DoubleTensor)
-    precision = cm.diag() / (cm.sum(dim=0) + 1e-15)
+    precision = cm.diag() / (cm.sum(dim=0) + 1e-15)  # type: MetricsLambda
     if average:
-        return precision.mean()
+        mean = precision.mean()  # type: MetricsLambda
+        return mean
     return precision
 
 
@@ -255,9 +258,10 @@ def cmRecall(cm: ConfusionMatrix, average: bool = True) -> MetricsLambda:
 
     # Increase floating point precision and pass to CPU
     cm = cm.type(torch.DoubleTensor)
-    recall = cm.diag() / (cm.sum(dim=1) + 1e-15)
+    recall = cm.diag() / (cm.sum(dim=1) + 1e-15)  # type: MetricsLambda
     if average:
-        return recall.mean()
+        mean = recall.mean()  # type: MetricsLambda
+        return mean
     return recall
 
 
@@ -278,7 +282,7 @@ def DiceCoefficient(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> 
 
     # Increase floating point precision and pass to CPU
     cm = cm.type(torch.DoubleTensor)
-    dice = 2.0 * cm.diag() / (cm.sum(dim=1) + cm.sum(dim=0) + 1e-15)
+    dice = 2.0 * cm.diag() / (cm.sum(dim=1) + cm.sum(dim=0) + 1e-15)  # type: MetricsLambda
 
     if ignore_index is not None:
         ignore_idx = ignore_index  # type: int  # used due to typing issues with mympy

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,27 @@ files = ignite
 pretty = True
 show_error_codes = True
 
+check_untyped_defs = True
+; a lot of work needed to fix issues
+disallow_any_generics = False
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+; due to missing types in pytorch set to False
+disallow_untyped_calls = False
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+; would need a more precise import of pytorch classes and methods, which is not possible, therefore set to False
+no_implicit_reexport = False
+strict_equality = True
+warn_redundant_casts = True
+; due to missing types in multiple libs set to False
+warn_return_any = False
+; results in too many false positives, therefore set to False
+warn_unreachable = False
+warn_unused_configs = True
+warn_unused_ignores = True
+
 [mypy-ignite.contrib.handlers.*]
 
 ignore_errors = True


### PR DESCRIPTION
@vfdev-5 Sorry, was to lazy to create an issue for it 😄 

Description:
I enabled as much extra `mypy` flags as possible and fixed related issues. For each flag, which `mypy` would normally set to `True`, if the strict mode is used, I added a comment, why I disabled it.
