### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/ignite/contrib/handlers/lr_finder.py
+++ b/ignite/contrib/handlers/lr_finder.py
@@ -362,7 +362,7 @@ class _ExponentialLR(_LRScheduler):
     """Exponentially increases the learning rate between two boundaries over a number of
     iterations.
 
-    Arguments:
+    Args:
         optimizer (torch.optim.Optimizer): wrapped optimizer.
         end_lr (float, optional): the initial learning rate which is the lower
             boundary of the test. Default: 10.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue when I was parsing/generating from the TensorFlow—and now PyTorch—codebases: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see pytorch/pytorch/pull/49736