### PR TITLE
[docstring] `max_iter` to `max_iters`

### DIFF
--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -344,7 +344,7 @@ class State:
         state.dataloader        # data passed to engine
         state.epoch_length      # optional length of an epoch
         state.max_epochs        # number of epochs to run
-        state.max_iter          # number of iterations to run
+        state.max_iters         # number of iterations to run
         state.batch             # batch passed to `process_function`
         state.output            # output of `process_function` after a single iteration
         state.metrics           # dictionary with defined metrics if any


### PR DESCRIPTION
Fixes #{issue number} 

Description: `State` only has `max_iters` attribute


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
