### PR TITLE
Fix attach_opt_params_handler return statement

### DIFF
--- a/ignite/contrib/handlers/base_logger.py
+++ b/ignite/contrib/handlers/base_logger.py
@@ -186,7 +186,9 @@ class BaseLogger(metaclass=ABCMeta):
         """
         return self.attach(engine, self._create_output_handler(*args, **kwargs), event_name=event_name)
 
-    def attach_opt_params_handler(self, engine: Engine, event_name: Any, *args: Any, **kwargs: Any) -> RemovableEventHandle:
+    def attach_opt_params_handler(
+        self, engine: Engine, event_name: Any, *args: Any, **kwargs: Any
+    ) -> RemovableEventHandle:
         """Shortcut method to attach `OptimizerParamsHandler` to the logger.
 
         Args:

--- a/ignite/contrib/handlers/base_logger.py
+++ b/ignite/contrib/handlers/base_logger.py
@@ -186,7 +186,7 @@ class BaseLogger(metaclass=ABCMeta):
         """
         return self.attach(engine, self._create_output_handler(*args, **kwargs), event_name=event_name)
 
-    def attach_opt_params_handler(self, engine: Engine, event_name: Any, *args: Any, **kwargs: Any) -> None:
+    def attach_opt_params_handler(self, engine: Engine, event_name: Any, *args: Any, **kwargs: Any) -> RemovableEventHandle:
         """Shortcut method to attach `OptimizerParamsHandler` to the logger.
 
         Args:
@@ -200,7 +200,7 @@ class BaseLogger(metaclass=ABCMeta):
         Returns:
             :class:`~ignite.engine.RemovableEventHandle`, which can be used to remove the handler.
         """
-        self.attach(engine, self._create_opt_params_handler(*args, **kwargs), event_name=event_name)
+        return self.attach(engine, self._create_opt_params_handler(*args, **kwargs), event_name=event_name)
 
     @abstractmethod
     def _create_output_handler(self, engine: Engine, *args: Any, **kwargs: Any) -> Callable:

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -6,7 +6,7 @@ import torch
 
 from ignite.contrib.handlers.base_logger import BaseLogger, BaseOutputHandler
 from ignite.engine import Engine, Events
-from ignite.engine.events import CallableEventWithFilter
+from ignite.engine.events import CallableEventWithFilter, RemovableEventHandle
 
 
 class ProgressBar(BaseLogger):
@@ -203,7 +203,7 @@ class ProgressBar(BaseLogger):
 
     def attach_opt_params_handler(
         self, engine: Engine, event_name: Union[str, Events], *args: Any, **kwargs: Any
-    ) -> None:
+    ) -> RemovableEventHandle:
         """Intentionally empty"""
         pass
 


### PR DESCRIPTION
I monkey patched this small bug in my project so I might as well contribute it. I hope I haven't broken something.

Description:
This pull request adds the missing return statement such that the function `attach_opt_params_handler` returns a `RemovableEventHandle` like mentioned in the documentation.

Check list:
* [X] New tests are added (if a new feature is added) (no new feature)
* [X] New doc strings: description and/or example code are in RST format (not necessary)
* [X] Documentation is updated (if required) (not necessary)
