### PR TITLE
[docs] use katex instead of mathjax

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           python-version: 3.7
 
+      - run: sudo npm install katex@0.12.0 -g
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.7
 
-      - run: sudo npm install katex@0.12.0 -g
+      - run: sudo npm install katex@latest -g
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/install_docs_deps.sh
+++ b/.github/workflows/install_docs_deps.sh
@@ -1,8 +1,5 @@
-npm install katex
-PATH="${PATH}:$(pwd)/node_modules/.bin"
-
 # remove pkg-resources as it causes failure when installing https://github.com/vfdev-5/sphinxcontrib-versioning
-pip uninstall -y pkg-resources setuptools && pip install --upgrade setuptools
+pip uninstall -y pkg-resources setuptools && pip install --upgrade setuptools pip wheel
 pip install torch torchvision -f https://download.pytorch.org/whl/cpu/torch_stable.html -U
 pip install -r requirements-dev.txt
 pip install -r docs/requirements.txt

--- a/.github/workflows/install_docs_deps.sh
+++ b/.github/workflows/install_docs_deps.sh
@@ -1,3 +1,6 @@
+npm install katex
+PATH="${PATH}:$(pwd)/node_modules/.bin"
+
 # remove pkg-resources as it causes failure when installing https://github.com/vfdev-5/sphinxcontrib-versioning
 pip uninstall -y pkg-resources setuptools && pip install --upgrade setuptools
 pip install torch torchvision -f https://download.pytorch.org/whl/cpu/torch_stable.html -U

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==3.2.1
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+sphinxcontrib-katex

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -80,11 +80,11 @@
   <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
 
   <!-- katex links / this needs to be loaded before fonts.html -->
-  <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" as="style"
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.css" as="style"
     integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.css"
     integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
-  <script async src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+  <script async src="https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.js"
     integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
 
   {% include "fonts.html" %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -79,6 +79,14 @@
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
   <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
 
+  <!-- katex links / this needs to be loaded before fonts.html -->
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" as="style"
+    integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
+    integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
+  <script async src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+    integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
+
   {% include "fonts.html" %}
 </head>
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,11 +56,14 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
+    "sphinxcontrib.katex",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
 ]
+
+# katex options
+katex_prerender = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
Fixes #1576 

Description: use katex instead of mathjax for math equations as `pytorch_sphinx_theme` is loaded with `katex` fonts.


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
