### PR TITLE
Add missing classes and links for engine docs

### DIFF
--- a/docs/source/engine.rst
+++ b/docs/source/engine.rst
@@ -15,6 +15,12 @@ Main module of the library containing:
     :nosignatures:
     :autolist:
 
+.. currentmodule:: ignite.engine.deterministic
+
+.. autosummary::
+    :nosignatures:
+    :autolist:
+
 and helper methods:
 
 .. currentmodule:: ignite.engine
@@ -98,6 +104,9 @@ ignite.engine.events
 --------------------
 
 .. currentmodule:: ignite.engine.events
+
+.. autoclass:: CallableEventWithFilter
+   :members:
 
 .. autoclass:: Events
    :members:


### PR DESCRIPTION
Fixes #1459 

Description:

Add missing classes from `engine` module, fix link for `CallableEventWithFilter`

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
