### PR TITLE
Improve ConfusionMatrix for binary classification

### DIFF
--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -44,6 +44,8 @@ class ConfusionMatrix(Metric):
         so that you have one value for each class. E.g. you can transform your network output into a one-hot vector
         with:
 
+        .. code-block:: python
+
             def binary_one_hot_output_transform(output):
                 y_pred, y = output
                 y_pred = torch.sigmoid(y_pred).round().long()
@@ -58,6 +60,7 @@ class ConfusionMatrix(Metric):
             evaluator = create_supervised_evaluator(
                 model, metrics=metrics, output_transform=lambda x, y, y_pred: (y_pred, y)
             )
+
     """
 
     def __init__(

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -70,7 +70,7 @@ class ConfusionMatrix(Metric):
             raise ValueError("Argument average can None or one of 'samples', 'recall', 'precision'")
         
         if num_classes <= 1:
-            raise ValueError("Argument num_classes needs to be >1")
+            raise ValueError("Argument num_classes needs to be > 1")
 
         self.num_classes = num_classes
         self._num_examples = 0

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -14,7 +14,7 @@ class ConfusionMatrix(Metric):
     """Calculates confusion matrix for multi-class data.
 
     - ``update`` must receive output of the form ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``.
-    - `y_pred` must contain logits and has the following shape (batch_size, num_classes, ...). 
+    - `y_pred` must contain logits and has the following shape (batch_size, num_classes, ...).
       If you are doing binary classification, see Note for an example on how to get this.
     - `y` should have the following shape (batch_size, ...) and contains ground-truth class indices
       with or without the background class. During the computation, argmax of `y_pred` is taken to determine
@@ -39,9 +39,10 @@ class ConfusionMatrix(Metric):
         In case of the targets `y` in `(batch_size, ...)` format, target indices between 0 and `num_classes` only
         contribute to the confusion matrix and others are neglected. For example, if `num_classes=20` and target index
         equal 255 is encountered, then it is filtered out.
-        
+
         If you are doing binary classification with a single output unit, you may have to transform your network output,
-        so that you have one value for each class. E.g. you can transform your network output into a one-hot vector with:
+        so that you have one value for each class. E.g. you can transform your network output into a one-hot vector
+        with:
 
             def binary_one_hot_output_transform(output):
                 y_pred, y = output
@@ -53,8 +54,10 @@ class ConfusionMatrix(Metric):
             metrics = {
                 "confusion_matrix": ConfusionMatrix(2, output_transform=binary_one_hot_output_transform),
             }
-            
-            evaluator = create_supervised_evaluator(model, metrics=metrics, output_transform=lambda x, y, y_pred: (y_pred, y))
+
+            evaluator = create_supervised_evaluator(
+                model, metrics=metrics, output_transform=lambda x, y, y_pred: (y_pred, y)
+            )
 
     """
 
@@ -86,7 +89,8 @@ class ConfusionMatrix(Metric):
 
         if y_pred.ndimension() < 2:
             raise ValueError(
-                f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...), but given {y_pred.shape}"
+                f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...), "
+                f"but given {y_pred.shape}"
             )
 
         if y_pred.shape[1] != self.num_classes:
@@ -94,8 +98,8 @@ class ConfusionMatrix(Metric):
 
         if not (y.ndimension() + 1 == y_pred.ndimension()):
             raise ValueError(
-                f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...) and y must have "
-                "shape of (batch_size, ...), "
+                f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...) "
+                "and y must have shape of (batch_size, ...), "
                 f"but given {y.shape} vs {y_pred.shape}."
             )
 

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -44,7 +44,6 @@ class ConfusionMatrix(Metric):
         so that you have one value for each class. E.g. you can transform your network output into a one-hot vector with:
 
             def binary_one_hot_output_transform(output):
-                """Ouptuts a one-hot encoded vector with 0 or 1 values."""
                 y_pred, y = output
                 y_pred = torch.sigmoid(y_pred).round().long()
                 y_pred = ignite.utils.to_onehot(y_pred, 2)
@@ -68,7 +67,7 @@ class ConfusionMatrix(Metric):
     ):
         if average is not None and average not in ("samples", "recall", "precision"):
             raise ValueError("Argument average can None or one of 'samples', 'recall', 'precision'")
-        
+
         if num_classes <= 1:
             raise ValueError("Argument num_classes needs to be > 1")
 
@@ -86,12 +85,12 @@ class ConfusionMatrix(Metric):
         y_pred, y = output[0].detach(), output[1].detach()
 
         if y_pred.ndimension() < 2:
-            raise ValueError(f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...), but given {y_pred.shape}")
+            raise ValueError(
+                f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...), but given {y_pred.shape}"
+            )
 
         if y_pred.shape[1] != self.num_classes:
-            raise ValueError(
-                f"y_pred does not have correct number of classes: {y_pred.shape[1]} vs {self.num_classes}"
-            )
+            raise ValueError(f"y_pred does not have correct number of classes: {y_pred.shape[1]} vs {self.num_classes}")
 
         if not (y.ndimension() + 1 == y_pred.ndimension()):
             raise ValueError(

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -58,7 +58,6 @@ class ConfusionMatrix(Metric):
             evaluator = create_supervised_evaluator(
                 model, metrics=metrics, output_transform=lambda x, y, y_pred: (y_pred, y)
             )
-
     """
 
     def __init__(

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -14,7 +14,7 @@ class ConfusionMatrix(Metric):
     """Calculates confusion matrix for multi-class data.
 
     - ``update`` must receive output of the form ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``.
-    - `y_pred` must contain logits and has the following shape (batch_size, num_categories, ...)
+    - `y_pred` must contain logits and has the following shape (batch_size, num_classes, ...)
     - `y` should have the following shape (batch_size, ...) and contains ground-truth class indices
       with or without the background class. During the computation, argmax of `y_pred` is taken to determine
       predicted classes.
@@ -68,16 +68,16 @@ class ConfusionMatrix(Metric):
         y_pred, y = output[0].detach(), output[1].detach()
 
         if y_pred.ndimension() < 2:
-            raise ValueError(f"y_pred must have shape (batch_size, num_categories, ...), but given {y_pred.shape}")
+            raise ValueError(f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...), but given {y_pred.shape}")
 
         if y_pred.shape[1] != self.num_classes:
             raise ValueError(
-                f"y_pred does not have correct number of categories: {y_pred.shape[1]} vs {self.num_classes}"
+                f"y_pred does not have correct number of classes: {y_pred.shape[1]} vs {self.num_classes}"
             )
 
         if not (y.ndimension() + 1 == y_pred.ndimension()):
             raise ValueError(
-                "y_pred must have shape (batch_size, num_categories, ...) and y must have "
+                f"y_pred must have shape (batch_size, num_classes (currently set to {self.num_classes}), ...) and y must have "
                 "shape of (batch_size, ...), "
                 f"but given {y.shape} vs {y_pred.shape}."
             )

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -20,7 +20,7 @@ class ConfusionMatrix(Metric):
       predicted classes.
 
     Args:
-        num_classes (int): number of classes. See notes for more details.
+        num_classes (int): Number of classes, should be >1. See notes for more details.
         average (str, optional): confusion matrix values averaging schema: None, "samples", "recall", "precision".
             Default is None. If `average="samples"` then confusion matrix values are normalized by the number of seen
             samples. If `average="recall"` then confusion matrix values are normalized such that diagonal values
@@ -50,6 +50,9 @@ class ConfusionMatrix(Metric):
     ):
         if average is not None and average not in ("samples", "recall", "precision"):
             raise ValueError("Argument average can None or one of 'samples', 'recall', 'precision'")
+        
+        if num_classes <= 1:
+            raise ValueError("Argument num_classes needs to be >1")
 
         self.num_classes = num_classes
         self._num_examples = 0

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -21,7 +21,7 @@ class ConfusionMatrix(Metric):
       predicted classes.
 
     Args:
-        num_classes (int): Number of classes, should be >1. See notes for more details.
+        num_classes (int): Number of classes, should be > 1. See notes for more details.
         average (str, optional): confusion matrix values averaging schema: None, "samples", "recall", "precision".
             Default is None. If `average="samples"` then confusion matrix values are normalized by the number of seen
             samples. If `average="recall"` then confusion matrix values are normalized such that diagonal values

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -20,7 +20,7 @@ def test_no_update():
 
 
 def test_num_classes_wrong_input():
-    with pytest.raises(ValueError, match="Argument num_classes needs to be >1"):
+    with pytest.raises(ValueError, match="Argument num_classes needs to be > 1"):
         ConfusionMatrix(num_classes=1)
 
 

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -27,14 +27,19 @@ def test_num_classes_wrong_input():
 def test_multiclass_wrong_inputs():
     cm = ConfusionMatrix(10)
 
-    with pytest.raises(ValueError, match=r"y_pred must have shape \(batch_size, num_classes \(currently set to 10\), ...\)"):
+    with pytest.raises(
+        ValueError, match=r"y_pred must have shape \(batch_size, num_classes " r"\(currently set to 10\), ...\)"
+    ):
         cm.update((torch.rand(10), torch.randint(0, 2, size=(10,)).long()))
 
     with pytest.raises(ValueError, match=r"y_pred does not have correct number of classes:"):
         cm.update((torch.rand(10, 5, 4), torch.randint(0, 2, size=(10,)).long()))
 
     with pytest.raises(
-        ValueError, match=r"y_pred must have shape \(batch_size, num_classes \(currently set to 10\), ...\) " r"and y must have "
+        ValueError,
+        match=r"y_pred must have shape \(batch_size, num_classes "
+        r"\(currently set to 10\), ...\) "
+        r"and y must have ",
     ):
         cm.update((torch.rand(4, 10, 12, 12), torch.randint(0, 10, size=(10,)).long()))
 

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -27,14 +27,14 @@ def test_num_classes_wrong_input():
 def test_multiclass_wrong_inputs():
     cm = ConfusionMatrix(10)
 
-    with pytest.raises(ValueError, match=r"y_pred must have shape \(batch_size, num_categories, ...\)"):
+    with pytest.raises(ValueError, match=r"y_pred must have shape \(batch_size, num_classes \(currently set to 10\), ...\)"):
         cm.update((torch.rand(10), torch.randint(0, 2, size=(10,)).long()))
 
-    with pytest.raises(ValueError, match=r"y_pred does not have correct number of categories:"):
+    with pytest.raises(ValueError, match=r"y_pred does not have correct number of classes:"):
         cm.update((torch.rand(10, 5, 4), torch.randint(0, 2, size=(10,)).long()))
 
     with pytest.raises(
-        ValueError, match=r"y_pred must have shape \(batch_size, num_categories, ...\) " r"and y must have "
+        ValueError, match=r"y_pred must have shape \(batch_size, num_classes \(currently set to 10\), ...\) " r"and y must have "
     ):
         cm.update((torch.rand(4, 10, 12, 12), torch.randint(0, 10, size=(10,)).long()))
 

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -19,6 +19,11 @@ def test_no_update():
         cm.compute()
 
 
+def test_num_classes_wrong_input():
+    with pytest.raises(ValueError, match="Argument num_classes needs to be >1"):
+        ConfusionMatrix(num_classes=1)
+
+
 def test_multiclass_wrong_inputs():
     cm = ConfusionMatrix(10)
 


### PR DESCRIPTION
Fixes #1380 

Description:

Makes confusion matrix work better with binary classification. Adds a check that the `num_classes` arg of `ConfusionMatrix` is >1 (and tests for that), improves other error messages, and adds an example for how to transform the network output for binary classification. See [this comment](https://github.com/pytorch/ignite/issues/1380#issuecomment-768681135) for more details.

Check list:
* [x] New tests are added (if a new feature is added)
* [x] New doc strings: description and/or example code are in RST format
* [ ] Documentation is updated (if required)
