### PR TITLE
Revert "[docker] Pillow to Pillow-SIMD"

### DIFF
--- a/docker/hvd/Dockerfile.hvd-apex-vision
+++ b/docker/hvd/Dockerfile.hvd-apex-vision
@@ -15,6 +15,5 @@ RUN pip install --upgrade --no-cache-dir albumentations \
                                          numpy \
                                          opencv-python \
                                          py_config_runner \
+                                         pillow \
                                          "trains>=0.15.0"
-
-RUN pip uninstall -y pillow && CC="cc -mavx2" pip install -U --force-reinstall pillow-simd

--- a/docker/hvd/Dockerfile.hvd-vision
+++ b/docker/hvd/Dockerfile.hvd-vision
@@ -15,6 +15,5 @@ RUN pip install --upgrade --no-cache-dir albumentations \
                                          numpy \
                                          opencv-python \
                                          py_config_runner \
+                                         pillow \
                                          "trains>=0.15.0"
-
-RUN pip uninstall -y pillow && CC="cc -mavx2" pip install -U --force-reinstall pillow-simd

--- a/docker/main/Dockerfile.apex-vision
+++ b/docker/main/Dockerfile.apex-vision
@@ -15,6 +15,5 @@ RUN pip install --upgrade --no-cache-dir albumentations \
                                          numpy \
                                          opencv-python \
                                          py_config_runner \
+                                         pillow \
                                          "trains>=0.15.0"
-
-RUN pip uninstall -y pillow && CC="cc -mavx2" pip install -U --force-reinstall pillow-simd

--- a/docker/msdp/Dockerfile.msdp-apex-vision
+++ b/docker/msdp/Dockerfile.msdp-apex-vision
@@ -15,6 +15,5 @@ RUN pip install --upgrade --no-cache-dir albumentations \
                                          numpy \
                                          opencv-python \
                                          py_config_runner \
+                                         pillow \
                                          "trains>=0.15.0"
-
-RUN pip uninstall -y pillow && CC="cc -mavx2" pip install -U --force-reinstall pillow-simd


### PR DESCRIPTION
Reverts pytorch/ignite#1506

New dockerfile do not work
```
unable to execute 'cc': No such file or directory

The command '/bin/sh -c pip uninstall -y pillow && CC="cc -mavx2" pip install -U --force-reinstall pillow-simd' returned a non-zero code: 1
```
as there is no building tools on runtime pytorch image.

cc @ydcjeff 