### PR TITLE
Drop python 3.5 support in the CI

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -13,15 +13,11 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         pytorch-version: [1.7.0, 1.6.0, 1.5.1, 1.4.0, 1.3.1]
         exclude:
           - pytorch-version: 1.3.1
             python-version: 3.8
-          - pytorch-version: 1.6.0
-            python-version: 3.5
-          - pytorch-version: 1.7.0
-            python-version: 3.5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,12 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         pytorch-channel: [pytorch, pytorch-nightly]
-        exclude:
-          # excludes pytorch-nightly python 3.5 as it was dropped
-          - pytorch-channel: pytorch-nightly
-            python-version: 3.5
         include:
           # includes a single build on windows
           - os: windows-latest
@@ -82,7 +78,7 @@ jobs:
 
       - name: Run Mypy
         shell: bash -l {0}
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version != '3.5' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           pip install mypy
           mypy --config-file mypy.ini


### PR DESCRIPTION
Fixes #1495  

Description:

Drops python3.5 from CI configs

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
