### PR TITLE
Removed temporary hack and install PyTorch 1.7.1 directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ parameters:
   pytorch_stable_image:
     type: string
     # https://hub.docker.com/r/pytorch/pytorch/tags
-    default: "pytorch/pytorch:1.7.0-cuda11.0-cudnn8-runtime"
+    default: "pytorch/pytorch:1.7.1-cuda11.0-cudnn8-runtime"
   pytorch_stable_image_devel:
     type: string
     # https://hub.docker.com/r/pytorch/pytorch/tags
-    default: "pytorch/pytorch:1.7.0-cuda11.0-cudnn8-devel"
+    default: "pytorch/pytorch:1.7.1-cuda11.0-cudnn8-devel"
   workingdir:
     type: string
     default: "/tmp/ignite"
@@ -20,7 +20,7 @@ parameters:
     default: false
   build_docker_image_pytorch_version:
     type: string
-    default: "1.7.0-cuda11.0-cudnn8"
+    default: "1.7.1-cuda11.0-cudnn8"
   build_docker_image_hvd_version:
     type: string
     default: "v0.21.0"
@@ -195,7 +195,7 @@ jobs:
           name: Install dependencies
           command: |
             conda --version
-            conda install -y pytorch torchvision cudatoolkit=10.1 -c pytorch
+            conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
             pip install -r requirements-dev.txt
             pip install .
 

--- a/.github/workflows/trigger_circle_ci.py
+++ b/.github/workflows/trigger_circle_ci.py
@@ -101,6 +101,9 @@ if __name__ == "__main__":
 
     print(f"- should_publish_docker_images: {should_publish_docker_images}")
     print(f"- Branch: {branch}")
+    if branch.startswith("refs/pull") and branch.endswith("/merge"):
+        branch = branch.replace("/merge", "/head")
+        print(f"Replaced /merge -> /head : {branch}")
 
     headers = {"authorization": "Basic", "content-type": "application/json", "Circle-Token": os.environ["CIRCLE_TOKEN"]}
 

--- a/docker/hvd/Dockerfile.hvd-apex
+++ b/docker/hvd/Dockerfile.hvd-apex
@@ -6,10 +6,7 @@ ARG PTH_VERSION
 # 1/Building apex with pytorch:*-devel
 FROM pytorch/pytorch:${PTH_VERSION}-devel AS apex-hvd-builder
 
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
-
-ARG ARG_TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5"
+ARG ARG_TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX 8.0"
 ENV TORCH_CUDA_ARCH_LIST=$ARG_TORCH_CUDA_ARCH_LIST
 
 # Install git
@@ -36,9 +33,6 @@ RUN apt-get update && apt-get install -y git && \
 
 # Build runtime image
 FROM pytorch/pytorch:${PTH_VERSION}-runtime
-
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
 
 # Apex
 COPY --from=apex-hvd-builder /tmp/apex/apex-*.whl /tmp/apex/

--- a/docker/hvd/Dockerfile.hvd-base
+++ b/docker/hvd/Dockerfile.hvd-base
@@ -5,9 +5,6 @@ ARG PTH_VERSION
 
 FROM pytorch/pytorch:${PTH_VERSION}-devel as builder
 
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
-
 ARG HVD_VERSION
 
 # Build Horovod
@@ -20,9 +17,6 @@ RUN apt-get update && apt-get install -y git && \
 
 # Build runtime image
 FROM pytorch/pytorch:${PTH_VERSION}-runtime
-
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
 
 # Install tzdata / git
 RUN apt-get update && \

--- a/docker/main/Dockerfile.apex
+++ b/docker/main/Dockerfile.apex
@@ -6,10 +6,7 @@ ARG PTH_VERSION
 # 1/Building apex with pytorch:*-devel
 FROM pytorch/pytorch:${PTH_VERSION}-devel AS apex-builder
 
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
-
-ARG ARG_TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5"
+ARG ARG_TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX 8.0"
 ENV TORCH_CUDA_ARCH_LIST=$ARG_TORCH_CUDA_ARCH_LIST
 
 # Install git
@@ -26,9 +23,6 @@ RUN echo "Setup NVIDIA Apex" && \
 
 # 2/ Build the runtime image
 FROM pytorch/pytorch:${PTH_VERSION}-runtime
-
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
 
 COPY --from=apex-builder /tmp/apex/apex-*.whl /tmp/apex/
 RUN pip install --no-cache-dir /tmp/apex/apex-*.whl && \

--- a/docker/main/Dockerfile.base
+++ b/docker/main/Dockerfile.base
@@ -3,9 +3,6 @@ ARG PTH_VERSION
 
 FROM pytorch/pytorch:${PTH_VERSION}-runtime
 
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
-
 # Install tzdata / git
 RUN apt-get update && \
     ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \

--- a/docker/msdp/Dockerfile.msdp-apex
+++ b/docker/msdp/Dockerfile.msdp-apex
@@ -6,10 +6,7 @@ ARG PTH_VERSION
 # 1/Building apex with pytorch:*-devel
 FROM pytorch/pytorch:${PTH_VERSION}-devel AS apex-msdp-builder
 
-# Temporary hack to install pth 1.7.1
-RUN conda install -y pytorch torchvision cudatoolkit=11.0 -c pytorch
-
-ARG ARG_TORCH_CUDA_ARCH_LIST="6.0;6.1;6.2;7.0;7.5"
+ARG ARG_TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX 8.0"
 ENV TORCH_CUDA_ARCH_LIST=$ARG_TORCH_CUDA_ARCH_LIST
 
 # Install git


### PR DESCRIPTION

Description:
- Removed temporary hack to install pth 1.7.1
- updated default pth image for gpu tests
- updated TORCH_CUDA_ARCH_LIST

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
