### PR TITLE
Update handlers to use setup_logger

### DIFF
--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -1,9 +1,9 @@
-import logging
 from collections import OrderedDict
 from typing import Callable, Mapping, Optional, cast
 
 from ignite.base import Serializable
 from ignite.engine import Engine
+from ignite.utils import setup_logger
 
 __all__ = ["EarlyStopping"]
 
@@ -76,7 +76,7 @@ class EarlyStopping(Serializable):
         self.trainer = trainer
         self.counter = 0
         self.best_score = None  # type: Optional[float]
-        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
+        self.logger = setup_logger(__name__ + "." + self.__class__.__name__)
 
     def __call__(self, engine: Engine) -> None:
         score = self.score_function(engine)

--- a/ignite/handlers/terminate_on_nan.py
+++ b/ignite/handlers/terminate_on_nan.py
@@ -5,7 +5,7 @@ from typing import Callable, Union
 import torch
 
 from ignite.engine import Engine
-from ignite.utils import apply_to_type
+from ignite.utils import apply_to_type, setup_logger
 
 __all__ = ["TerminateOnNan"]
 
@@ -33,7 +33,7 @@ class TerminateOnNan:
     """
 
     def __init__(self, output_transform: Callable = lambda x: x):
-        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
+        self.logger = setup_logger(__name__ + "." + self.__class__.__name__)
         self.logger.addHandler(logging.StreamHandler())
         self._output_transform = output_transform
 

--- a/ignite/handlers/time_limit.py
+++ b/ignite/handlers/time_limit.py
@@ -1,10 +1,11 @@
-import logging
 import time
 from typing import Optional
 
 from ignite.engine import Engine
 
 __all__ = ["TimeLimit"]
+
+from ignite.utils import setup_logger
 
 
 class TimeLimit:
@@ -37,7 +38,7 @@ class TimeLimit:
 
         self.limit_sec = limit_sec
         self.start_time = time.time()
-        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
+        self.logger = setup_logger(__name__ + "." + self.__class__.__name__)
 
     def __call__(self, engine: Engine) -> None:
         elapsed_time = time.time() - self.start_time


### PR DESCRIPTION
Fixes #1614 

Description:
- Updated handlers `EarlyStopping` and `TerminateOnNan`
- Replaced `logging.getLogger` with `setup_logger` from `ignite.utils` in the mentioned handlers


