### PR TITLE
Fix for Checkpoint and ModelCheckpoint consistency

### DIFF
--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -45,9 +45,6 @@ def test_checkpoint_wrong_input():
     with pytest.raises(TypeError, match=r"Argument `to_save` should be a dictionary"):
         Checkpoint([12], lambda x: x, "prefix")
 
-    with pytest.raises(ValueError, match=r"No objects to checkpoint."):
-        Checkpoint({}, lambda x: x, "prefix")
-
     model = DummyModel()
     to_save = {"model": model}
 


### PR DESCRIPTION
Partially addresses #1405

Description:

Solve `ModelCheckpoint` and `Checkpoint` consistency. Now `to_save`is no longer optional.

Cherry pick from #1567 
commit 89d4312eb31983aa1fdad7afa5491b01de61d2d4 

Check list:
* [ ] New tests are added (if a new feature is added)
* [ ] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
