### PR TITLE
add cohen kappa

### DIFF
--- a/ignite/contrib/metrics/__init__.py
+++ b/ignite/contrib/metrics/__init__.py
@@ -1,5 +1,6 @@
 import ignite.contrib.metrics.regression
 from ignite.contrib.metrics.average_precision import AveragePrecision
+from ignite.contrib.metrics.cohen_kappa import CohenKappa
 from ignite.contrib.metrics.gpu_info import GpuInfo
 from ignite.contrib.metrics.precision_recall_curve import PrecisionRecallCurve
 from ignite.contrib.metrics.roc_auc import ROC_AUC, RocCurve

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -37,9 +37,10 @@ class CohenKappa(EpochMetric):
 
     def __init__(self, output_transform: Callable = lambda x: x, weights: str = "", check_compute_fn: bool = False):
         # initalize weights
-        self.weights = weights
-        if self.weights == "":
+        if weights == "":
             self.weights = None
+        else:
+            self.weights = weights
 
         self.cohen_kappa_compute = self.get_cohen_kappa_fn()
 
@@ -47,14 +48,14 @@ class CohenKappa(EpochMetric):
             self.cohen_kappa_compute, output_transform=output_transform, check_compute_fn=check_compute_fn
         )
 
-    def get_cohen_kappa_fn(self):
+    def get_cohen_kappa_fn(self) -> float:
 
         try:
             from sklearn.metrics import cohen_kappa_score
         except ImportError:
             raise RuntimeError("This contrib module requires sklearn to be installed.")
 
-        def wrapper(y_targets: torch.Tensor, y_preds: torch.Tensor):
+        def wrapper(y_targets: torch.Tensor, y_preds: torch.Tensor) -> float:
             y_true = y_targets.numpy()
             y_pred = y_preds.numpy()
             return cohen_kappa_score(y_true, y_pred, weights=self.weights)

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -48,7 +48,7 @@ class CohenKappa(EpochMetric):
             self.cohen_kappa_compute, output_transform=output_transform, check_compute_fn=check_compute_fn
         )
 
-    def get_cohen_kappa_fn(self) -> float:
+    def get_cohen_kappa_fn(self) -> Callable[[torch.Tensor, torch.Tensor], float]:
 
         try:
             from sklearn.metrics import cohen_kappa_score

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -16,13 +16,13 @@ class CohenKappa(EpochMetric):
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        weights: a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear or Quadratic
-            (default: "")
+        weights: a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear
+            or Quadratic. Default, None.
         check_compute_fn: Default False. If True, `cohen_kappa_score
             <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_
             is run on the first batch of data to ensure there are
             no issues. User will be warned in case there are any issues computing the function.
-        device (str or torch.device, optional): optional device specification for internal storage.
+        device: optional device specification for internal storage.
 
     .. code-block:: python
 
@@ -48,6 +48,9 @@ class CohenKappa(EpochMetric):
             from sklearn.metrics import cohen_kappa_score
         except ImportError:
             raise RuntimeError("This contrib module requires sklearn to be installed.")
+
+        if weights not in (None, "linear", "quadratic"):
+            raise ValueError("Kappa Weighting type must be None or linear or quadratic.")
 
         # initalize weights
         self.weights = weights

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import torch
 
@@ -16,12 +16,13 @@ class CohenKappa(EpochMetric):
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        weights (str): a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear or Quadratic
+        weights: a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear or Quadratic
             (default: "")
-        check_compute_fn (bool): Default False. If True, `cohen_kappa_score
+        check_compute_fn: Default False. If True, `cohen_kappa_score
             <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_
             is run on the first batch of data to ensure there are
             no issues. User will be warned in case there are any issues computing the function.
+        device (str or torch.device, optional): optional device specification for internal storage.
 
     .. code-block:: python
 
@@ -36,7 +37,11 @@ class CohenKappa(EpochMetric):
     """
 
     def __init__(
-        self, output_transform: Callable = lambda x: x, weights: Optional[str] = None, check_compute_fn: bool = False
+        self,
+        output_transform: Callable = lambda x: x,
+        weights: Optional[str] = None,
+        check_compute_fn: bool = False,
+        device: Union[str, torch.device] = torch.device("cpu"),
     ):
 
         try:
@@ -44,21 +49,24 @@ class CohenKappa(EpochMetric):
         except ImportError:
             raise RuntimeError("This contrib module requires sklearn to be installed.")
 
-        self.cohen_kappa_sk = cohen_kappa_score
-
         # initalize weights
         self.weights = weights
 
         self.cohen_kappa_compute = self.get_cohen_kappa_fn()
 
         super(CohenKappa, self).__init__(
-            self.cohen_kappa_compute, output_transform=output_transform, check_compute_fn=check_compute_fn
+            self.cohen_kappa_compute,
+            output_transform=output_transform,
+            check_compute_fn=check_compute_fn,
+            device=device,
         )
 
     def get_cohen_kappa_fn(self) -> Callable[[torch.Tensor, torch.Tensor], float]:
+        from sklearn.metrics import cohen_kappa_score
+
         def wrapper(y_targets: torch.Tensor, y_preds: torch.Tensor) -> float:
-            y_true = y_targets.numpy()
-            y_pred = y_preds.numpy()
-            return self.cohen_kappa_sk(y_true, y_pred, weights=self.weights)
+            y_true = y_targets.cpu().numpy()
+            y_pred = y_preds.cpu().numpy()
+            return cohen_kappa_score(y_true, y_pred, weights=self.weights)
 
         return wrapper

--- a/ignite/contrib/metrics/cohen_kappa.py
+++ b/ignite/contrib/metrics/cohen_kappa.py
@@ -1,0 +1,62 @@
+from typing import Callable
+
+import torch
+
+from ignite.metrics import EpochMetric
+
+
+class CohenKappa(EpochMetric):
+    """Compute different types of Cohen's Kappa: Non-Wieghted, Linear, Quadratic.
+    Accumulating predictions and the ground-truth during an epoch and applying
+    `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
+    generated/sklearn.metrics.cohen_kappa_score.html>`_ .
+
+    Args:
+        output_transform (callable, optional): a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        weights (str): a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear or Quadratic
+            (default: "")
+        check_compute_fn (bool): Default False. If True, `cohen_kappa_score
+            <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_
+            is run on the first batch of data to ensure there are
+            no issues. User will be warned in case there are any issues computing the function.
+
+    .. code-block:: python
+
+        def activated_output_transform(output):
+            y_pred, y = output
+            return y_pred, y
+
+        weights = None or linear or quadratic
+
+        cohen_kappa = CohenKappa(activated_output_transform, weights)
+
+    """
+
+    def __init__(self, output_transform: Callable = lambda x: x, weights: str = "", check_compute_fn: bool = False):
+        # initalize weights
+        self.weights = weights
+        if self.weights == "":
+            self.weights = None
+
+        self.cohen_kappa_compute = self.get_cohen_kappa_fn()
+
+        super(CohenKappa, self).__init__(
+            self.cohen_kappa_compute, output_transform=output_transform, check_compute_fn=check_compute_fn
+        )
+
+    def get_cohen_kappa_fn(self):
+
+        try:
+            from sklearn.metrics import cohen_kappa_score
+        except ImportError:
+            raise RuntimeError("This contrib module requires sklearn to be installed.")
+
+        def wrapper(y_targets: torch.Tensor, y_preds: torch.Tensor):
+            y_true = y_targets.numpy()
+            y_pred = y_preds.numpy()
+            return cohen_kappa_score(y_true, y_pred, weights=self.weights)
+
+        return wrapper

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -64,6 +64,14 @@ def test_cohen_kappa_all_weights(weights):
     assert ck == pytest.approx(np_ck)
 
 
+def test_cohen_kappa_wrong_weights_type():
+    with pytest.raises(ValueError, match=r"Kappa Weighting type must be"):
+        ck = CohenKappa(weights=7)
+
+    with pytest.raises(ValueError, match=r"Kappa Weighting type must be"):
+        ck = CohenKappa(weights="dd")
+
+
 @pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
 def test_cohen_kappa_all_weights_with_output_transform(weights):
     np.random.seed(1)

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -95,7 +95,7 @@ def test_cohen_kappa_all_weights_with_output_transform(weights):
     size = 100
     np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
     np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
+    np_y[size // 2:] = 1
     np.random.shuffle(np_y)
 
     ck_value_sk = cohen_kappa_score(np_y, np_y_pred)
@@ -104,8 +104,8 @@ def test_cohen_kappa_all_weights_with_output_transform(weights):
 
     def update_fn(engine, batch):
         idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
+        y_true_batch = np_y[idx: idx + batch_size]
+        y_pred_batch = np_y_pred[idx: idx + batch_size]
         return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
 
     engine = Engine(update_fn)

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -71,22 +71,22 @@ def test_cohen_kappa_all_weights(weights):
 
 def test_cohen_kappa_wrong_weights_type():
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights=7)
+        CohenKappa(weights=7)
 
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights="dd")
+        CohenKappa(weights="dd")
 
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights="ss")
+        CohenKappa(weights="ss")
 
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights="l")
+        CohenKappa(weights="l")
 
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights="q")
+        CohenKappa(weights="q")
 
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights="z")
+        CohenKappa(weights="z")
 
 
 @pytest.mark.parametrize("weights", [None, "linear", "quadratic"])

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -1,8 +1,11 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 from sklearn.metrics import cohen_kappa_score
 
+import ignite.distributed as idist
 from ignite.contrib.metrics import CohenKappa
 from ignite.engine import Engine
 
@@ -146,3 +149,99 @@ def test_integration_cohen_kappa_quadratic_weighted_with_output_transform():
     ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
 
     assert np.array_equal(ck_value, ck_value_sk)
+
+
+def _test_distrib_compute(device):
+    rank = idist.get_rank()
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        ck_metric = CohenKappa(device=metric_device)
+
+        torch.manual_seed(10 + rank)
+
+        y_pred = torch.randint(0, 2, size=(100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device)
+
+        ck_metric.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y_pred = y_pred.cpu().numpy()
+        np_y = y.cpu().numpy()
+
+        np_ck = cohen_kappa_score(np_y, np_y_pred)
+
+        res = ck_metric.compute()
+        assert res == np_ck
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_gpu(distributed_context_single_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_cpu(distributed_context_single_node_gloo):
+
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -25,7 +25,7 @@ def test_cohen_kappa_non_weighted():
     ck_metric.update((y_pred, y))
     ck = ck_metric.compute()
 
-    assert ck == np_ck
+    assert ck == pytest.approx(np_ck)
 
 
 def test_cohen_kappa_linear_weighted():
@@ -43,7 +43,7 @@ def test_cohen_kappa_linear_weighted():
     ck_metric.update((y_pred, y))
     ck = ck_metric.compute()
 
-    assert ck == np_ck
+    assert ck == pytest.approx(np_ck)
 
 
 def test_cohen_kappa_queadratic_weighted():
@@ -61,7 +61,7 @@ def test_cohen_kappa_queadratic_weighted():
     ck_metric.update((y_pred, y))
     ck = ck_metric.compute()
 
-    assert ck == np_ck
+    assert ck == pytest.approx(np_ck)
 
 
 def test_integration_cohen_kappa_non_weighted_with_output_transform():
@@ -175,7 +175,7 @@ def _test_distrib_compute(device):
         np_ck = cohen_kappa_score(np_y, np_y_pred)
 
         res = ck_metric.compute()
-        assert res == np_ck
+        assert res == pytest.approx(np_ck)
 
     for _ in range(3):
         _test("cpu")

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -1,0 +1,148 @@
+import numpy as np
+import pytest
+import torch
+from sklearn.metrics import cohen_kappa_score
+
+from ignite.contrib.metrics import CohenKappa
+from ignite.engine import Engine
+
+
+def test_cohen_kappa_non_weighted():
+
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_ck = cohen_kappa_score(np_y, np_y_pred)
+
+    ck_metric = CohenKappa()
+    y_pred = torch.from_numpy(np_y_pred)
+    y = torch.from_numpy(np_y)
+
+    ck_metric.reset()
+    ck_metric.update((y_pred, y))
+    ck = ck_metric.compute()
+
+    assert ck == np_ck
+
+
+def test_cohen_kappa_linear_weighted():
+
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_ck = cohen_kappa_score(np_y, np_y_pred, weights="linear")
+
+    ck_metric = CohenKappa(weights="linear")
+    y_pred = torch.from_numpy(np_y_pred)
+    y = torch.from_numpy(np_y)
+
+    ck_metric.reset()
+    ck_metric.update((y_pred, y))
+    ck = ck_metric.compute()
+
+    assert ck == np_ck
+
+
+def test_cohen_kappa_queadratic_weighted():
+
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_ck = cohen_kappa_score(np_y, np_y_pred, weights="quadratic")
+
+    ck_metric = CohenKappa(weights="quadratic")
+    y_pred = torch.from_numpy(np_y_pred)
+    y = torch.from_numpy(np_y)
+
+    ck_metric.reset()
+    ck_metric.update((y_pred, y))
+    ck = ck_metric.compute()
+
+    assert ck == np_ck
+
+
+def test_integration_cohen_kappa_non_weighted_with_output_transform():
+    np.random.seed(1)
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.zeros((size,), dtype=np.long)
+    np_y[size // 2 :] = 1
+    np.random.shuffle(np_y)
+
+    ck_value_sk = cohen_kappa_score(np_y, np_y_pred)
+
+    batch_size = 10
+
+    def update_fn(engine, batch):
+        idx = (engine.state.iteration - 1) * batch_size
+        y_true_batch = np_y[idx : idx + batch_size]
+        y_pred_batch = np_y_pred[idx : idx + batch_size]
+        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+    engine = Engine(update_fn)
+
+    ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]))
+    ck_metric.attach(engine, "cohen_kappa")
+
+    data = list(range(size // batch_size))
+    ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
+
+    assert np.array_equal(ck_value, ck_value_sk)
+
+
+def test_integration_cohen_kappa_linear_weighted_with_output_transform():
+    np.random.seed(1)
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.zeros((size,), dtype=np.long)
+    np_y[size // 2 :] = 1
+    np.random.shuffle(np_y)
+
+    ck_value_sk = cohen_kappa_score(np_y, np_y_pred, weights="linear")
+
+    batch_size = 10
+
+    def update_fn(engine, batch):
+        idx = (engine.state.iteration - 1) * batch_size
+        y_true_batch = np_y[idx : idx + batch_size]
+        y_pred_batch = np_y_pred[idx : idx + batch_size]
+        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+    engine = Engine(update_fn)
+
+    ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]), weights="linear")
+    ck_metric.attach(engine, "cohen_kappa")
+
+    data = list(range(size // batch_size))
+    ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
+
+    assert np.array_equal(ck_value, ck_value_sk)
+
+
+def test_integration_cohen_kappa_quadratic_weighted_with_output_transform():
+    np.random.seed(1)
+    size = 100
+    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
+    np_y = np.zeros((size,), dtype=np.long)
+    np_y[size // 2 :] = 1
+    np.random.shuffle(np_y)
+
+    ck_value_sk = cohen_kappa_score(np_y, np_y_pred, weights="quadratic")
+
+    batch_size = 10
+
+    def update_fn(engine, batch):
+        idx = (engine.state.iteration - 1) * batch_size
+        y_true_batch = np_y[idx : idx + batch_size]
+        y_pred_batch = np_y_pred[idx : idx + batch_size]
+        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+    engine = Engine(update_fn)
+
+    ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]), weights="quadratic")
+    ck_metric.attach(engine, "cohen_kappa")
+
+    data = list(range(size // batch_size))
+    ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
+
+    assert np.array_equal(ck_value, ck_value_sk)

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -25,7 +25,14 @@ def test_input_types():
         ck.update((torch.randint(0, 2, size=(10, 2, 3)).long(), torch.arange(0, 10).float()))
 
     with pytest.raises(ValueError):
-        ck.update((torch.rand(10,).float(), torch.randint(0, 2, size=(10, 3, 1)).long()))
+        ck.update(
+            (
+                torch.rand(
+                    10,
+                ).float(),
+                torch.randint(0, 2, size=(10, 3, 1)).long(),
+            )
+        )
 
     with pytest.raises(ValueError):
         ck.update((torch.randint(0, 4, size=(10, 2, 3)).long(), torch.randint(0, 2, size=(10, 5)).long()))
@@ -44,7 +51,7 @@ def test_check_shape():
         ck._check_shape((torch.randint(0, 2, size=(10, 1)).long(), torch.randint(0, 2, size=(10, 5, 2)).long()))
 
 
-@pytest.mark.parametrize('weights', [None, 'linear', 'quadratic'])
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
 def test_cohen_kappa_all_weights(weights):
     size = 100
     np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
@@ -65,24 +72,24 @@ def test_cohen_kappa_all_weights(weights):
 def test_cohen_kappa_wrong_weights_type():
     with pytest.raises(ValueError):
         ck = CohenKappa(weights=7)
-        
+
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights='dd')
-        
+        ck = CohenKappa(weights="dd")
+
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights='ss')
-        
+        ck = CohenKappa(weights="ss")
+
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights='l')
-        
+        ck = CohenKappa(weights="l")
+
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights='q')
-        
+        ck = CohenKappa(weights="q")
+
     with pytest.raises(ValueError):
-        ck = CohenKappa(weights='z')
+        ck = CohenKappa(weights="z")
 
 
-@pytest.mark.parametrize('weights', [None, 'linear', 'quadratic'])
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
 def test_cohen_kappa_all_weights_with_output_transform(weights):
     np.random.seed(1)
     size = 100


### PR DESCRIPTION
Fixes #1673

Added Cohen's Kappa in `ignite.contrib.metrics`. Implemented 'CohenKappa' in `cohen_kappa.py` file. And added the tests in `test_cohen_kappa.py`.

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
