### PR TITLE
feat(ci): create an issue automatically if cron jobs fail [skip ci]

### DIFF
--- a/.github/failed_schedule_issue_template.md
+++ b/.github/failed_schedule_issue_template.md
@@ -1,0 +1,13 @@
+---
+title: Scheduled workflow failed
+labels:
+  - bug
+  - "module: datasets"
+---
+
+Oh no, something went wrong in the scheduled workflow **{{ env.GITHUB_WORKFLOW }}/{{ env.GITHUB_JOB }} with commit {{ env.GITHUB_SHA }}**.
+Please look into it:
+
+{{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
+
+Feel free to close this if this was just a one-off error.

--- a/.github/failed_schedule_issue_template.md
+++ b/.github/failed_schedule_issue_template.md
@@ -2,7 +2,6 @@
 title: Scheduled workflow failed
 labels:
   - bug
-  - "module: datasets"
 ---
 
 Oh no, something went wrong in the scheduled workflow **{{ env.GITHUB_WORKFLOW }}/{{ env.GITHUB_JOB }} with commit {{ env.GITHUB_SHA }}**.

--- a/.github/workflows/binaries-nightly-release.yml
+++ b/.github/workflows/binaries-nightly-release.yml
@@ -46,3 +46,9 @@ jobs:
           python setup.py sdist bdist_wheel
           twine check dist/*
           TWINE_USERNAME="${{ secrets.PYPI_USER }}" TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" twine upload --verbose dist/*
+
+      - uses: JasonEtco/create-an-issue@v2
+        name: Create issue if nightly releases failed
+        if: failure()
+        with:
+          filename: .github/failed_schedule_issue_template.md

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -61,3 +61,9 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest tests -vvv
+
+      - uses: JasonEtco/create-an-issue@v2
+        name: Create issue if pytorch version tests failed
+        if: failure()
+        with:
+          filename: .github/failed_schedule_issue_template.md


### PR DESCRIPTION
Fixes #1659 

Description: create an issue automatically if cron jobs fail

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)

Sample created issue: https://github.com/ydcjeff/play-gh-actions/issues/28
Default env var: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
Link to the failed CI using:
```
Note: If you need to use a workflow run's URL from within a job, you can combine these environment variables: 

$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
```