### PR TITLE
add test for new loss detach behavior

### DIFF
--- a/tests/ignite/metrics/test_loss.py
+++ b/tests/ignite/metrics/test_loss.py
@@ -55,6 +55,7 @@ def test_non_averaging_loss():
 
 
 def test_gradient_based_loss():
+    # Tests https://github.com/pytorch/ignite/issues/1674
     x = torch.tensor([[0.1, 0.4, 0.5], [0.1, 0.7, 0.2]], requires_grad=True)
     y_pred = x.mm(torch.randn(size=(3, 1)))
 

--- a/tests/ignite/metrics/test_loss.py
+++ b/tests/ignite/metrics/test_loss.py
@@ -54,6 +54,23 @@ def test_non_averaging_loss():
         loss.update((y_pred, y))
 
 
+def test_gradient_based_loss():
+    x = torch.tensor([[0.1, 0.4, 0.5], [0.1, 0.7, 0.2]], requires_grad=True)
+    y_pred = x.mm(torch.randn(size=(3, 1)))
+
+    def loss_fn(y_pred, x):
+        gradients = torch.autograd.grad(
+            outputs=y_pred, inputs=x, grad_outputs=torch.ones_like(y_pred), create_graph=True,
+        )[0]
+
+        gradients = gradients.flatten(start_dim=1)
+
+        return gradients.norm(2, dim=1).mean()
+
+    loss = Loss(loss_fn)
+    loss.update((y_pred, x))
+
+
 def test_kwargs_loss():
     loss = Loss(nll_loss)
 


### PR DESCRIPTION
Follow up of #1674 and #1675 

Add a test for the new detach behavior in the loss. This test only checks for non-failure, it doesn't check numerical correctness as that is expected to be tested elsewhere.

I verified manually that this test indeed fails before my previous PR.