### PR TITLE
#1615 : add check_opencv function in 'build_all.sh' for 'vision' . Sw…

### DIFF
--- a/docker/hvd/Dockerfile.hvd-apex-vision
+++ b/docker/hvd/Dockerfile.hvd-apex-vision
@@ -6,14 +6,15 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends libglib2.0 \
                                                libsm6 \
                                                libxext6 \
-                                               libxrender-dev && \
+                                               libxrender-dev \
+                                               libgl1-mesa-glx && \
     rm -rf /var/lib/apt/lists/*
 
 # Ignite vision dependencies
 RUN pip install --upgrade --no-cache-dir albumentations \
                                          image-dataset-viz \
                                          numpy \
-                                         opencv-python \
+                                         opencv-python-headless \
                                          py_config_runner \
                                          pillow \
                                          clearml

--- a/docker/hvd/Dockerfile.hvd-vision
+++ b/docker/hvd/Dockerfile.hvd-vision
@@ -6,14 +6,15 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends libglib2.0 \
                                                libsm6 \
                                                libxext6 \
-                                               libxrender-dev && \
+                                               libxrender-dev \
+                                               libgl1-mesa-glx && \
     rm -rf /var/lib/apt/lists/*
 
 # Ignite vision dependencies
 RUN pip install --upgrade --no-cache-dir albumentations \
                                          image-dataset-viz \
                                          numpy \
-                                         opencv-python \
+                                         opencv-python-headless \
                                          py_config_runner \
                                          pillow \
                                          clearml

--- a/docker/hvd/build_all.sh
+++ b/docker/hvd/build_all.sh
@@ -17,6 +17,21 @@ retry()
     fi
 }
 
+# check OpenCV import is valid
+check_opencv()
+{
+  image_to_check=$1
+  { # try
+    msg=`docker run --rm -it ${image_to_check} python -c "import cv2"`  &&
+    echo "OpenCV import OK"
+  } || { # catch
+      echo "${msg}"
+      echo "OpenCV import NOK : removing ${image_to_check}"
+      docker rmi -f ${image_to_check}
+      exit 1
+  }
+}
+
 # Start script from ignite docker folder
 if [ ! -d hvd ]; then
     echo "Can not find 'hvd' folder"
@@ -50,6 +65,9 @@ do
     retry "docker build --build-arg PTH_VERSION=${pth_version} --build-arg HVD_VERSION=${hvd_version} -t pytorchignite/${image_name}:latest -f Dockerfile.${image_name} ." "\nBuild failed: ${image_name}"
     if [ -z $image_tag ]; then
         image_tag=`docker run --rm -i pytorchignite/${image_name}:latest python -c "import torch; import ignite; print(torch.__version__ + \"-\" + ignite.__version__, end=\"\")"`
+    fi
+    if [[ ${image_name} == "hvd-vision" || ${image_name} == "hvd-apex-vision" ]]; then
+        check_opencv "pytorchignite/${image_name}:latest"
     fi
     docker tag pytorchignite/${image_name}:latest pytorchignite/${image_name}:${image_tag}
 

--- a/docker/main/Dockerfile.apex-vision
+++ b/docker/main/Dockerfile.apex-vision
@@ -6,14 +6,15 @@ RUN apt-get update && \
     apt-get -y install --no-install-recommends libglib2.0 \
                                                libsm6 \
                                                libxext6 \
-                                               libxrender-dev && \
+                                               libxrender-dev \
+                                               libgl1-mesa-glx && \
     rm -rf /var/lib/apt/lists/*
 
 # Ignite vision dependencies
 RUN pip install --upgrade --no-cache-dir albumentations \
                                          image-dataset-viz \
                                          numpy \
-                                         opencv-python \
+                                         opencv-python-headless \
                                          py_config_runner \
                                          pillow \
                                          clearml

--- a/docker/main/Dockerfile.vision
+++ b/docker/main/Dockerfile.vision
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip install --upgrade --no-cache-dir albumentations \
                                          image-dataset-viz \
                                          numpy \
-                                         opencv-python \
+                                         opencv-python-headless \
                                          py_config_runner \
                                          pillow \
                                          clearml


### PR DESCRIPTION


Fixes #1615 
Description:
 add check_opencv function in 'build_all.sh' for 'vision' . Switch to 'opencv-python-headless'. add `libgl1-mesa-glx ` for pytorch-*-devel` based images.

Check list:
Images builds OK {main, hvd}  `PTH_VERSION=1.7.1-cuda11.0-cudnn8`,  `HVD_VERSION=v0.21.2`, `ignite=0.4.3`
  
- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
