### PR TITLE
Fix `setup_logger` docstring formatting

### DIFF
--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -75,7 +75,7 @@ def setup_logger(
         format (str): logging format. By default, `%(asctime)s %(name)s %(levelname)s: %(message)s`
         filepath (str, optional): Optional logging file path. If not None, logs are written to the file.
         distributed_rank (int, optional): Optional, rank in distributed configuration to avoid logger setup for workers.
-        If None, distributed_rank is initialized to the rank of process.
+            If None, distributed_rank is initialized to the rank of process.
 
     Returns:
         logging.Logger


### PR DESCRIPTION
Description: Fix `setup_logger` docstring formatting for `distributed_rank` argument.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [x] Documentation is updated (if required)
