### PR TITLE
Improve contrib metrics

### DIFF
--- a/ignite/contrib/metrics/average_precision.py
+++ b/ignite/contrib/metrics/average_precision.py
@@ -1,19 +1,8 @@
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import torch
 
 from ignite.metrics import EpochMetric
-
-
-def average_precision_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
-    try:
-        from sklearn.metrics import average_precision_score
-    except ImportError:
-        raise RuntimeError("This contrib module requires sklearn to be installed.")
-
-    y_true = y_targets.numpy()
-    y_pred = y_preds.numpy()
-    return average_precision_score(y_true, y_pred)
 
 
 class AveragePrecision(EpochMetric):
@@ -22,14 +11,15 @@ class AveragePrecision(EpochMetric):
     sklearn.metrics.average_precision_score.html#sklearn.metrics.average_precision_score>`_ .
 
     Args:
-        output_transform (callable, optional): a callable that is used to transform the
+        output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        check_compute_fn (bool): Default False. If True, `average_precision_score
+        check_compute_fn: Default False. If True, `average_precision_score
             <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html
             #sklearn.metrics.average_precision_score>`_ is run on the first batch of data to ensure there are
             no issues. User will be warned in case there are any issues computing the function.
+        device: optional device specification for internal storage.
 
     AveragePrecision expects y to be comprised of 0's and 1's. y_pred must either be probability estimates or
     confidence values. To apply an activation to y_pred, use output_transform as shown below:
@@ -45,7 +35,33 @@ class AveragePrecision(EpochMetric):
 
     """
 
-    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
+    def __init__(
+        self,
+        output_transform: Callable = lambda x: x,
+        check_compute_fn: bool = False,
+        device: Union[str, torch.device] = torch.device("cpu"),
+    ):
+
+        try:
+            from sklearn.metrics import average_precision_score
+        except ImportError:
+            raise RuntimeError("This contrib module requires sklearn to be installed.")
+
+        self.average_precision_compute = self.average_precision_compute_fn()
+
         super(AveragePrecision, self).__init__(
-            average_precision_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
+            self.average_precision_compute,
+            output_transform=output_transform,
+            check_compute_fn=check_compute_fn,
+            device=device,
         )
+
+    def average_precision_compute_fn(self) -> Callable[[torch.Tensor, torch.Tensor], float]:
+        from sklearn.metrics import average_precision_score
+
+        def wrapper(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
+            y_true = y_targets.cpu().numpy()
+            y_pred = y_preds.cpu().numpy()
+            return average_precision_score(y_true, y_pred)
+
+        return wrapper

--- a/ignite/contrib/metrics/precision_recall_curve.py
+++ b/ignite/contrib/metrics/precision_recall_curve.py
@@ -1,19 +1,8 @@
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, Tuple, Union
 
 import torch
 
 from ignite.metrics import EpochMetric
-
-
-def precision_recall_curve_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> Tuple[Any, Any, Any]:
-    try:
-        from sklearn.metrics import precision_recall_curve
-    except ImportError:
-        raise RuntimeError("This contrib module requires sklearn to be installed.")
-
-    y_true = y_targets.numpy()
-    y_pred = y_preds.numpy()
-    return precision_recall_curve(y_true, y_pred)
 
 
 class PrecisionRecallCurve(EpochMetric):
@@ -23,14 +12,15 @@ class PrecisionRecallCurve(EpochMetric):
     sklearn.metrics.precision_recall_curve.html#sklearn.metrics.precision_recall_curve>`_ .
 
     Args:
-        output_transform (callable, optional): a callable that is used to transform the
+        output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        check_compute_fn (bool): Default False. If True, `precision_recall_curve
+        check_compute_fn: Default False. If True, `precision_recall_curve
             <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_curve.html
             #sklearn.metrics.precision_recall_curve>`_ is run on the first batch of data to ensure there are
             no issues. User will be warned in case there are any issues computing the function.
+        device: optional device specification for internal storage.
 
     PrecisionRecallCurve expects y to be comprised of 0's and 1's. y_pred must either be probability estimates
     or confidence values. To apply an activation to y_pred, use output_transform as shown below:
@@ -46,7 +36,33 @@ class PrecisionRecallCurve(EpochMetric):
 
     """
 
-    def __init__(self, output_transform: Callable = lambda x: x, check_compute_fn: bool = False) -> None:
+    def __init__(
+        self,
+        output_transform: Callable = lambda x: x,
+        check_compute_fn: bool = False,
+        device: Union[str, torch.device] = torch.device("cpu"),
+    ):
+
+        try:
+            from sklearn.metrics import average_precision_score
+        except ImportError:
+            raise RuntimeError("This contrib module requires sklearn to be installed.")
+
+        self.precision_recall_curve_compute = self.precision_recall_curve_compute_fn()
+
         super(PrecisionRecallCurve, self).__init__(
-            precision_recall_curve_compute_fn, output_transform=output_transform, check_compute_fn=check_compute_fn
+            self.precision_recall_curve_compute,
+            output_transform=output_transform,
+            check_compute_fn=check_compute_fn,
+            device=device,
         )
+
+    def precision_recall_curve_compute_fn(self) -> Tuple[Any, Any, Any]:
+        from sklearn.metrics import precision_recall_curve
+
+        def wrapper(y_preds: torch.Tensor, y_targets: torch.Tensor):
+            y_true = y_targets.cpu().numpy()
+            y_pred = y_preds.cpu().numpy()
+            return precision_recall_curve(y_true, y_pred)
+
+        return wrapper

--- a/ignite/metrics/epoch_metric.py
+++ b/ignite/metrics/epoch_metric.py
@@ -142,7 +142,10 @@ class EpochMetric(Metric):
             # Run compute_fn on zero rank only
             result = self.compute_fn(_prediction_tensor, _target_tensor)
             if result is not None:
-                apply_to_type(result, (torch.Tensor, float, int, str), partial(idist.broadcast, src=0))
+                try:
+                    apply_to_type(result, (torch.Tensor, float), partial(idist.broadcast, src=0))
+                except TypeError:
+                    apply_to_type(result, (torch.Tensor, int), partial(idist.broadcast, src=0))
 
         if ws > 1:
             # broadcast result to all processes

--- a/tests/ignite/contrib/metrics/test_average_precision.py
+++ b/tests/ignite/contrib/metrics/test_average_precision.py
@@ -1,12 +1,52 @@
+import os
+
 import numpy as np
+import pytest
 import torch
 from sklearn.metrics import average_precision_score
 
+import ignite.distributed as idist
 from ignite.contrib.metrics import AveragePrecision
 from ignite.engine import Engine
+from ignite.exceptions import NotComputableError
 
 
-def test_ap_score():
+def test_no_update():
+    ap = AveragePrecision()
+
+    with pytest.raises(
+        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+    ):
+        ap.compute()
+
+
+def test_input_types():
+    ap = AveragePrecision()
+    ap.reset()
+    output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 3), dtype=torch.long))
+    ap.update(output1)
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        ap.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
+        ap.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
+
+
+def test_check_shape():
+    ap = AveragePrecision()
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        ap._check_shape((torch.tensor(0), torch.tensor(0)))
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        ap._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
+
+    with pytest.raises(ValueError, match=r"Targets should be of shape"):
+        ap._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
+
+
+def test_average_precision():
 
     size = 100
     np_y_pred = np.random.rand(size, 5)
@@ -21,10 +61,10 @@ def test_ap_score():
     ap_metric.update((y_pred, y))
     ap = ap_metric.compute()
 
-    assert ap == np_ap
+    assert ap == pytest.approx(np_ap)
 
 
-def test_ap_score_2():
+def test_average_precision_2():
 
     np.random.seed(1)
     size = 100
@@ -47,7 +87,7 @@ def test_ap_score_2():
 
     ap = ap_metric.compute()
 
-    assert ap == np_ap
+    assert ap == pytest.approx(np_ap)
 
 
 def test_integration_ap_score_with_output_transform():
@@ -77,7 +117,7 @@ def test_integration_ap_score_with_output_transform():
     data = list(range(size // batch_size))
     ap = engine.run(data, max_epochs=1).metrics["ap"]
 
-    assert ap == np_ap
+    assert ap == pytest.approx(np_ap)
 
 
 def test_integration_ap_score_with_activated_output_transform():
@@ -108,4 +148,100 @@ def test_integration_ap_score_with_activated_output_transform():
     data = list(range(size // batch_size))
     ap = engine.run(data, max_epochs=1).metrics["ap"]
 
-    assert ap == np_ap
+    assert ap == pytest.approx(np_ap)
+
+
+def _test_distrib_compute(device):
+    rank = idist.get_rank()
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        ap_metric = AveragePrecision(device=metric_device)
+
+        torch.manual_seed(10 + rank)
+
+        y_pred = torch.rand(size=(100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device)
+
+        ap_metric.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y_pred = y_pred.cpu().numpy()
+        np_y = y.cpu().numpy()
+
+        np_ap = average_precision_score(np_y, np_y_pred)
+
+        res = ap_metric.compute()
+        assert res == pytest.approx(np_ap)
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_gpu(distributed_context_single_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_cpu(distributed_context_single_node_gloo):
+
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)

--- a/tests/ignite/contrib/metrics/test_average_precision.py
+++ b/tests/ignite/contrib/metrics/test_average_precision.py
@@ -10,6 +10,8 @@ from ignite.contrib.metrics import AveragePrecision
 from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
 
+torch.manual_seed(12)
+
 
 def test_no_update():
     ap = AveragePrecision()
@@ -32,6 +34,9 @@ def test_input_types():
     with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
         ap.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
 
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        ap.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
+
 
 def test_check_shape():
     ap = AveragePrecision()
@@ -46,136 +51,376 @@ def test_check_shape():
         ap._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
 
 
-def test_average_precision():
+def test_binary_input_N():
+    def _test():
+        ap = AveragePrecision()
 
-    size = 100
-    np_y_pred = np.random.rand(size, 5)
-    np_y = np.random.randint(0, 2, size=(size, 5), dtype=np.long)
-    np_ap = average_precision_score(np_y, np_y_pred)
+        y_pred = torch.randint(0, 2, size=(10,)).long()
+        y = torch.randint(0, 2, size=(10,)).long()
+        ap.update((y_pred, y))
 
-    ap_metric = AveragePrecision()
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    ap_metric.reset()
-    ap_metric.update((y_pred, y))
-    ap = ap_metric.compute()
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
 
-    assert ap == pytest.approx(np_ap)
+        # Batched Updates
+        ap.reset()
+        y_pred = torch.randint(0, 2, size=(100,)).long()
+        y = torch.randint(0, 2, size=(100,)).long()
 
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
 
-def test_average_precision_2():
+        for i in range(n_iters):
+            idx = i * batch_size
+            ap.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
 
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
-    np_ap = average_precision_score(np_y, np_y_pred)
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    ap_metric = AveragePrecision()
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
 
-    ap_metric.reset()
-    n_iters = 10
-    batch_size = size // n_iters
-    for i in range(n_iters):
-        idx = i * batch_size
-        ap_metric.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+        ap.reset()
+        y_pred = torch.randint(0, 2, size=(10, 1)).long()
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        ap.update((y_pred, y))
 
-    ap = ap_metric.compute()
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    assert ap == pytest.approx(np_ap)
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
 
+        ap.reset()
+        y_pred = torch.randint(0, 2, size=(10, 1)).long()
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        ap.update((y_pred, y))
 
-def test_integration_ap_score_with_output_transform():
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
 
-    np_ap = average_precision_score(np_y, np_y_pred)
+        # Batched Updates
+        ap.reset()
+        y_pred = torch.randint(0, 2, size=(100, 1)).long()
+        y = torch.randint(0, 2, size=(100, 1)).long()
 
-    batch_size = 10
+        n_iters = 16
+        batch_size = y.shape[0] // n_iters + 1
 
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+        for i in range(n_iters):
+            idx = i * batch_size
+            ap.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
 
-    engine = Engine(update_fn)
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    ap_metric = AveragePrecision(output_transform=lambda x: (x[1], x[2]))
-    ap_metric.attach(engine, "ap")
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
 
-    data = list(range(size // batch_size))
-    ap = engine.run(data, max_epochs=1).metrics["ap"]
-
-    assert ap == pytest.approx(np_ap)
-
-
-def test_integration_ap_score_with_activated_output_transform():
-
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y_pred_softmax = torch.softmax(torch.from_numpy(np_y_pred), dim=1).numpy()
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
-
-    np_ap = average_precision_score(np_y, np_y_pred_softmax)
-
-    batch_size = 10
-
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
-
-    engine = Engine(update_fn)
-
-    ap_metric = AveragePrecision(output_transform=lambda x: (torch.softmax(x[1], dim=1), x[2]))
-    ap_metric.attach(engine, "ap")
-
-    data = list(range(size // batch_size))
-    ap = engine.run(data, max_epochs=1).metrics["ap"]
-
-    assert ap == pytest.approx(np_ap)
+    for _ in range(10):
+        _test()
 
 
-def _test_distrib_compute(device):
+def test_multilabel_input_N():
+    def _test():
+        ap = AveragePrecision()
+
+        y_pred = torch.randint(0, 2, size=(10, 4)).long()
+        y = torch.randint(0, 2, size=(10, 4)).long()
+        ap.update((y_pred, y))
+
+        np_y_pred = y_pred.numpy()
+        np_y = y.numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        ap.reset()
+        y_pred = torch.randint(0, 2, size=(50, 7)).long()
+        y = torch.randint(0, 2, size=(50, 7)).long()
+        ap.update((y_pred, y))
+        np_y_pred = y_pred.numpy()
+        np_y = y.numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        ap.reset()
+        y_pred = torch.randint(0, 2, size=(100, 4))
+        y = torch.randint(0, 2, size=(100, 4)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ap.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+    for _ in range(10):
+        _test()
+
+
+def test_multiclass_inputs():
+    ap = AveragePrecision()
+
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        ap.update((torch.randint(0, 3, size=(10, 4)).long(), torch.randint(0, 3, size=(10, 4)).long()))
+
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        ap.update((torch.randint(0, 5, size=(10, 6)).long(), torch.randint(0, 5, size=(10, 6)).long()))
+
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        ap.update((torch.randint(0, 7, size=(10, 8)).long(), torch.randint(0, 7, size=(10, 8)).long()))
+
+
+def test_integration_binary_input_with_output_transform():
+    def _test():
+
+        y_pred = torch.randint(0, 2, size=(100,)).long()
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        ap_metric = AveragePrecision(output_transform=lambda x: (x[1], x[2]))
+        ap_metric.attach(engine, "ap")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_ap = average_precision_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        ap = engine.run(data, max_epochs=1).metrics["ap"]
+
+        assert isinstance(ap, float)
+        assert np_ap == pytest.approx(ap)
+
+        y_pred = torch.randint(0, 2, size=(100, 1)).long()
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        ap_metric = AveragePrecision(output_transform=lambda x: (x[1], x[2]))
+        ap_metric.attach(engine, "ap")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_ap = average_precision_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        ap = engine.run(data, max_epochs=1).metrics["ap"]
+
+        assert isinstance(ap, float)
+        assert np_ap == pytest.approx(ap)
+
+    for _ in range(10):
+        _test()
+
+
+def test_integration_multilabel_input_with_output_transform():
+    def _test():
+
+        y_pred = torch.randint(0, 2, size=(100, 3)).long()
+        y = torch.randint(0, 2, size=(100, 3)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        ap_metric = AveragePrecision(output_transform=lambda x: (x[1], x[2]))
+        ap_metric.attach(engine, "ap")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_ap = average_precision_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        ap = engine.run(data, max_epochs=1).metrics["ap"]
+
+        assert isinstance(ap, float)
+        assert np_ap == pytest.approx(ap)
+
+        y_pred = torch.randint(0, 2, size=(100, 7)).long()
+        y = torch.randint(0, 2, size=(100, 7)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        ap_metric = AveragePrecision(output_transform=lambda x: (x[1], x[2]))
+        ap_metric.attach(engine, "ap")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_ap = average_precision_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        ap = engine.run(data, max_epochs=1).metrics["ap"]
+
+        assert isinstance(ap, float)
+        assert np_ap == pytest.approx(ap)
+
+    for _ in range(10):
+        _test()
+
+
+def _test_distirb_binary_input_N(device):
     rank = idist.get_rank()
 
     def _test(metric_device):
         metric_device = torch.device(metric_device)
-        ap_metric = AveragePrecision(device=metric_device)
+        ap = AveragePrecision(device=metric_device)
 
         torch.manual_seed(10 + rank)
 
-        y_pred = torch.rand(size=(100, 1), device=device)
-        y = torch.randint(0, 2, size=(100, 1), device=device)
-
-        ap_metric.update((y_pred, y))
+        y_pred = torch.randint(0, 2, size=(10,), device=device).long()
+        y = torch.randint(0, 2, size=(10,), device=device).long()
+        ap.update((y_pred, y))
 
         # gather y_pred, y
         y_pred = idist.all_gather(y_pred)
         y = idist.all_gather(y)
 
-        np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
 
-        np_ap = average_precision_score(np_y, np_y_pred)
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
 
-        res = ap_metric.compute()
-        assert res == pytest.approx(np_ap)
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100,), device=device).long()
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+        ap.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 1), device=device).long()
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+        ap.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100,), device=device).long()
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ap.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 1), device=device).long()
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ap.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
 
     for _ in range(3):
         _test("cpu")
@@ -183,12 +428,224 @@ def _test_distrib_compute(device):
             _test(idist.device())
 
 
+def _test_distirb_multilabel_input_N(device):
+    rank = idist.get_rank()
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        ap = AveragePrecision(device=metric_device)
+
+        torch.manual_seed(10 + rank)
+
+        y_pred = torch.randint(0, 2, size=(10, 4), device=device).long()
+        y = torch.randint(0, 2, size=(10, 4), device=device).long()
+        ap.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 7), device=device).long()
+        y = torch.randint(0, 2, size=(100, 7), device=device).long()
+        ap.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 3), device=device).long()
+        y = torch.randint(0, 2, size=(100, 3), device=device).long()
+        ap.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 5), device=device).long()
+        y = torch.randint(0, 2, size=(100, 5), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ap.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        ap.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 8), device=device).long()
+        y = torch.randint(0, 2, size=(100, 8), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ap.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ap.compute()
+        assert isinstance(res, float)
+        assert average_precision_score(np_y, np_y_pred) == pytest.approx(res)
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+def _test_distrib_integration_binary(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(offset * idist.get_world_size(),).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            )
+
+        engine = Engine(update)
+
+        ap = AveragePrecision(device=metric_device)
+        ap.attach(engine, "ap")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "ap" in engine.state.metrics
+
+        res = engine.state.metrics["ap"]
+        if isinstance(res, torch.Tensor):
+            res = res.cpu().numpy()
+
+        true_res = average_precision_score(y_true.cpu().numpy(), y_preds.cpu().numpy())
+
+        assert pytest.approx(res) == true_res
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
+def _test_distrib_integration_multilabel(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(), 10)).to(device)
+        y_preds = torch.randint(0, n_classes, size=(offset * idist.get_world_size(), 10)).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset, :],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset, :],
+            )
+
+        engine = Engine(update)
+
+        ap = AveragePrecision(device=metric_device)
+        ap.attach(engine, "ap")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "ap" in engine.state.metrics
+
+        res = engine.state.metrics["ap"]
+        if isinstance(res, torch.Tensor):
+            res = res.cpu().numpy()
+
+        true_res = average_precision_score(y_true.cpu().numpy(), y_preds.cpu().numpy())
+
+        assert pytest.approx(res) == true_res
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
 def test_distrib_gpu(distributed_context_single_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.distributed
@@ -196,7 +653,10 @@ def test_distrib_gpu(distributed_context_single_node_nccl):
 def test_distrib_cpu(distributed_context_single_node_gloo):
 
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.distributed
@@ -207,36 +667,54 @@ def test_distrib_hvd(gloo_hvd_executor):
     device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
     nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
 
-    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distirb_binary_input_N, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distirb_multilabel_input_N, (device), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration_binary, (device), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration_multilabel, (device), np=nproc, do_init=True)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.tpu
 @pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 def _test_distrib_xla_nprocs(index):
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/test_cohen_kappa.py
+++ b/tests/ignite/contrib/metrics/test_cohen_kappa.py
@@ -10,6 +10,8 @@ from ignite.contrib.metrics import CohenKappa
 from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
 
+torch.manual_seed(12)
+
 
 def test_no_update():
     ck = CohenKappa()
@@ -32,36 +34,21 @@ def test_input_types():
     with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
         ck.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
 
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        ck.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
+
 
 def test_check_shape():
     ck = CohenKappa()
 
     with pytest.raises(ValueError, match=r"Predictions should be of shape"):
-        ck._check_shape((torch.randint(0, 2, size=(10, 1, 5, 12)).long(), torch.randint(0, 2, size=(10, 5, 6)).long()))
+        ck._check_shape((torch.tensor(0), torch.tensor(0)))
 
     with pytest.raises(ValueError, match=r"Predictions should be of shape"):
-        ck._check_shape((torch.randint(0, 2, size=(10, 1, 6)).long(), torch.randint(0, 2, size=(10, 5, 6)).long()))
+        ck._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
 
     with pytest.raises(ValueError, match=r"Targets should be of shape"):
-        ck._check_shape((torch.randint(0, 2, size=(10, 1)).long(), torch.randint(0, 2, size=(10, 5, 2)).long()))
-
-
-@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
-def test_cohen_kappa_all_weights(weights):
-    size = 100
-    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
-    np_y = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
-    np_ck = cohen_kappa_score(np_y, np_y_pred)
-
-    ck_metric = CohenKappa(weights=weights)
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
-
-    ck_metric.reset()
-    ck_metric.update((y_pred, y))
-    ck = ck_metric.compute()
-
-    assert ck == pytest.approx(np_ck)
+        ck._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
 
 
 def test_cohen_kappa_wrong_weights_type():
@@ -73,60 +60,287 @@ def test_cohen_kappa_wrong_weights_type():
 
 
 @pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
-def test_cohen_kappa_all_weights_with_output_transform(weights):
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.randint(0, 2, size=(size, 1), dtype=np.long)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
+def test_binary_input_N(weights):
+    def _test():
+        ck = CohenKappa(weights)
 
-    ck_value_sk = cohen_kappa_score(np_y, np_y_pred)
+        y_pred = torch.randint(0, 2, size=(10,)).long()
+        y = torch.randint(0, 2, size=(10,)).long()
+        ck.update((y_pred, y))
 
-    batch_size = 10
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
 
-    engine = Engine(update_fn)
+        # Batched Updates
+        ck.reset()
+        y_pred = torch.randint(0, 2, size=(100,)).long()
+        y = torch.randint(0, 2, size=(100,)).long()
 
-    ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]), weights=weights)
-    ck_metric.attach(engine, "cohen_kappa")
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
 
-    data = list(range(size // batch_size))
-    ck_value = engine.run(data, max_epochs=1).metrics["cohen_kappa"]
+        for i in range(n_iters):
+            idx = i * batch_size
+            ck.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
 
-    assert ck_value == pytest.approx(ck_value_sk)
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+
+        ck.reset()
+        y_pred = torch.randint(0, 2, size=(10, 1)).long()
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        ck.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+
+        ck.reset()
+        y_pred = torch.randint(0, 2, size=(10, 1)).long()
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        ck.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+
+        # Batched Updates
+        ck.reset()
+        y_pred = torch.randint(0, 2, size=(100, 1)).long()
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ck.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+
+    for _ in range(10):
+        _test()
 
 
-def _test_distrib_compute(device):
+def test_multilabel_inputs():
+    ck = CohenKappa()
+
+    with pytest.raises(ValueError, match=r"multilabel-indicator is not supported"):
+        ck.reset()
+        ck.update((torch.randint(0, 2, size=(10, 4)).long(), torch.randint(0, 2, size=(10, 4)).long()))
+        ck.compute()
+
+    with pytest.raises(ValueError, match=r"multilabel-indicator is not supported"):
+        ck.reset()
+        ck.update((torch.randint(0, 2, size=(10, 6)).long(), torch.randint(0, 2, size=(10, 6)).long()))
+        ck.compute()
+
+    with pytest.raises(ValueError, match=r"multilabel-indicator is not supported"):
+        ck.reset()
+        ck.update((torch.randint(0, 2, size=(10, 8)).long(), torch.randint(0, 2, size=(10, 8)).long()))
+        ck.compute()
+
+
+def test_multiclass_inputs():
+    ck = CohenKappa()
+
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        ck.update((torch.randint(0, 3, size=(10, 4)).long(), torch.randint(0, 3, size=(10, 4)).long()))
+
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        ck.update((torch.randint(0, 5, size=(10, 6)).long(), torch.randint(0, 5, size=(10, 6)).long()))
+
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        ck.update((torch.randint(0, 7, size=(10, 8)).long(), torch.randint(0, 7, size=(10, 8)).long()))
+
+
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_integration_binary_input_with_output_transform(weights):
+    def _test():
+
+        y_pred = torch.randint(0, 2, size=(100,)).long()
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]), weights=weights)
+        ck_metric.attach(engine, "ck")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_ck = cohen_kappa_score(np_y, np_y_pred, weights=weights)
+
+        data = list(range(100 // batch_size))
+        ck = engine.run(data, max_epochs=1).metrics["ck"]
+
+        assert isinstance(ck, float)
+        assert np_ck == pytest.approx(ck)
+
+        y_pred = torch.randint(0, 2, size=(100, 1)).long()
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        ck_metric = CohenKappa(output_transform=lambda x: (x[1], x[2]), weights=weights)
+        ck_metric.attach(engine, "ck")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_ck = cohen_kappa_score(np_y, np_y_pred, weights=weights)
+
+        data = list(range(100 // batch_size))
+        ck = engine.run(data, max_epochs=1).metrics["ck"]
+
+        assert isinstance(ck, float)
+        assert np_ck == pytest.approx(ck)
+
+    for _ in range(10):
+        _test()
+
+
+def _test_distirb_binary_input_N(device, weights):
     rank = idist.get_rank()
+    torch.manual_seed(12)
 
     def _test(metric_device):
         metric_device = torch.device(metric_device)
-        ck_metric = CohenKappa(device=metric_device)
+        ck = CohenKappa(device=metric_device, weights=weights)
 
         torch.manual_seed(10 + rank)
 
-        y_pred = torch.randint(0, 2, size=(100, 1), device=device)
-        y = torch.randint(0, 2, size=(100, 1), device=device)
-
-        ck_metric.update((y_pred, y))
+        y_pred = torch.randint(0, 2, size=(10,), device=device).long()
+        y = torch.randint(0, 2, size=(10,), device=device).long()
+        ck.update((y_pred, y))
 
         # gather y_pred, y
         y_pred = idist.all_gather(y_pred)
         y = idist.all_gather(y)
 
-        np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
 
-        np_ck = cohen_kappa_score(np_y, np_y_pred)
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
 
-        res = ck_metric.compute()
-        assert res == pytest.approx(np_ck)
+        ck.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100,), device=device).long()
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+        ck.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+
+        ck.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 1), device=device).long()
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+        ck.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+
+        # Batched Updates
+        ck.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100,), device=device).long()
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ck.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+
+        # Batched Updates
+        ck.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 1), device=device).long()
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            ck.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = ck.compute()
+        assert isinstance(res, float)
+        assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
 
     for _ in range(3):
         _test("cpu")
@@ -134,60 +348,131 @@ def _test_distrib_compute(device):
             _test(idist.device())
 
 
+def _test_distrib_integration_binary(device, weights):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            )
+
+        engine = Engine(update)
+
+        ck = CohenKappa(device=metric_device, weights=weights)
+        ck.attach(engine, "ck")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "ck" in engine.state.metrics
+
+        res = engine.state.metrics["ck"]
+        if isinstance(res, torch.Tensor):
+            res = res.cpu().numpy()
+
+        true_res = cohen_kappa_score(y_true.cpu().numpy(), y_preds.cpu().numpy(), weights=weights)
+
+        assert pytest.approx(res) == true_res
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-def test_distrib_gpu(distributed_context_single_node_nccl):
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_distrib_gpu(distributed_context_single_node_nccl, weights):
+
     device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device, weights)
+    _test_distrib_integration_binary(device, weights)
 
 
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-def test_distrib_cpu(distributed_context_single_node_gloo):
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_distrib_cpu(distributed_context_single_node_gloo, weights):
 
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device, weights)
+    _test_distrib_integration_binary(device, weights)
 
 
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
-def test_distrib_hvd(gloo_hvd_executor):
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_distrib_hvd(gloo_hvd_executor, weights):
 
     device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
     nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
 
-    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(
+        _test_distirb_binary_input_N, (device, weights,), np=nproc, do_init=True,
+    )
+    gloo_hvd_executor(
+        _test_distrib_integration_binary, (device, weights,), np=nproc, do_init=True,
+    )
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
-def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo, weights):
+
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device, weights)
+    _test_distrib_integration_binary(device, weights)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
-def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl, weights):
+
     device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device, weights)
+    _test_distrib_integration_binary(device, weights)
 
 
 @pytest.mark.tpu
 @pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
-def test_distrib_single_device_xla():
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_distrib_single_device_xla(weights):
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device, weights)
+    _test_distrib_integration_binary(device, weights)
 
 
-def _test_distrib_xla_nprocs(index):
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def _test_distrib_xla_nprocs(index, weights):
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device, weights)
+    _test_distrib_integration_binary(device, weights)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/test_precision_recall_curve.py
+++ b/tests/ignite/contrib/metrics/test_precision_recall_curve.py
@@ -1,14 +1,54 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 from sklearn.metrics import precision_recall_curve
 
+import ignite.distributed as idist
 from ignite.contrib.metrics.precision_recall_curve import PrecisionRecallCurve
 from ignite.engine import Engine
+from ignite.exceptions import NotComputableError
 from ignite.metrics.epoch_metric import EpochMetricWarning
 
 
+def test_no_update():
+    prc = PrecisionRecallCurve()
+
+    with pytest.raises(
+        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+    ):
+        prc.compute()
+
+
+def test_input_types():
+    prc = PrecisionRecallCurve()
+    prc.reset()
+    output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 3), dtype=torch.long))
+    prc.update(output1)
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        prc.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
+        prc.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
+
+
+def test_check_shape():
+    prc = PrecisionRecallCurve()
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        prc._check_shape((torch.tensor(0), torch.tensor(0)))
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        prc._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
+
+    with pytest.raises(ValueError, match=r"Targets should be of shape"):
+        prc._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
+
+
 def test_precision_recall_curve():
+
     size = 100
     np_y_pred = np.random.rand(size, 1)
     np_y = np.zeros((size,), dtype=np.long)
@@ -29,6 +69,7 @@ def test_precision_recall_curve():
 
 
 def test_integration_precision_recall_curve_with_output_transform():
+
     np.random.seed(1)
     size = 100
     np_y_pred = np.random.rand(size, 1)
@@ -61,6 +102,7 @@ def test_integration_precision_recall_curve_with_output_transform():
 
 
 def test_integration_precision_recall_curve_with_activated_output_transform():
+
     np.random.seed(1)
     size = 100
     np_y_pred = np.random.rand(size, 1)
@@ -93,17 +135,101 @@ def test_integration_precision_recall_curve_with_activated_output_transform():
     np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
 
 
-def test_check_compute_fn():
-    y_pred = torch.zeros((8, 13))
-    y_pred[:, 1] = 1
-    y_true = torch.zeros_like(y_pred)
-    output = (y_pred, y_true)
+def _test_distrib_compute(device):
+    rank = idist.get_rank()
 
-    em = PrecisionRecallCurve(check_compute_fn=True)
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        pcr_metric = PrecisionRecallCurve(device=metric_device)
 
-    em.reset()
-    with pytest.warns(EpochMetricWarning, match=r"Probably, there can be a problem with `compute_fn`"):
-        em.update(output)
+        torch.manual_seed(10 + rank)
 
-    em = PrecisionRecallCurve(check_compute_fn=False)
-    em.update(output)
+        y_pred = torch.rand(size=(100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device)
+
+        pcr_metric.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y_pred = y_pred.cpu().numpy()
+        np_y = y.cpu().numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+
+        precision, recall, thresholds = pcr_metric.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_gpu(distributed_context_single_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_cpu(distributed_context_single_node_gloo):
+
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)

--- a/tests/ignite/contrib/metrics/test_precision_recall_curve.py
+++ b/tests/ignite/contrib/metrics/test_precision_recall_curve.py
@@ -11,6 +11,8 @@ from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
 from ignite.metrics.epoch_metric import EpochMetricWarning
 
+torch.manual_seed(12)
+
 
 def test_no_update():
     prc = PrecisionRecallCurve()
@@ -33,6 +35,9 @@ def test_input_types():
     with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
         prc.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
 
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        prc.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
+
 
 def test_check_shape():
     prc = PrecisionRecallCurve()
@@ -47,118 +52,325 @@ def test_check_shape():
         prc._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
 
 
-def test_precision_recall_curve():
+def test_binary_input_N():
+    def _test():
+        prc = PrecisionRecallCurve()
 
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        y_pred = torch.rand(10,)
+        y = torch.randint(0, 2, size=(10,)).long()
+        prc.update((y_pred, y))
 
-    precision_recall_curve_metric = PrecisionRecallCurve()
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    precision_recall_curve_metric.update((y_pred, y))
-    precision, recall, thresholds = precision_recall_curve_metric.compute()
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
 
-    assert np.array_equal(precision, sk_precision)
-    assert np.array_equal(recall, sk_recall)
-    # assert thresholds almost equal, due to numpy->torch->numpy conversion
-    np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        prc.reset()
+        y_pred = torch.rand(100,)
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            prc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        prc.reset()
+        y_pred = torch.rand(10, 1)
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        prc.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        prc.reset()
+        y_pred = torch.rand(10, 1)
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        prc.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        prc.reset()
+        y_pred = torch.rand(100, 1)
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            prc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    for _ in range(10):
+        _test()
 
 
-def test_integration_precision_recall_curve_with_output_transform():
+def test_multilabel_inputs():
+    prc = PrecisionRecallCurve()
 
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
+    with pytest.raises(ValueError, match=r"multilabel-indicator format is not supported"):
+        prc.reset()
+        prc.update((torch.randint(0, 2, size=(10, 4)).long(), torch.randint(0, 2, size=(10, 4)).long()))
+        prc.compute()
 
-    sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+    with pytest.raises(ValueError, match=r"multilabel-indicator format is not supported"):
+        prc.reset()
+        prc.update((torch.randint(0, 2, size=(10, 6)).long(), torch.randint(0, 2, size=(10, 6)).long()))
+        prc.compute()
 
-    batch_size = 10
-
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
-
-    engine = Engine(update_fn)
-
-    precision_recall_curve_metric = PrecisionRecallCurve(output_transform=lambda x: (x[1], x[2]))
-    precision_recall_curve_metric.attach(engine, "precision_recall_curve")
-
-    data = list(range(size // batch_size))
-    precision, recall, thresholds = engine.run(data, max_epochs=1).metrics["precision_recall_curve"]
-
-    assert np.array_equal(precision, sk_precision)
-    assert np.array_equal(recall, sk_recall)
-    # assert thresholds almost equal, due to numpy->torch->numpy conversion
-    np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+    with pytest.raises(ValueError, match=r"multilabel-indicator format is not supported"):
+        prc.reset()
+        prc.update((torch.randint(0, 2, size=(10, 8)).long(), torch.randint(0, 2, size=(10, 8)).long()))
+        prc.compute()
 
 
-def test_integration_precision_recall_curve_with_activated_output_transform():
+def test_multiclass_inputs():
+    prc = PrecisionRecallCurve()
 
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y_pred_sigmoid = torch.sigmoid(torch.from_numpy(np_y_pred)).numpy()
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        prc.update((torch.randint(0, 3, size=(10, 4)).long(), torch.randint(0, 3, size=(10, 4)).long()))
 
-    sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred_sigmoid)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        prc.update((torch.randint(0, 5, size=(10, 6)).long(), torch.randint(0, 5, size=(10, 6)).long()))
 
-    batch_size = 10
-
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
-
-    engine = Engine(update_fn)
-
-    precision_recall_curve_metric = PrecisionRecallCurve(output_transform=lambda x: (torch.sigmoid(x[1]), x[2]))
-    precision_recall_curve_metric.attach(engine, "precision_recall_curve")
-
-    data = list(range(size // batch_size))
-    precision, recall, thresholds = engine.run(data, max_epochs=1).metrics["precision_recall_curve"]
-
-    assert np.array_equal(precision, sk_precision)
-    assert np.array_equal(recall, sk_recall)
-    # assert thresholds almost equal, due to numpy->torch->numpy conversion
-    np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        prc.update((torch.randint(0, 7, size=(10, 8)).long(), torch.randint(0, 7, size=(10, 8)).long()))
 
 
-def _test_distrib_compute(device):
+def test_integration_binary_input_with_output_transform():
+    def _test():
+
+        y_pred = torch.rand(100)
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        prc_metric = PrecisionRecallCurve(output_transform=lambda x: (x[1], x[2]))
+        prc_metric.attach(engine, "prc")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        data = list(range(100 // batch_size))
+        precision, recall, thresholds = engine.run(data, max_epochs=1).metrics["prc"]
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        y_pred = torch.rand(100, 1)
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        prc_metric = PrecisionRecallCurve(output_transform=lambda x: (x[1], x[2]))
+        prc_metric.attach(engine, "prc")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        data = list(range(100 // batch_size))
+        precision, recall, thresholds = engine.run(data, max_epochs=1).metrics["prc"]
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    for _ in range(10):
+        _test()
+
+
+def _test_distirb_binary_input_N(device):
     rank = idist.get_rank()
+    # torch.manual_seed(12)
 
     def _test(metric_device):
         metric_device = torch.device(metric_device)
-        pcr_metric = PrecisionRecallCurve(device=metric_device)
+        prc = PrecisionRecallCurve(device=metric_device)
 
         torch.manual_seed(10 + rank)
 
-        y_pred = torch.rand(size=(100, 1), device=device)
-        y = torch.randint(0, 2, size=(100, 1), device=device)
-
-        pcr_metric.update((y_pred, y))
+        y_pred = torch.rand((10,), device=device)
+        y = torch.randint(0, 2, size=(10,), device=device).long()
+        prc.update((y_pred, y))
 
         # gather y_pred, y
         y_pred = idist.all_gather(y_pred)
         y = idist.all_gather(y)
 
-        np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
 
         sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
 
-        precision, recall, thresholds = pcr_metric.compute()
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        prc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100,), device=device)
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+        prc.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        prc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+        prc.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        prc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100,), device=device)
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            prc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        prc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            prc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(np_y, np_y_pred)
+        precision, recall, thresholds = prc.compute()
 
         assert np.array_equal(precision, sk_precision)
         assert np.array_equal(recall, sk_recall)
@@ -171,12 +383,71 @@ def _test_distrib_compute(device):
             _test(idist.device())
 
 
+def _test_distrib_integration_binary(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(offset * idist.get_world_size(),).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            )
+
+        engine = Engine(update)
+
+        prc = PrecisionRecallCurve(device=metric_device)
+        prc.attach(engine, "prc")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "prc" in engine.state.metrics
+
+        precision, recall, thresholds = engine.state.metrics["prc"]
+        if isinstance(precision, torch.Tensor):
+            precision = precision.cpu().numpy()
+
+        if isinstance(recall, torch.Tensor):
+            recall = recall.cpu().numpy()
+
+        if isinstance(thresholds, torch.Tensor):
+            thresholds = thresholds.cpu().numpy()
+
+        sk_precision, sk_recall, sk_thresholds = precision_recall_curve(y_true.cpu().numpy(), y_preds.cpu().numpy())
+
+        assert np.array_equal(precision, sk_precision)
+        assert np.array_equal(recall, sk_recall)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
 def test_distrib_gpu(distributed_context_single_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.distributed
@@ -184,7 +455,8 @@ def test_distrib_gpu(distributed_context_single_node_nccl):
 def test_distrib_cpu(distributed_context_single_node_gloo):
 
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.distributed
@@ -195,36 +467,45 @@ def test_distrib_hvd(gloo_hvd_executor):
     device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
     nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
 
-    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distirb_binary_input_N, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration_binary, (device,), np=nproc, do_init=True)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.tpu
 @pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 def _test_distrib_xla_nprocs(index):
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/test_roc_auc.py
+++ b/tests/ignite/contrib/metrics/test_roc_auc.py
@@ -1,11 +1,50 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 from sklearn.metrics import roc_auc_score
 
+import ignite.distributed as idist
 from ignite.contrib.metrics import ROC_AUC
 from ignite.engine import Engine
+from ignite.exceptions import NotComputableError
 from ignite.metrics.epoch_metric import EpochMetricWarning
+
+
+def test_no_update():
+    roc_auc = ROC_AUC()
+
+    with pytest.raises(
+        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+    ):
+        roc_auc.compute()
+
+
+def test_input_types():
+    roc_auc = ROC_AUC()
+    roc_auc.reset()
+    output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 3), dtype=torch.long))
+    roc_auc.update(output1)
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        roc_auc.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
+        roc_auc.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
+
+
+def test_check_shape():
+    roc_auc = ROC_AUC()
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        roc_auc._check_shape((torch.tensor(0), torch.tensor(0)))
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        roc_auc._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
+
+    with pytest.raises(ValueError, match=r"Targets should be of shape"):
+        roc_auc._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
 
 
 def test_roc_auc_score():
@@ -24,7 +63,7 @@ def test_roc_auc_score():
     roc_auc_metric.update((y_pred, y))
     roc_auc = roc_auc_metric.compute()
 
-    assert roc_auc == np_roc_auc
+    assert roc_auc == pytest.approx(np_roc_auc)
 
 
 def test_roc_auc_score_2():
@@ -50,7 +89,7 @@ def test_roc_auc_score_2():
 
     roc_auc = roc_auc_metric.compute()
 
-    assert roc_auc == np_roc_auc
+    assert roc_auc == pytest.approx(np_roc_auc)
 
 
 def test_integration_roc_auc_score_with_output_transform():
@@ -80,7 +119,7 @@ def test_integration_roc_auc_score_with_output_transform():
     data = list(range(size // batch_size))
     roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
 
-    assert roc_auc == np_roc_auc
+    assert roc_auc == pytest.approx(np_roc_auc)
 
 
 def test_integration_roc_auc_score_with_activated_output_transform():
@@ -111,7 +150,7 @@ def test_integration_roc_auc_score_with_activated_output_transform():
     data = list(range(size // batch_size))
     roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
 
-    assert roc_auc == np_roc_auc
+    assert roc_auc == pytest.approx(np_roc_auc)
 
 
 def test_check_compute_fn():
@@ -128,3 +167,99 @@ def test_check_compute_fn():
 
     em = ROC_AUC(check_compute_fn=False)
     em.update(output)
+
+
+def _test_distrib_compute(device):
+    rank = idist.get_rank()
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        roc_auc_metric = ROC_AUC(device=metric_device)
+
+        torch.manual_seed(10 + rank)
+
+        y_pred = torch.rand(size=(100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device)
+
+        roc_auc_metric.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y_pred = y_pred.cpu().numpy()
+        np_y = y.cpu().numpy()
+
+        np_roc_auc = roc_auc_score(np_y, np_y_pred)
+
+        res = roc_auc_metric.compute()
+        assert res == pytest.approx(np_roc_auc)
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_gpu(distributed_context_single_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_cpu(distributed_context_single_node_gloo):
+
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)

--- a/tests/ignite/contrib/metrics/test_roc_auc.py
+++ b/tests/ignite/contrib/metrics/test_roc_auc.py
@@ -11,6 +11,8 @@ from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
 from ignite.metrics.epoch_metric import EpochMetricWarning
 
+torch.manual_seed(12)
+
 
 def test_no_update():
     roc_auc = ROC_AUC()
@@ -33,6 +35,9 @@ def test_input_types():
     with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
         roc_auc.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
 
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        roc_auc.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
+
 
 def test_check_shape():
     roc_auc = ROC_AUC()
@@ -47,110 +52,147 @@ def test_check_shape():
         roc_auc._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
 
 
-def test_roc_auc_score():
+def test_binary_input_N():
+    def _test():
+        roc_auc = ROC_AUC()
 
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np_roc_auc = roc_auc_score(np_y, np_y_pred)
+        y_pred = torch.randint(0, 2, size=(10,)).long()
+        y = torch.randint(0, 2, size=(10,)).long()
+        roc_auc.update((y_pred, y))
 
-    roc_auc_metric = ROC_AUC()
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    roc_auc_metric.reset()
-    roc_auc_metric.update((y_pred, y))
-    roc_auc = roc_auc_metric.compute()
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
 
-    assert roc_auc == pytest.approx(np_roc_auc)
+        # Batched Updates
+        roc_auc.reset()
+        y_pred = torch.randint(0, 2, size=(100,)).long()
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_auc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        roc_auc.reset()
+        y_pred = torch.randint(0, 2, size=(10, 1)).long()
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        roc_auc.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        roc_auc.reset()
+        y_pred = torch.randint(0, 2, size=(10, 1)).long()
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        roc_auc.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        roc_auc.reset()
+        y_pred = torch.randint(0, 2, size=(100, 1)).long()
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_auc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+    for _ in range(10):
+        _test()
 
 
-def test_roc_auc_score_2():
+def test_multilabel_input_N():
+    def _test():
+        roc_auc = ROC_AUC()
 
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
-    np_roc_auc = roc_auc_score(np_y, np_y_pred)
+        y_pred = torch.randint(0, 2, size=(10, 4)).long()
+        y = torch.randint(0, 2, size=(10, 4)).long()
+        roc_auc.update((y_pred, y))
 
-    roc_auc_metric = ROC_AUC()
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
+        np_y_pred = y_pred.numpy()
+        np_y = y.numpy()
 
-    roc_auc_metric.reset()
-    n_iters = 10
-    batch_size = size // n_iters
-    for i in range(n_iters):
-        idx = i * batch_size
-        roc_auc_metric.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
 
-    roc_auc = roc_auc_metric.compute()
+        roc_auc.reset()
+        y_pred = torch.randint(0, 2, size=(50, 7)).long()
+        y = torch.randint(0, 2, size=(50, 7)).long()
+        roc_auc.update((y_pred, y))
+        np_y_pred = y_pred.numpy()
+        np_y = y.numpy()
 
-    assert roc_auc == pytest.approx(np_roc_auc)
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
 
+        # Batched Updates
+        roc_auc.reset()
+        y_pred = torch.randint(0, 2, size=(100, 4))
+        y = torch.randint(0, 2, size=(100, 4)).long()
 
-def test_integration_roc_auc_score_with_output_transform():
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
 
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_auc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
 
-    np_roc_auc = roc_auc_score(np_y, np_y_pred)
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
 
-    batch_size = 10
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
 
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
-
-    engine = Engine(update_fn)
-
-    roc_auc_metric = ROC_AUC(output_transform=lambda x: (x[1], x[2]))
-    roc_auc_metric.attach(engine, "roc_auc")
-
-    data = list(range(size // batch_size))
-    roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
-
-    assert roc_auc == pytest.approx(np_roc_auc)
+    for _ in range(10):
+        _test()
 
 
-def test_integration_roc_auc_score_with_activated_output_transform():
+def test_multiclass_inputs():
+    roc_auc = ROC_AUC()
 
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y_pred_sigmoid = torch.sigmoid(torch.from_numpy(np_y_pred)).numpy()
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        roc_auc.update((torch.randint(0, 3, size=(10, 4)).long(), torch.randint(0, 3, size=(10, 4)).long()))
 
-    np_roc_auc = roc_auc_score(np_y, np_y_pred_sigmoid)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        roc_auc.update((torch.randint(0, 5, size=(10, 6)).long(), torch.randint(0, 5, size=(10, 6)).long()))
 
-    batch_size = 10
-
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
-
-    engine = Engine(update_fn)
-
-    roc_auc_metric = ROC_AUC(output_transform=lambda x: (torch.sigmoid(x[1]), x[2]))
-    roc_auc_metric.attach(engine, "roc_auc")
-
-    data = list(range(size // batch_size))
-    roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
-
-    assert roc_auc == pytest.approx(np_roc_auc)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        roc_auc.update((torch.randint(0, 7, size=(10, 8)).long(), torch.randint(0, 7, size=(10, 8)).long()))
 
 
 def test_check_compute_fn():
@@ -169,31 +211,227 @@ def test_check_compute_fn():
     em.update(output)
 
 
-def _test_distrib_compute(device):
+def test_integration_binary_input_with_output_transform():
+    def _test():
+
+        y_pred = torch.randint(0, 2, size=(100,)).long()
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        roc_auc_metric = ROC_AUC(output_transform=lambda x: (x[1], x[2]))
+        roc_auc_metric.attach(engine, "roc_auc")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_roc_auc = roc_auc_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
+
+        assert isinstance(roc_auc, float)
+        assert np_roc_auc == pytest.approx(roc_auc)
+
+        y_pred = torch.randint(0, 2, size=(100, 1)).long()
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        roc_auc_metric = ROC_AUC(output_transform=lambda x: (x[1], x[2]))
+        roc_auc_metric.attach(engine, "roc_auc")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_roc_auc = roc_auc_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
+
+        assert isinstance(roc_auc, float)
+        assert np_roc_auc == pytest.approx(roc_auc)
+
+    for _ in range(10):
+        _test()
+
+
+def test_integration_multilabel_input_with_output_transform():
+    def _test():
+
+        y_pred = torch.randint(0, 2, size=(100, 3)).long()
+        y = torch.randint(0, 2, size=(100, 3)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        roc_auc_metric = ROC_AUC(output_transform=lambda x: (x[1], x[2]))
+        roc_auc_metric.attach(engine, "roc_auc")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_roc_auc = roc_auc_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
+
+        assert isinstance(roc_auc, float)
+        assert np_roc_auc == pytest.approx(roc_auc)
+
+        y_pred = torch.randint(0, 2, size=(100, 7)).long()
+        y = torch.randint(0, 2, size=(100, 7)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        roc_auc_metric = ROC_AUC(output_transform=lambda x: (x[1], x[2]))
+        roc_auc_metric.attach(engine, "roc_auc")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        np_roc_auc = roc_auc_score(np_y, np_y_pred)
+
+        data = list(range(100 // batch_size))
+        roc_auc = engine.run(data, max_epochs=1).metrics["roc_auc"]
+
+        assert isinstance(roc_auc, float)
+        assert np_roc_auc == pytest.approx(roc_auc)
+
+    for _ in range(10):
+        _test()
+
+
+def _test_distirb_binary_input_N(device):
+
     rank = idist.get_rank()
+    torch.manual_seed(12)
 
     def _test(metric_device):
         metric_device = torch.device(metric_device)
-        roc_auc_metric = ROC_AUC(device=metric_device)
+        roc_auc = ROC_AUC(device=metric_device)
 
         torch.manual_seed(10 + rank)
 
-        y_pred = torch.rand(size=(100, 1), device=device)
-        y = torch.randint(0, 2, size=(100, 1), device=device)
-
-        roc_auc_metric.update((y_pred, y))
+        y_pred = torch.randint(0, 2, size=(10,), device=device).long()
+        y = torch.randint(0, 2, size=(10,), device=device).long()
+        roc_auc.update((y_pred, y))
 
         # gather y_pred, y
         y_pred = idist.all_gather(y_pred)
         y = idist.all_gather(y)
 
-        np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
 
-        np_roc_auc = roc_auc_score(np_y, np_y_pred)
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
 
-        res = roc_auc_metric.compute()
-        assert res == pytest.approx(np_roc_auc)
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100,), device=device).long()
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+        roc_auc.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 1), device=device).long()
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+        roc_auc.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100,), device=device).long()
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_auc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 1), device=device).long()
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_auc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
 
     for _ in range(3):
         _test("cpu")
@@ -201,12 +439,226 @@ def _test_distrib_compute(device):
             _test(idist.device())
 
 
+def _test_distirb_multilabel_input_N(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        roc_auc = ROC_AUC(device=metric_device)
+
+        torch.manual_seed(10 + rank)
+
+        y_pred = torch.randint(0, 2, size=(10, 4), device=device).long()
+        y = torch.randint(0, 2, size=(10, 4), device=device).long()
+        roc_auc.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 7), device=device).long()
+        y = torch.randint(0, 2, size=(100, 7), device=device).long()
+        roc_auc.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 3), device=device).long()
+        y = torch.randint(0, 2, size=(100, 3), device=device).long()
+        roc_auc.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 5), device=device).long()
+        y = torch.randint(0, 2, size=(100, 5), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_auc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+        # Batched Updates
+        roc_auc.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.randint(0, 2, size=(100, 8), device=device).long()
+        y = torch.randint(0, 2, size=(100, 8), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_auc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        res = roc_auc.compute()
+        assert isinstance(res, float)
+        assert roc_auc_score(np_y, np_y_pred) == pytest.approx(res)
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+def _test_distrib_integration_binary(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(offset * idist.get_world_size(),).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            )
+
+        engine = Engine(update)
+
+        roc_auc = ROC_AUC(device=metric_device)
+        roc_auc.attach(engine, "roc_auc")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "roc_auc" in engine.state.metrics
+
+        res = engine.state.metrics["roc_auc"]
+        if isinstance(res, torch.Tensor):
+            res = res.cpu().numpy()
+
+        true_res = roc_auc_score(y_true.cpu().numpy(), y_preds.cpu().numpy())
+
+        assert pytest.approx(res) == true_res
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
+def _test_distrib_integration_multilabel(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(), 10)).to(device)
+        y_preds = torch.rand(offset * idist.get_world_size(), 10).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset, :],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset, :],
+            )
+
+        engine = Engine(update)
+
+        roc_auc = ROC_AUC(device=metric_device)
+        roc_auc.attach(engine, "roc_auc")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "roc_auc" in engine.state.metrics
+
+        res = engine.state.metrics["roc_auc"]
+        if isinstance(res, torch.Tensor):
+            res = res.cpu().numpy()
+
+        true_res = roc_auc_score(y_true.cpu().numpy(), y_preds.cpu().numpy())
+
+        assert pytest.approx(res) == true_res
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
 def test_distrib_gpu(distributed_context_single_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.distributed
@@ -214,7 +666,10 @@ def test_distrib_gpu(distributed_context_single_node_nccl):
 def test_distrib_cpu(distributed_context_single_node_gloo):
 
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.distributed
@@ -225,36 +680,55 @@ def test_distrib_hvd(gloo_hvd_executor):
     device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
     nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
 
-    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distirb_binary_input_N, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distirb_multilabel_input_N, (device), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration_binary, (device), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration_multilabel, (device), np=nproc, do_init=True)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.tpu
 @pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 def _test_distrib_xla_nprocs(index):
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distirb_multilabel_input_N(device)
+    _test_distrib_integration_binary(device)
+    _test_distrib_integration_multilabel(device)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/test_roc_curve.py
+++ b/tests/ignite/contrib/metrics/test_roc_curve.py
@@ -11,127 +11,178 @@ from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
 from ignite.metrics.epoch_metric import EpochMetricWarning
 
+torch.manual_seed(12)
+
 
 def test_no_update():
-    roc_curve = RocCurve()
+    roc_curve_metric = RocCurve()
 
     with pytest.raises(
         NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
     ):
-        roc_curve.compute()
+        roc_curve_metric.compute()
 
 
 def test_input_types():
-    roc_curve = RocCurve()
-    roc_curve.reset()
+    roc_curve_metric = RocCurve()
+    roc_curve_metric.reset()
     output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 3), dtype=torch.long))
-    roc_curve.update(output1)
+    roc_curve_metric.update(output1)
 
     with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
-        roc_curve.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
+        roc_curve_metric.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
 
     with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
-        roc_curve.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
+        roc_curve_metric.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        roc_curve_metric.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
 
 
 def test_check_shape():
-    roc_curve = RocCurve()
+    roc_curve_metric = RocCurve()
 
     with pytest.raises(ValueError, match=r"Predictions should be of shape"):
-        roc_curve._check_shape((torch.tensor(0), torch.tensor(0)))
+        roc_curve_metric._check_shape((torch.tensor(0), torch.tensor(0)))
 
     with pytest.raises(ValueError, match=r"Predictions should be of shape"):
-        roc_curve._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
+        roc_curve_metric._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
 
     with pytest.raises(ValueError, match=r"Targets should be of shape"):
-        roc_curve._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
+        roc_curve_metric._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
 
 
-def test_roc_curve():
+def test_binary_input_N():
+    def _test():
+        roc_curve_metric = RocCurve()
 
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        y_pred = torch.rand(10,)
+        y = torch.randint(0, 2, size=(10,)).long()
+        roc_curve_metric.update((y_pred, y))
 
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        roc_curve_metric.reset()
+        y_pred = torch.rand(100,)
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_curve_metric.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        roc_curve_metric.reset()
+        y_pred = torch.rand(10, 1)
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        roc_curve_metric.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        roc_curve_metric.reset()
+        y_pred = torch.rand(10, 1)
+        y = torch.randint(0, 2, size=(10, 1)).long()
+        roc_curve_metric.update((y_pred, y))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        roc_curve_metric.reset()
+        y_pred = torch.rand(100, 1)
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_curve_metric.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    for _ in range(10):
+        _test()
+
+
+def test_multilabel_inputs():
     roc_curve_metric = RocCurve()
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
 
-    roc_curve_metric.update((y_pred, y))
-    fpr, tpr, thresholds = roc_curve_metric.compute()
+    with pytest.raises(ValueError, match=r"multilabel-indicator format is not supported"):
+        roc_curve_metric.reset()
+        roc_curve_metric.update((torch.randint(0, 2, size=(10, 4)).long(), torch.randint(0, 2, size=(10, 4)).long()))
+        roc_curve_metric.compute()
 
-    assert np.array_equal(fpr, sk_fpr)
-    assert np.array_equal(tpr, sk_tpr)
-    # assert thresholds almost equal, due to numpy->torch->numpy conversion
-    np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+    with pytest.raises(ValueError, match=r"multilabel-indicator format is not supported"):
+        roc_curve_metric.reset()
+        roc_curve_metric.update((torch.randint(0, 2, size=(10, 6)).long(), torch.randint(0, 2, size=(10, 6)).long()))
+        roc_curve_metric.compute()
 
-
-def test_integration_roc_curve_with_output_transform():
-
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
-
-    sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
-
-    batch_size = 10
-
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
-
-    engine = Engine(update_fn)
-
-    roc_curve_metric = RocCurve(output_transform=lambda x: (x[1], x[2]))
-    roc_curve_metric.attach(engine, "roc_curve")
-
-    data = list(range(size // batch_size))
-    fpr, tpr, thresholds = engine.run(data, max_epochs=1).metrics["roc_curve"]
-
-    assert np.array_equal(fpr, sk_fpr)
-    assert np.array_equal(tpr, sk_tpr)
-    # assert thresholds almost equal, due to numpy->torch->numpy conversion
-    np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+    with pytest.raises(ValueError, match=r"multilabel-indicator format is not supported"):
+        roc_curve_metric.reset()
+        roc_curve_metric.update((torch.randint(0, 2, size=(10, 8)).long(), torch.randint(0, 2, size=(10, 8)).long()))
+        roc_curve_metric.compute()
 
 
-def test_integration_roc_curve_with_activated_output_transform():
-    np.random.seed(1)
-    size = 100
-    np_y_pred = np.random.rand(size, 1)
-    np_y_pred_sigmoid = torch.sigmoid(torch.from_numpy(np_y_pred)).numpy()
-    np_y = np.zeros((size,), dtype=np.long)
-    np_y[size // 2 :] = 1
-    np.random.shuffle(np_y)
+def test_multiclass_inputs():
+    roc_curve_metric = RocCurve()
 
-    sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred_sigmoid)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        roc_curve_metric.update((torch.randint(0, 3, size=(10, 4)).long(), torch.randint(0, 3, size=(10, 4)).long()))
 
-    batch_size = 10
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        roc_curve_metric.update((torch.randint(0, 5, size=(10, 6)).long(), torch.randint(0, 5, size=(10, 6)).long()))
 
-    def update_fn(engine, batch):
-        idx = (engine.state.iteration - 1) * batch_size
-        y_true_batch = np_y[idx : idx + batch_size]
-        y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
-
-    engine = Engine(update_fn)
-
-    roc_curve_metric = RocCurve(output_transform=lambda x: (torch.sigmoid(x[1]), x[2]))
-    roc_curve_metric.attach(engine, "roc_curve")
-
-    data = list(range(size // batch_size))
-    fpr, tpr, thresholds = engine.run(data, max_epochs=1).metrics["roc_curve"]
-
-    assert np.array_equal(fpr, sk_fpr)
-    assert np.array_equal(tpr, sk_tpr)
-    # assert thresholds almost equal, due to numpy->torch->numpy conversion
-    np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+    with pytest.raises(ValueError, match=r"Targets should be binary"):
+        roc_curve_metric.update((torch.randint(0, 7, size=(10, 8)).long(), torch.randint(0, 7, size=(10, 8)).long()))
 
 
 def test_check_compute_fn():
@@ -150,7 +201,72 @@ def test_check_compute_fn():
     em.update(output)
 
 
-def _test_distrib_compute(device):
+def test_integration_binary_input_with_output_transform():
+    def _test():
+
+        y_pred = torch.rand(100)
+        y = torch.randint(0, 2, size=(100,)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        roc_curve_metric = RocCurve(output_transform=lambda x: (x[1], x[2]))
+        roc_curve_metric.attach(engine, "roc_curve")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        data = list(range(100 // batch_size))
+
+        fpr, tpr, thresholds = engine.run(data, max_epochs=1).metrics["roc_curve"]
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        y_pred = torch.rand(100, 1)
+        y = torch.randint(0, 2, size=(100, 1)).long()
+
+        batch_size = 10
+
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        roc_curve_metric = RocCurve(output_transform=lambda x: (x[1], x[2]))
+        roc_curve_metric.attach(engine, "roc_curve")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        data = list(range(100 // batch_size))
+
+        fpr, tpr, thresholds = engine.run(data, max_epochs=1).metrics["roc_curve"]
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    for _ in range(10):
+        _test()
+
+
+def _test_distirb_binary_input_N(device):
     rank = idist.get_rank()
 
     def _test(metric_device):
@@ -159,20 +275,116 @@ def _test_distrib_compute(device):
 
         torch.manual_seed(10 + rank)
 
-        y_pred = torch.rand(size=(100, 1), device=device)
-        y = torch.randint(0, 2, size=(100, 1), device=device)
-
+        y_pred = torch.rand((10,), device=device)
+        y = torch.randint(0, 2, size=(10,), device=device).long()
         roc_curve_metric.update((y_pred, y))
 
         # gather y_pred, y
         y_pred = idist.all_gather(y_pred)
         y = idist.all_gather(y)
 
-        np_y_pred = y_pred.cpu().numpy()
         np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
 
         sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
 
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        roc_curve_metric.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100,), device=device)
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+        roc_curve_metric.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        roc_curve_metric.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+        roc_curve_metric.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        roc_curve_metric.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100,), device=device)
+        y = torch.randint(0, 2, size=(100,), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_curve_metric.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+        # Batched Updates
+        roc_curve_metric.reset()
+        torch.manual_seed(10 + rank)
+        y_pred = torch.rand((100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device).long()
+
+        batch_size = 16
+        n_iters = y.shape[0] // batch_size + 1
+
+        for i in range(n_iters):
+            idx = i * batch_size
+            roc_curve_metric.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
         fpr, tpr, thresholds = roc_curve_metric.compute()
 
         assert np.array_equal(fpr, sk_fpr)
@@ -186,12 +398,70 @@ def _test_distrib_compute(device):
             _test(idist.device())
 
 
+def _test_distrib_integration_binary(device):
+
+    rank = idist.get_rank()
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(offset * idist.get_world_size(),).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            )
+
+        engine = Engine(update)
+
+        roc_curve_metric = RocCurve(device=metric_device)
+        roc_curve_metric.attach(engine, "roc_cuve")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "roc_cuve" in engine.state.metrics
+
+        fpr, tpr, thresholds = engine.state.metrics["roc_cuve"]
+        if isinstance(fpr, torch.Tensor):
+            fpr = fpr.cpu().numpy()
+
+        if isinstance(tpr, torch.Tensor):
+            tpr = tpr.cpu().numpy()
+
+        if isinstance(thresholds, torch.Tensor):
+            thresholds = thresholds.cpu().numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(y_true.cpu().numpy(), y_preds.cpu().numpy())
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
 def test_distrib_gpu(distributed_context_single_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.distributed
@@ -199,7 +469,8 @@ def test_distrib_gpu(distributed_context_single_node_nccl):
 def test_distrib_cpu(distributed_context_single_node_gloo):
 
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.distributed
@@ -210,36 +481,45 @@ def test_distrib_hvd(gloo_hvd_executor):
     device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
     nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
 
-    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distirb_binary_input_N, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration_binary, (device,), np=nproc, do_init=True)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+
     device = torch.device("cpu")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.multinode_distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
 def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+
     device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.tpu
 @pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
 @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
 def test_distrib_single_device_xla():
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 def _test_distrib_xla_nprocs(index):
+
     device = idist.device()
-    _test_distrib_compute(device)
+    _test_distirb_binary_input_N(device)
+    _test_distrib_integration_binary(device)
 
 
 @pytest.mark.tpu

--- a/tests/ignite/contrib/metrics/test_roc_curve.py
+++ b/tests/ignite/contrib/metrics/test_roc_curve.py
@@ -1,14 +1,54 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 from sklearn.metrics import roc_curve
 
+import ignite.distributed as idist
 from ignite.contrib.metrics.roc_auc import RocCurve
 from ignite.engine import Engine
+from ignite.exceptions import NotComputableError
 from ignite.metrics.epoch_metric import EpochMetricWarning
 
 
+def test_no_update():
+    roc_curve = RocCurve()
+
+    with pytest.raises(
+        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+    ):
+        roc_curve.compute()
+
+
+def test_input_types():
+    roc_curve = RocCurve()
+    roc_curve.reset()
+    output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 3), dtype=torch.long))
+    roc_curve.update(output1)
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        roc_curve.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
+        roc_curve.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
+
+
+def test_check_shape():
+    roc_curve = RocCurve()
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        roc_curve._check_shape((torch.tensor(0), torch.tensor(0)))
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        roc_curve._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
+
+    with pytest.raises(ValueError, match=r"Targets should be of shape"):
+        roc_curve._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
+
+
 def test_roc_curve():
+
     size = 100
     np_y_pred = np.random.rand(size, 1)
     np_y = np.zeros((size,), dtype=np.long)
@@ -29,6 +69,7 @@ def test_roc_curve():
 
 
 def test_integration_roc_curve_with_output_transform():
+
     np.random.seed(1)
     size = 100
     np_y_pred = np.random.rand(size, 1)
@@ -107,3 +148,103 @@ def test_check_compute_fn():
 
     em = RocCurve(check_compute_fn=False)
     em.update(output)
+
+
+def _test_distrib_compute(device):
+    rank = idist.get_rank()
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        roc_curve_metric = RocCurve(device=metric_device)
+
+        torch.manual_seed(10 + rank)
+
+        y_pred = torch.rand(size=(100, 1), device=device)
+        y = torch.randint(0, 2, size=(100, 1), device=device)
+
+        roc_curve_metric.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y_pred = y_pred.cpu().numpy()
+        np_y = y.cpu().numpy()
+
+        sk_fpr, sk_tpr, sk_thresholds = roc_curve(np_y, np_y_pred)
+
+        fpr, tpr, thresholds = roc_curve_metric.compute()
+
+        assert np.array_equal(fpr, sk_fpr)
+        assert np.array_equal(tpr, sk_tpr)
+        # assert thresholds almost equal, due to numpy->torch->numpy conversion
+        np.testing.assert_array_almost_equal(thresholds, sk_thresholds)
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_gpu(distributed_context_single_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_cpu(distributed_context_single_node_gloo):
+
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)


### PR DESCRIPTION
Fixes #1695 

Improved the 3 implementation metrics in `ignite.contrib.metrics` [Average Precision](https://github.com/pytorch/ignite/blob/master/ignite/contrib/metrics/average_precision.py),  [Precision Recall Curve](https://github.com/pytorch/ignite/blob/master/ignite/contrib/metrics/precision_recall_curve.py), [Roc Auc](https://github.com/pytorch/ignite/blob/master/ignite/contrib/metrics/roc_auc.py) similar to [Cohen's Kappa](https://github.com/pytorch/ignite/blob/master/ignite/contrib/metrics/cohen_kappa.py) and added the `device` arg for the future support. Updated the tests, added distributed tests as well

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
