### PR TITLE
Use events list for logger handlers

### DIFF
--- a/ignite/contrib/handlers/base_logger.py
+++ b/ignite/contrib/handlers/base_logger.py
@@ -155,8 +155,8 @@ class BaseLogger(metaclass=ABCMeta):
             engine (Engine): engine object.
             log_handler (callable): a logging handler to execute
             event_name: event to attach the logging handler to. Valid events are from
-                :class:`~ignite.engine.events.Events` or any `event_name` added by
-                :meth:`~ignite.engine.engine.Engine.register_events`.
+                :class:`~ignite.engine.events.Events` or class:`~ignite.engine.events.EventsList` or any `event_name`
+                added by :meth:`~ignite.engine.engine.Engine.register_events`.
 
         Returns:
             :class:`~ignite.engine.RemovableEventHandle`, which can be used to remove the handler.

--- a/ignite/contrib/handlers/base_logger.py
+++ b/ignite/contrib/handlers/base_logger.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 from torch.optim import Optimizer
 
-from ignite.engine import Engine, Events, State
+from ignite.engine import Engine, Events, EventsList, State
 from ignite.engine.events import CallableEventWithFilter, RemovableEventHandle
 
 
@@ -147,7 +147,7 @@ class BaseLogger(metaclass=ABCMeta):
     """
 
     def attach(
-        self, engine: Engine, log_handler: Callable, event_name: Union[str, Events, CallableEventWithFilter]
+        self, engine: Engine, log_handler: Callable, event_name: Union[str, Events, CallableEventWithFilter, EventsList]
     ) -> RemovableEventHandle:
         """Attach the logger to the engine and execute `log_handler` function at `event_name` events.
 
@@ -161,12 +161,21 @@ class BaseLogger(metaclass=ABCMeta):
         Returns:
             :class:`~ignite.engine.RemovableEventHandle`, which can be used to remove the handler.
         """
-        name = event_name
+        if isinstance(event_name, EventsList):
+            for name in event_name:
+                if name not in State.event_to_attr:
+                    raise RuntimeError(f"Unknown event name '{name}'")
+                engine.add_event_handler(name, log_handler, self, name)
 
-        if name not in State.event_to_attr:
-            raise RuntimeError(f"Unknown event name '{name}'")
+            return RemovableEventHandle(event_name, log_handler, engine)
 
-        return engine.add_event_handler(event_name, log_handler, self, name)
+        else:
+            name = event_name
+
+            if name not in State.event_to_attr:
+                raise RuntimeError(f"Unknown event name '{name}'")
+
+            return engine.add_event_handler(event_name, log_handler, self, name)
 
     def attach_output_handler(self, engine: Engine, event_name: Any, *args: Any, **kwargs: Any) -> RemovableEventHandle:
         """Shortcut method to attach `OutputHandler` to the logger.

--- a/ignite/contrib/handlers/base_logger.py
+++ b/ignite/contrib/handlers/base_logger.py
@@ -170,12 +170,11 @@ class BaseLogger(metaclass=ABCMeta):
             return RemovableEventHandle(event_name, log_handler, engine)
 
         else:
-            name = event_name
 
-            if name not in State.event_to_attr:
-                raise RuntimeError(f"Unknown event name '{name}'")
+            if event_name not in State.event_to_attr:
+                raise RuntimeError(f"Unknown event name '{event_name}'")
 
-            return engine.add_event_handler(event_name, log_handler, self, name)
+            return engine.add_event_handler(event_name, log_handler, self, event_name)
 
     def attach_output_handler(self, engine: Engine, event_name: Any, *args: Any, **kwargs: Any) -> RemovableEventHandle:
         """Shortcut method to attach `OutputHandler` to the logger.

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -6,7 +6,7 @@ import torch
 import ignite.distributed as idist
 from ignite.engine.deterministic import DeterministicEngine
 from ignite.engine.engine import Engine
-from ignite.engine.events import CallableEventWithFilter, EventEnum, Events, State
+from ignite.engine.events import CallableEventWithFilter, EventEnum, Events, EventsList, State, RemovableEventHandle
 from ignite.metrics import Metric
 from ignite.utils import convert_tensor
 
@@ -21,8 +21,10 @@ __all__ = [
     "Engine",
     "DeterministicEngine",
     "Events",
+    "EventsList",
     "EventEnum",
     "CallableEventWithFilter",
+    "RemovableEventHandle",
 ]
 
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -12,7 +12,7 @@ from ignite.engine.utils import _check_signature
 if TYPE_CHECKING:
     from ignite.engine.engine import Engine
 
-__all__ = ["CallableEventWithFilter", "EventEnum", "Events", "State"]
+__all__ = ["CallableEventWithFilter", "EventEnum", "Events", "State", "EventsList", "RemovableEventHandle"]
 
 
 class CallableEventWithFilter:

--- a/tests/ignite/contrib/handlers/test_base_logger.py
+++ b/tests/ignite/contrib/handlers/test_base_logger.py
@@ -151,6 +151,12 @@ def test_attach_wrong_event_name():
     with pytest.raises(RuntimeError, match="Unknown event name"):
         logger.attach(trainer, log_handler=mock_log_handler, event_name="unknown")
 
+    events_list = EventsList()
+    events_list._events = ["unknown"]
+
+    with pytest.raises(RuntimeError, match="Unknown event name"):
+        logger.attach(trainer, log_handler=mock_log_handler, event_name=events_list)
+
 
 def test_attach_on_custom_event():
     n_epochs = 10


### PR DESCRIPTION
Fixes #1543 

Description:

Allow `EventsList` in `BaseLogger` attachment. The key point is to attach each event independently as it is done in `Engine`.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
