### PR TITLE
[ci] change to py3.8 for nightly releases

### DIFF
--- a/.github/workflows/binaries-nightly-release.yml
+++ b/.github/workflows/binaries-nightly-release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Setup nightly version
         run: |

--- a/.github/workflows/binaries-release.yml
+++ b/.github/workflows/binaries-release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         shell: bash -l {0}


### PR DESCRIPTION
Fixes #1580 

Description: change to py3.8 as suggest by @vfdev-5 in nightly releases


Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
