### PR TITLE
ClearMLLogger: add older Trains SDK backwards compatibility

### DIFF
--- a/examples/contrib/cifar10/main.py
+++ b/examples/contrib/cifar10/main.py
@@ -48,7 +48,11 @@ def training(local_rank, config):
             config["cuda device name"] = torch.cuda.get_device_name(local_rank)
 
         if config["with_clearml"]:
-            from clearml import Task
+            try:
+                from clearml import Task
+            except ImportError:
+                # Backwards-compatibility for legacy Trains SDK
+                from trains import Task
 
             task = Task.init("CIFAR10-Training", task_name=output_path.stem)
             task.connect_configuration(config)

--- a/examples/references/classification/imagenet/code/scripts/training.py
+++ b/examples/references/classification/imagenet/code/scripts/training.py
@@ -250,7 +250,11 @@ def run(config, **kwargs):
         assert hasattr(config, "script_filepath") and isinstance(config.script_filepath, Path)
 
         if idist.get_rank() == 0 and exp_tracking.has_clearml:
-            from clearml import Task
+            try:
+                from clearml import Task
+            except ImportError:
+                # Backwards-compatibility for legacy Trains SDK
+                from trains import Task
 
             task = Task.init("ImageNet Training", config.config_filepath.stem)
             task.connect_configuration(config.config_filepath.as_posix())

--- a/examples/references/classification/imagenet/code/utils/exp_tracking.py
+++ b/examples/references/classification/imagenet/code/utils/exp_tracking.py
@@ -32,7 +32,10 @@ except ImportError:
 
 
 try:
-    import clearml
+    try:
+        import clearml
+    except ImportError:
+        import trains
 
     if "CLEARML_OUTPUT_PATH" not in os.environ:
         raise ImportError("CLEARML_OUTPUT_PATH should be defined")
@@ -100,7 +103,11 @@ def _clearml_get_output_path():
 
 @idist.one_rank_only()
 def _clearml_log_artifact(fp):
-    from clearml import Task
+    try:
+        from clearml import Task
+    except ImportError:
+        # Backwards-compatibility for legacy Trains SDK
+        from trains import Task
 
     task = Task.current_task()
     task.upload_artifact(Path(fp).name, fp)
@@ -108,7 +115,11 @@ def _clearml_log_artifact(fp):
 
 @idist.one_rank_only()
 def _clearml_log_params(params_dict):
-    from clearml import Task
+    try:
+        from clearml import Task
+    except ImportError:
+        # Backwards-compatibility for legacy Trains SDK
+        from trains import Task
 
     task = Task.current_task()
     task.connect(params_dict)

--- a/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
+++ b/examples/references/segmentation/pascal_voc2012/code/scripts/training.py
@@ -263,7 +263,11 @@ def training(local_rank, config, logger=None):
             cm = ConfusionMatrix.normalize(cm, "recall").cpu().numpy()
 
             if idist.get_rank() == 0:
-                from clearml import Task
+                try:
+                    from clearml import Task
+                except ImportError:
+                    # Backwards-compatibility for legacy Trains SDK
+                    from trains import Task
 
                 clearml_logger = Task.current_task().get_logger()
                 clearml_logger.report_confusion_matrix(
@@ -302,7 +306,11 @@ def run(config, **kwargs):
         assert hasattr(config, "script_filepath") and isinstance(config.script_filepath, Path)
 
         if idist.get_rank() == 0 and exp_tracking.has_clearml:
-            from clearml import Task
+            try:
+                from clearml import Task
+            except ImportError:
+                # Backwards-compatibility for legacy Trains SDK
+                from trains import Task
 
             task = Task.init("Pascal-VOC12 Training", config.config_filepath.stem)
             task.connect_configuration(config.config_filepath.as_posix())

--- a/examples/references/segmentation/pascal_voc2012/code/utils/exp_tracking.py
+++ b/examples/references/segmentation/pascal_voc2012/code/utils/exp_tracking.py
@@ -32,7 +32,10 @@ except ImportError:
 
 
 try:
-    import clearml
+    try:
+        import clearml
+    except ImportError:
+        import trains
 
     if "CLEARML_OUTPUT_PATH" not in os.environ:
         raise ImportError("CLEARML_OUTPUT_PATH should be defined")
@@ -100,7 +103,11 @@ def _clearml_get_output_path():
 
 @idist.one_rank_only()
 def _clearml_log_artifact(fp):
-    from clearml import Task
+    try:
+        from clearml import Task
+    except ImportError:
+        # Backwards-compatibility for legacy Trains SDK
+        from trains import Task
 
     task = Task.current_task()
     task.upload_artifact(Path(fp).name, fp)
@@ -108,7 +115,11 @@ def _clearml_log_artifact(fp):
 
 @idist.one_rank_only()
 def _clearml_log_params(params_dict):
-    from clearml import Task
+    try:
+        from clearml import Task
+    except ImportError:
+        # Backwards-compatibility for legacy Trains SDK
+        from trains import Task
 
     task = Task.current_task()
     task.connect(params_dict)

--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -124,10 +124,15 @@ class ClearMLLogger(BaseLogger):
             from clearml import Task
             from clearml.binding.frameworks.tensorflow_bind import WeightsGradientHistHelper
         except ImportError:
-            raise RuntimeError(
-                "This contrib module requires clearml to be installed. "
-                "You may install clearml using: \n pip install clearml \n"
-            )
+            try:
+                # Backwards-compatibility for legacy Trains SDK
+                from trains import Task
+                from trains.binding.frameworks.tensorflow_bind import WeightsGradientHistHelper
+            except ImportError:
+                raise RuntimeError(
+                    "This contrib module requires clearml to be installed. "
+                    "You may install clearml using: \n pip install clearml \n"
+                )
 
         experiment_kwargs = {k: v for k, v in kwargs.items() if k not in ("project_name", "task_name", "task_type")}
 
@@ -667,10 +672,14 @@ class ClearMLSaver(DiskSaver):
         try:
             from clearml import Task
         except ImportError:
-            raise RuntimeError(
-                "This contrib module requires clearml to be installed. "
-                "You may install clearml using: \n pip install clearml \n"
-            )
+            try:
+                # Backwards-compatibility for legacy Trains SDK
+                from trains import Task
+            except ImportError:
+                raise RuntimeError(
+                    "This contrib module requires clearml to be installed. "
+                    "You may install clearml using: \n pip install clearml \n"
+                )
 
         if logger and not isinstance(logger, ClearMLLogger):
             raise TypeError("logger must be an instance of ClearMLLogger")
@@ -739,10 +748,15 @@ class ClearMLSaver(DiskSaver):
             from clearml import Model
             from clearml.binding.frameworks import WeightsFileHandler
         except ImportError:
-            raise RuntimeError(
-                "This contrib module requires clearml to be installed. "
-                "You may install clearml using: \n pip install clearml \n"
-            )
+            try:
+                # Backwards-compatibility for legacy Trains SDK
+                from trains import Model
+                from trains.binding.frameworks import WeightsFileHandler
+            except ImportError:
+                raise RuntimeError(
+                    "This contrib module requires clearml to be installed. "
+                    "You may install clearml using: \n pip install clearml \n"
+                )
 
         try:
             basename = metadata["basename"]  # type: ignore[index]

--- a/mypy.ini
+++ b/mypy.ini
@@ -60,5 +60,8 @@ ignore_missing_imports = True
 [mypy-torch_xla.*]
 ignore_missing_imports = True
 
+[mypy-trains.*]
+ignore_missing_imports = True
+
 [mypy-tqdm.*]
 ignore_missing_imports = True


### PR DESCRIPTION
Description:
Add backwards-compatibility so that users who still use older Trains SDK packages can still use the ClearMLLogger (formerly TrainsLogger).
Tested using `mnist_with_clearml_logger.py`.
Obviously, any test explicitly importing `clearml` will neither be affected nor will support backwards compatibility.
Runtime errors were kept as-is since there's no reason to instruct users to install anything but the latest ClearML SDK in case it is required.

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
