### PR TITLE
Enable footer for the docs

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -1,0 +1,82 @@
+<footer>
+  {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+      {% if next %}
+        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="next-page"></a>
+      {% endif %}
+      {% if prev %}
+        <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="previous-page"> {{ _('Previous') }}</a>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if theme_pytorch_project == 'tutorials' %}
+
+    <hr class="rating-hr hr-top">
+      <div class="rating-container">
+        <div class="rating-prompt">Rate this Tutorial</div>
+        <div class="stars-outer">
+          <i class="far fa-star" title="1 Star" data-behavior="tutorial-rating" data-count="1"></i>
+          <i class="far fa-star" title="2 Stars" data-behavior="tutorial-rating" data-count="2"></i>
+          <i class="far fa-star" title="3 Stars" data-behavior="tutorial-rating" data-count="3"></i>
+          <i class="far fa-star" title="4 Stars" data-behavior="tutorial-rating" data-count="4"></i>
+          <i class="far fa-star" title="5 Stars" data-behavior="tutorial-rating" data-count="5"></i>
+        </div>
+      </div>
+    <hr class="rating-hr hr-bottom"/>
+
+  {% else %}
+
+    <hr>
+
+  {% endif %}
+
+  <div role="contentinfo">
+    <p>
+    {%- if show_copyright %}
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+      {%- else %}
+        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+      {%- endif %}
+    {%- endif %}
+
+    {%- if build_id and build_url %}
+      {% trans build_url=build_url, build_id=build_id %}
+        <span class="build">
+          Build
+          <a href="{{ build_url }}">{{ build_id }}</a>.
+        </span>
+      {% endtrans %}
+    {%- elif commit %}
+      {% trans commit=commit %}
+        <span class="commit">
+          Revision <code>{{ commit }}</code>.
+        </span>
+      {% endtrans %}
+    {%- elif last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+    {%- endif %}
+
+    </p>
+  </div>
+
+  {%- if show_sphinx %}
+    {% trans %}
+      <div>
+        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+      </div>
+    {% endtrans %}
+  {%- endif %}
+
+  {%- block extrafooter %} {% endblock %}
+
+  {%- if show_netlify_badge %}
+    {% trans %}
+      <div>
+        <a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" /></a>
+      </div>
+    {% endtrans %}
+  {%- endif %}
+
+</footer>

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -58,25 +58,19 @@
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
 
+    {%- if show_sphinx %}
+      {% trans %}
+        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+      {% endtrans %}
+    {%- endif %}
+
+    {%- if show_netlify_badge %}
+      {% trans %}
+        <a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" /></a>
+      {% endtrans %}
+    {%- endif %}
     </p>
   </div>
-
-  {%- if show_sphinx %}
-    {% trans %}
-      <div>
-        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
-      </div>
-    {% endtrans %}
-  {%- endif %}
-
-  {%- if show_netlify_badge %}
-    {% trans %}
-      <div>
-        <a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" /></a>
-      </div>
-    {% endtrans %}
-  {%- endif %}
-
   {%- block extrafooter %} {% endblock %}
 
 </footer>

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -58,19 +58,21 @@
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
 
+    {%- if show_netlify_badge %}
+      {% trans %}
+        <a href="https://www.netlify.com"><img align="right" src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" /></a>
+        <br>
+      {% endtrans %}
+    {%- endif %}
+
     {%- if show_sphinx %}
       {% trans %}
         Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
       {% endtrans %}
     {%- endif %}
-
-    {%- if show_netlify_badge %}
-      {% trans %}
-        <a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" /></a>
-      {% endtrans %}
-    {%- endif %}
     </p>
   </div>
+
   {%- block extrafooter %} {% endblock %}
 
 </footer>

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -69,8 +69,6 @@
     {% endtrans %}
   {%- endif %}
 
-  {%- block extrafooter %} {% endblock %}
-
   {%- if show_netlify_badge %}
     {% trans %}
       <div>
@@ -78,5 +76,7 @@
       </div>
     {% endtrans %}
   {%- endif %}
+
+  {%- block extrafooter %} {% endblock %}
 
 </footer>

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -8,6 +8,7 @@
 {%- endif %}
 {%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) %}
 {% import 'theme_variables.jinja' as theme_variables %}
+{% set show_netlify_badge = True %}
 
 <!DOCTYPE html>
 <!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" > <![endif]-->


### PR DESCRIPTION
Fixes #1649 

Description:

I think the footer added here:

https://github.com/pytorch/ignite/blob/b1044d024b2150bcd5e439633ada41e24df281d7/docs/source/_templates/layout.html#L251

Moreover, "Built with Sphinx using a theme provided by Read the Docs." is hard coded in `footer.html` theme's template.

So, I think we can override `footer.html` with netlify badge.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
