### PR TITLE
[docs] fix a few formatting

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -7,7 +7,7 @@ Helper module to use distributed settings for multiple backends:
 
 - XLA on TPUs via `pytorch/xla <https://github.com/pytorch/xla>`_
 
-- using `Horovod distributed framework <https://horovod.readthedocs.io/en/stable/>`_ as a backend
+- using `Horovod framework <https://horovod.readthedocs.io/en/stable/>`_ as a backend
 
 
 Distributed launcher and `auto` helpers

--- a/docs/source/engine.rst
+++ b/docs/source/engine.rst
@@ -133,13 +133,13 @@ Deterministic training
 ``````````````````````
 
 In general, it is rather difficult task to achieve deterministic and reproducible trainings as it relies on multiple
-aspects, e.g. data version, code version, software environment, hardware etc. According to `PyTorch documentation <https://pytorch.org/docs/stable/notes/randomness.html>`__:
+aspects, e.g. data version, code version, software environment, hardware etc. According to `PyTorch note on randomness <https://pytorch.org/docs/stable/notes/randomness.html>`_:
 there are some steps to take in order to make computations deterministic on your specific problem on one specific
 platform and PyTorch release:
 
 - setup random state seed
 
-- set `cudnn to deterministic <https://pytorch.org/docs/stable/notes/randomness.html#cudnn>`__ if applicable
+- set `cudnn to deterministic <https://pytorch.org/docs/stable/notes/randomness.html#cuda-convolution-benchmarking>`_ if applicable
 
 By default, these two options can be enough to run and rerun experiments in a deterministic way. Ignite's engine does not impact this behaviour.
 

--- a/docs/source/engine.rst
+++ b/docs/source/engine.rst
@@ -133,13 +133,13 @@ Deterministic training
 ``````````````````````
 
 In general, it is rather difficult task to achieve deterministic and reproducible trainings as it relies on multiple
-aspects, e.g. data version, code version, software environment, hardware etc. According to `PyTorch documentation <https://pytorch.org/docs/stable/notes/randomness.html>`_:
+aspects, e.g. data version, code version, software environment, hardware etc. According to `PyTorch documentation <https://pytorch.org/docs/stable/notes/randomness.html>`__:
 there are some steps to take in order to make computations deterministic on your specific problem on one specific
 platform and PyTorch release:
 
 - setup random state seed
 
-- set `cudnn to deterministic <https://pytorch.org/docs/stable/notes/randomness.html#cudnn>`_ if applicable
+- set `cudnn to deterministic <https://pytorch.org/docs/stable/notes/randomness.html#cudnn>`__ if applicable
 
 By default, these two options can be enough to run and rerun experiments in a deterministic way. Ignite's engine does not impact this behaviour.
 

--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -567,7 +567,7 @@ class NeptuneSaver(BaseSaveHandler):
 
             evaluator.add_event_handler(Events.COMPLETED, handler)
 
-        # We need to close the logger when we are done
+            # We need to close the logger when we are done
             npt_logger.close()
 
     For example, you can access model checkpoints and download them from here:

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -15,7 +15,7 @@ class Parallel:
 
     - XLA on TPUs via `pytorch/xla <https://github.com/pytorch/xla>`_ (if installed)
 
-    - using `Horovod distributed framework <https://horovod.readthedocs.io>`__ (if installed)
+    - using `Horovod distributed framework <https://horovod.readthedocs.io>`_ (if installed)
 
     Namely, it can 1) spawn ``nproc_per_node`` child processes and initialize a processing group according to
     provided ``backend`` (useful for standalone scripts) or 2) only initialize a processing group given the ``backend``

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -15,7 +15,7 @@ class Parallel:
 
     - XLA on TPUs via `pytorch/xla <https://github.com/pytorch/xla>`_ (if installed)
 
-    - using `Horovod distributed framework <https://horovod.readthedocs.io>`_ (if installed)
+    - using `Horovod distributed framework <https://horovod.readthedocs.io>`__ (if installed)
 
     Namely, it can 1) spawn ``nproc_per_node`` child processes and initialize a processing group according to
     provided ``backend`` (useful for standalone scripts) or 2) only initialize a processing group given the ``backend``

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -16,8 +16,8 @@ class ConfusionMatrix(Metric):
     - ``update`` must receive output of the form ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``.
     - `y_pred` must contain logits and has the following shape (batch_size, num_categories, ...)
     - `y` should have the following shape (batch_size, ...) and contains ground-truth class indices
-        with or without the background class. During the computation, argmax of `y_pred` is taken to determine
-        predicted classes.
+      with or without the background class. During the computation, argmax of `y_pred` is taken to determine
+      predicted classes.
 
     Args:
         num_classes (int): number of classes. See notes for more details.

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ ignore = E402, E721
 max_line_length = 120
 
 [isort]
-known_third_party=dill,matplotlib,numpy,pkg_resources,pytest,setuptools,sklearn,torch,torchvision,trains
+known_third_party=dill,matplotlib,numpy,pkg_resources,pytest,requests,setuptools,sklearn,torch,torchvision,trains
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Description: Fix a few docs formatting in `ConfusionMatrix`, neptune logger, engine page and `Paralell` docstring

Some are for fixing docs WARNING when building. There are still 2 WARNINGS left to do which I have no idea how to.

```py
docs/source/utils.rst:11:<autosummary>:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
docs/source/contrib/handlers.rst:5: WARNING: Could not lex literal_block as "python". Highlighting skipped.
```