### PR TITLE
add cohen kappa

### DIFF
--- a/ignite/contrib/metrics/__init__.py
+++ b/ignite/contrib/metrics/__init__.py
@@ -1,6 +1,6 @@
 import ignite.contrib.metrics.regression
 from ignite.contrib.metrics.average_precision import AveragePrecision
+from ignite.contrib.metrics.cohen_kappa import CohenKappa
 from ignite.contrib.metrics.gpu_info import GpuInfo
 from ignite.contrib.metrics.precision_recall_curve import PrecisionRecallCurve
 from ignite.contrib.metrics.roc_auc import ROC_AUC, RocCurve
-from ignite.contrib.metrics.cohen_kappa import CohenKappa

--- a/ignite/contrib/metrics/__init__.py
+++ b/ignite/contrib/metrics/__init__.py
@@ -3,3 +3,4 @@ from ignite.contrib.metrics.average_precision import AveragePrecision
 from ignite.contrib.metrics.gpu_info import GpuInfo
 from ignite.contrib.metrics.precision_recall_curve import PrecisionRecallCurve
 from ignite.contrib.metrics.roc_auc import ROC_AUC, RocCurve
+from ignite.contrib.metrics.cohen_kappa import CohenKappa

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -52,7 +52,7 @@ class CohenKappa(EpochMetric):
         weights (str): a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear or Quadratic
             (default: `None`)
         check_compute_fn (bool): Default False. If True, `cohen_kappa_score
-            <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_ 
+            <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_
             is run on the first batch of data to ensure there are
             no issues. User will be warned in case there are any issues computing the function.
 
@@ -68,21 +68,16 @@ class CohenKappa(EpochMetric):
 
     """
 
-    def __init__(
-        self, 
-        output_transform: Callable = lambda x: x, 
-        weights: str = None,
-        check_compute_fn: bool = False
-        ):
+    def __init__(self, output_transform: Callable = lambda x: x, weights: str = None, check_compute_fn: bool = False):
 
         if weights is None:
             self.cohen_kappa_compute = non_weighted_cohen_kappa_compute_fn
-        elif weights == 'linear':
+        elif weights == "linear":
             self.cohen_kappa_compute = linear_cohen_kappa_compute_fn
-        elif weights == 'quadratic':
+        elif weights == "quadratic":
             self.cohen_kappa_compute = quadratic_cohen_kappa_compute_fn
         else:
-            raise ValueError("Weights must be None or linear or quadratic.")       
+            raise ValueError("Weights must be None or linear or quadratic.")
 
         super(CohenKappa, self).__init__(
             self.cohen_kappa_compute, output_transform=output_transform, check_compute_fn=check_compute_fn

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -1,0 +1,131 @@
+from typing import Callable
+
+import torch
+
+from ignite.metrics import EpochMetric
+
+
+def non_weighted_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
+    try:
+        from sklearn.metrics import cohen_kappa_score
+    except ImportError:
+        raise RuntimeError("This contrib module requires sklearn to be installed.")
+
+    y_true = y_targets.numpy()
+    y_pred = y_preds.numpy()
+    return cohen_kappa_score(y_true, y_pred, weights=None)
+
+
+class NonWeightedCohenKappa(EpochMetric):
+    """Computes Cohen Kappa with no weights. Applying `sklearn.metrics.cohen_kappa_score
+    <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>` .
+
+    Args:
+        output_transform (callable, optional): a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        check_compute_fn (bool): Default False. If True, `NonWeightedCohenKappa
+            `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
+            generated/sklearn.metrics.cohen_kappa_score.html>` is run on the first batch of data to ensure there are
+            no issues. User will be warned in case there are any issues computing the function.
+
+    .. code-block:: python
+
+        def activated_output_transform(output):
+            y_pred, y = output
+            y_pred = torch.softmax(y_pred, dim=1)
+            return y_pred, y
+
+        non_weighted_cohen_kappa = NonWeightedCohenKappa(activated_output_transform)
+
+    """
+
+    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
+        super(NonWeightedCohenKappa, self).__init__(
+            non_weighted_cohen_kappa_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
+        )
+
+
+def linear_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
+    try:
+        from sklearn.metrics import cohen_kappa_score
+    except ImportError:
+        raise RuntimeError("This contrib module requires sklearn to be installed.")
+
+    y_true = y_targets.numpy()
+    y_pred = y_preds.numpy()
+    return cohen_kappa_score(y_true, y_pred, weights="linear")
+
+
+class LinearCohenKappa(EpochMetric):
+    """Computes Cohen Kappa with linear weights. Applying `sklearn.metrics.cohen_kappa_score
+    <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>` .
+
+    Args:
+        output_transform (callable, optional): a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        check_compute_fn (bool): Default False. If True, `LinearCohenKappa
+            `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
+            generated/sklearn.metrics.cohen_kappa_score.html>` is run on the first batch of data to ensure there are
+            no issues. User will be warned in case there are any issues computing the function.
+
+    .. code-block:: python
+
+        def activated_output_transform(output):
+            y_pred, y = output
+            y_pred = torch.softmax(y_pred, dim=1)
+            return y_pred, y
+
+        lienar_cohen_kappa = LinearCohenKappa(activated_output_transform)
+
+    """
+
+    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
+        super(LinearCohenKappa, self).__init__(
+            linear_cohen_kappa_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
+        )
+
+
+def quadratic_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
+    try:
+        from sklearn.metrics import cohen_kappa_score
+    except ImportError:
+        raise RuntimeError("This contrib module requires sklearn to be installed.")
+
+    y_true = y_targets.numpy()
+    y_pred = y_preds.numpy()
+    return cohen_kappa_score(y_true, y_pred, weights="quadratic")
+
+
+class QuadraticCohenKappa(EpochMetric):
+    """Computes Cohen Kappa with quadratic weights. Applying `sklearn.metrics.cohen_kappa_score
+    <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>` .
+
+    Args:
+        output_transform (callable, optional): a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        check_compute_fn (bool): Default False. If True, `QuadraticCohenKappa
+            `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
+            generated/sklearn.metrics.cohen_kappa_score.html>` is run on the first batch of data to ensure there are
+            no issues. User will be warned in case there are any issues computing the function.
+
+    .. code-block:: python
+
+        def activated_output_transform(output):
+            y_pred, y = output
+            y_pred = torch.softmax(y_pred, dim=1)
+            return y_pred, y
+
+        quadratic_cohen_kappa = QuadraticCohenKappa(activated_output_transform)
+
+    """
+
+    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
+        super(QuadraticCohenKappa, self).__init__(
+            quadratic_cohen_kappa_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
+        )

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -50,7 +50,7 @@ class CohenKappa(EpochMetric):
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
         weights (str): a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear or Quadratic
-            (default: `None`)
+            (default: "")
         check_compute_fn (bool): Default False. If True, `cohen_kappa_score
             <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_
             is run on the first batch of data to ensure there are
@@ -68,9 +68,9 @@ class CohenKappa(EpochMetric):
 
     """
 
-    def __init__(self, output_transform: Callable = lambda x: x, weights: str = None, check_compute_fn: bool = False):
+    def __init__(self, output_transform: Callable = lambda x: x, weights: str = "", check_compute_fn: bool = False):
 
-        if weights is None:
+        if weights == "":
             self.cohen_kappa_compute = non_weighted_cohen_kappa_compute_fn
         elif weights == "linear":
             self.cohen_kappa_compute = linear_cohen_kappa_compute_fn

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -16,37 +16,6 @@ def non_weighted_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.
     return cohen_kappa_score(y_true, y_pred, weights=None)
 
 
-class NonWeightedCohenKappa(EpochMetric):
-    """Computes Cohen Kappa with no weights. Applying `sklearn.metrics.cohen_kappa_score
-    <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>` .
-
-    Args:
-        output_transform (callable, optional): a callable that is used to transform the
-            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
-            form expected by the metric. This can be useful if, for example, you have a multi-output model and
-            you want to compute the metric with respect to one of the outputs.
-        check_compute_fn (bool): Default False. If True, `NonWeightedCohenKappa
-            `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
-            generated/sklearn.metrics.cohen_kappa_score.html>` is run on the first batch of data to ensure there are
-            no issues. User will be warned in case there are any issues computing the function.
-
-    .. code-block:: python
-
-        def activated_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.softmax(y_pred, dim=1)
-            return y_pred, y
-
-        non_weighted_cohen_kappa = NonWeightedCohenKappa(activated_output_transform)
-
-    """
-
-    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
-        super(NonWeightedCohenKappa, self).__init__(
-            non_weighted_cohen_kappa_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
-        )
-
-
 def linear_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
     try:
         from sklearn.metrics import cohen_kappa_score
@@ -56,37 +25,6 @@ def linear_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor
     y_true = y_targets.numpy()
     y_pred = y_preds.numpy()
     return cohen_kappa_score(y_true, y_pred, weights="linear")
-
-
-class LinearCohenKappa(EpochMetric):
-    """Computes Cohen Kappa with linear weights. Applying `sklearn.metrics.cohen_kappa_score
-    <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>` .
-
-    Args:
-        output_transform (callable, optional): a callable that is used to transform the
-            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
-            form expected by the metric. This can be useful if, for example, you have a multi-output model and
-            you want to compute the metric with respect to one of the outputs.
-        check_compute_fn (bool): Default False. If True, `LinearCohenKappa
-            `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
-            generated/sklearn.metrics.cohen_kappa_score.html>` is run on the first batch of data to ensure there are
-            no issues. User will be warned in case there are any issues computing the function.
-
-    .. code-block:: python
-
-        def activated_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.softmax(y_pred, dim=1)
-            return y_pred, y
-
-        lienar_cohen_kappa = LinearCohenKappa(activated_output_transform)
-
-    """
-
-    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
-        super(LinearCohenKappa, self).__init__(
-            linear_cohen_kappa_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
-        )
 
 
 def quadratic_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
@@ -100,32 +38,52 @@ def quadratic_cohen_kappa_compute_fn(y_preds: torch.Tensor, y_targets: torch.Ten
     return cohen_kappa_score(y_true, y_pred, weights="quadratic")
 
 
-class QuadraticCohenKappa(EpochMetric):
-    """Computes Cohen Kappa with quadratic weights. Applying `sklearn.metrics.cohen_kappa_score
-    <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>` .
+class CohenKappa(EpochMetric):
+    """Compute different types of Cohen's Kappa: Non-Wieghted, Linear, Quadratic.
+    Accumulating predictions and the ground-truth during an epoch and applying
+    `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
+    generated/sklearn.metrics.cohen_kappa_score.html>`_ .
 
     Args:
         output_transform (callable, optional): a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        check_compute_fn (bool): Default False. If True, `QuadraticCohenKappa
-            `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
-            generated/sklearn.metrics.cohen_kappa_score.html>` is run on the first batch of data to ensure there are
+        weights (str): a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear or Quadratic
+            (default: `None`)
+        check_compute_fn (bool): Default False. If True, `cohen_kappa_score
+            <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_ 
+            is run on the first batch of data to ensure there are
             no issues. User will be warned in case there are any issues computing the function.
 
     .. code-block:: python
 
         def activated_output_transform(output):
             y_pred, y = output
-            y_pred = torch.softmax(y_pred, dim=1)
             return y_pred, y
 
-        quadratic_cohen_kappa = QuadraticCohenKappa(activated_output_transform)
+        weights = None or linear or quadratic
+
+        cohen_kappa = CohenKappa(activated_output_transform, weights)
 
     """
 
-    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
-        super(QuadraticCohenKappa, self).__init__(
-            quadratic_cohen_kappa_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
+    def __init__(
+        self, 
+        output_transform: Callable = lambda x: x, 
+        weights: str = None,
+        check_compute_fn: bool = False
+        ):
+
+        if weights is None:
+            self.cohen_kappa_compute = non_weighted_cohen_kappa_compute_fn
+        elif weights == 'linear':
+            self.cohen_kappa_compute = linear_cohen_kappa_compute_fn
+        elif weights == 'quadratic':
+            self.cohen_kappa_compute = quadratic_cohen_kappa_compute_fn
+        else:
+            raise ValueError("Weights must be None or linear or quadratic.")       
+
+        super(CohenKappa, self).__init__(
+            self.cohen_kappa_compute, output_transform=output_transform, check_compute_fn=check_compute_fn
         )

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -1,0 +1,148 @@
+import numpy as np
+import pytest
+import torch
+from sklearn.metrics import cohen_kappa_score
+
+from ignite.contrib.metrics import CohenKappa
+from ignite.engine import Engine
+
+
+def test_cohen_kappa_non_weighted():
+
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_ap = cohen_kappa_score(np_y, np_y_pred)
+
+    ck_metric = CohenKappa()
+    y_pred = torch.from_numpy(np_y_pred)
+    y = torch.from_numpy(np_y)
+
+    ck_metric.reset()
+    ck_metric.update((y_pred, y))
+    ap = ck_metric.compute()
+
+    assert ap == np_ap
+
+
+def test_cohen_kappa_linear_weighted():
+
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_ap = cohen_kappa_score(np_y, np_y_pred, weights="linear")
+
+    ck_metric = CohenKappa(weights="linear")
+    y_pred = torch.from_numpy(np_y_pred)
+    y = torch.from_numpy(np_y)
+
+    ck_metric.reset()
+    ck_metric.update((y_pred, y))
+    ap = ck_metric.compute()
+
+    assert ap == np_ap
+
+
+def test_cohen_kappa_queadratic_weighted():
+
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_ap = cohen_kappa_score(np_y, np_y_pred, weights="quadratic")
+
+    ck_metric = CohenKappa(weights="quadratic")
+    y_pred = torch.from_numpy(np_y_pred)
+    y = torch.from_numpy(np_y)
+
+    ck_metric.reset()
+    ck_metric.update((y_pred, y))
+    ap = ck_metric.compute()
+
+    assert ap == np_ap
+
+
+def test_integration_cohen_kappa_non_weighted_with_output_transform():
+    np.random.seed(1)
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.zeros((size,), dtype=np.long)
+    np_y[size // 2 :] = 1
+    np.random.shuffle(np_y)
+
+    ck_value_sk = cohen_kappa_score(np_y, np_y_pred)
+
+    batch_size = 10
+
+    def update_fn(engine, batch):
+        idx = (engine.state.iteration - 1) * batch_size
+        y_true_batch = np_y[idx : idx + batch_size]
+        y_pred_batch = np_y_pred[idx : idx + batch_size]
+        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+    engine = Engine(update_fn)
+
+    ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]))
+    ck_metric.attach(engine, "cohen_kappa")
+
+    data = list(range(size // batch_size))
+    ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
+
+    assert np.array_equal(ck_value, ck_value_sk)
+
+
+def test_integration_cohen_kappa_linear_weighted_with_output_transform():
+    np.random.seed(1)
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.zeros((size,), dtype=np.long)
+    np_y[size // 2 :] = 1
+    np.random.shuffle(np_y)
+
+    ck_value_sk = cohen_kappa_score(np_y, np_y_pred, weights="linear")
+
+    batch_size = 10
+
+    def update_fn(engine, batch):
+        idx = (engine.state.iteration - 1) * batch_size
+        y_true_batch = np_y[idx : idx + batch_size]
+        y_pred_batch = np_y_pred[idx : idx + batch_size]
+        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+    engine = Engine(update_fn)
+
+    ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]), weights="linear")
+    ck_metric.attach(engine, "cohen_kappa")
+
+    data = list(range(size // batch_size))
+    ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
+
+    assert np.array_equal(ck_value, ck_value_sk)
+
+
+def test_integration_cohen_kappa_quadratic_weighted_with_output_transform():
+    np.random.seed(1)
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.zeros((size,), dtype=np.long)
+    np_y[size // 2 :] = 1
+    np.random.shuffle(np_y)
+
+    ck_value_sk = cohen_kappa_score(np_y, np_y_pred, weights="quadratic")
+
+    batch_size = 10
+
+    def update_fn(engine, batch):
+        idx = (engine.state.iteration - 1) * batch_size
+        y_true_batch = np_y[idx : idx + batch_size]
+        y_pred_batch = np_y_pred[idx : idx + batch_size]
+        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+    engine = Engine(update_fn)
+
+    ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]), weights="quadratic")
+    ck_metric.attach(engine, "cohen_kappa")
+
+    data = list(range(size // batch_size))
+    ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
+
+    assert np.array_equal(ck_value, ck_value_sk)


### PR DESCRIPTION
Fixes #1673 

Added Cohen's Kappa in `ignite.contrib.metrics`. Implemented `NonWeightedCohenKappa`, `LinearCohenKappa`, 'QuadraticCohenKappa' in `cohen_kappa` file. The implementation is similar to [average precision](urhttps://github.com/pytorch/ignite/blob/master/ignite/contrib/metrics/average_precision.pyl)

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
