### PR TITLE
Replace relative paths with raw.githubusercontent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-readme = read("README.md")
+readme = read("README.md").replace(
+    'src="assets/', 'src="https://raw.githubusercontent.com/pytorch/ignite/master/assets/'
+)
 
 VERSION = find_version("ignite", "__init__.py")
 


### PR DESCRIPTION
Fixes #1626 

Description:
Replaced all the instances with `src="assets/*"` to the corresponding `raw.githubusercontent.com` URLs

Not as I elegant as expected, but I think this should work. Any suggestions?
Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
