### PR TITLE
Add dict in metrics results

### DIFF
--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -307,7 +307,7 @@ class Metric(metaclass=ABCMeta):
             if name in result.keys():
                 raise ValueError(
                     "Argument name '{}' is conflicting with mapping keys: {}".format(name, list(result.keys()))
-                 )
+                )
 
             for key, value in result.items():
                 engine.state.metrics[key] = value

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -305,7 +305,9 @@ class Metric(metaclass=ABCMeta):
         result = self.compute()
         if isinstance(result, Mapping):
             if name in result.keys():
-                raise ValueError("name of metric is conflicting with mapping keys")
+                raise ValueError(
+                    "Argument name '{}' is conflicting with mapping keys: {}".format(name, list(result.keys()))
+                 )
 
             for key, value in result.items():
                 engine.state.metrics[key] = value

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -300,11 +300,16 @@ class Metric(metaclass=ABCMeta):
 
         Args:
             engine (Engine): the engine to which the metric must be attached
+            name (str): the name of the metric used as key in dict `engine.state.metrics`
         """
         result = self.compute()
         if isinstance(result, Mapping):
+            if name in result.keys():
+                raise ValueError("name of metric is conflicting with mapping keys")
+
             for key, value in result.items():
                 engine.state.metrics[key] = value
+            engine.state.metrics[name] = result
         else:
             if isinstance(result, torch.Tensor) and len(result.size()) == 0:
                 result = result.item()

--- a/tests/ignite/metrics/test_metric.py
+++ b/tests/ignite/metrics/test_metric.py
@@ -672,7 +672,7 @@ def test_completed():
     engine = MagicMock(state=State(metrics={}))
     metrics = {"foo": 1, "bar": torch.tensor(2.0), "baz": {"qux": "quux"}}
     m.compute = MagicMock(return_value=metrics)
-    with pytest.raises(ValueError, match=r"name of metric is conflicting with mapping keys"):
+    with pytest.raises(ValueError, match=r"Argument name 'foo' is conflicting with mapping keys"):
         m.completed(engine, "foo")
     m.completed(engine, "metric")
     metrics["metric"] = metrics

--- a/tests/ignite/metrics/test_metric.py
+++ b/tests/ignite/metrics/test_metric.py
@@ -672,7 +672,10 @@ def test_completed():
     engine = MagicMock(state=State(metrics={}))
     metrics = {"foo": 1, "bar": torch.tensor(2.0), "baz": {"qux": "quux"}}
     m.compute = MagicMock(return_value=metrics)
+    with pytest.raises(ValueError, match=r"name of metric is conflicting with mapping keys"):
+        m.completed(engine, "foo")
     m.completed(engine, "metric")
+    metrics["metric"] = metrics
     assert engine.state.metrics == metrics
 
     # other


### PR DESCRIPTION
Fixes #1476 

Description:

As discussed, in case of metrics returning dict, in addition to flattened values, dict is added.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
