### PR TITLE
Keep nvcc for MSDeepSpeed Docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -48,12 +48,12 @@ Available Tensor Operations:
   - `docker pull pytorchignite/hvd-apex-vision:latest`
 - [hvd/Dockerfile.hvd-apex-nlp](hvd/Dockerfile.hvd-apex-nlp): base Horovod apex with useful NLP libraries
   - `docker pull pytorchignite/hvd-apex-nlp:latest`
-- [msdp/Dockerfile.msdp-apex-base](msdp/Dockerfile.msdp-apex-base): multi-stage MSDeepSpeed build with latest Pytorch, Ignite image with minimal dependencies
-  - `docker pull pytorchignite/msdp-base:latest`
+- [msdp/Dockerfile.msdp-apex-base](msdp/Dockerfile.msdp-apex): multi-stage MSDeepSpeed build with latest Pytorch, Ignite image with minimal dependencies
+  - `docker pull pytorchignite/msdp-apex:latest`
 - [msdp/Dockerfile.msdp-apex-vision](msdp/Dockerfile.msdp-apex-vision): base MSDeepSpeed build with useful computer vision libraries
-  - `docker pull pytorchignite/msdp-vision:latest`
+  - `docker pull pytorchignite/msdp-apex-vision:latest`
 - [msdp/Dockerfile.msdp-apex-nlp](msdp/Dockerfile.msdp-apex-nlp): base MSDeepSpeed build with useful NLP libraries
-  - `docker pull pytorchignite/msdp-nlp:latest`
+  - `docker pull pytorchignite/msdp-apex-nlp:latest`
 
 ## How to use
 

--- a/docker/msdp/Dockerfile.msdp-apex
+++ b/docker/msdp/Dockerfile.msdp-apex
@@ -67,10 +67,7 @@ RUN pip install --upgrade --no-cache-dir pytorch-ignite \
 # replace pillow with pillow-simd
 RUN apt-get update && apt-get -y install --no-install-recommends g++ && \
     pip uninstall -y pillow && \
-    CC="cc -mavx2" pip install --upgrade --no-cache-dir --force-reinstall pillow-simd && \
-    apt-get remove -y g++ && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+    CC="cc -mavx2" pip install --upgrade --no-cache-dir --force-reinstall pillow-simd
 
 # Checkout Ignite examples only
 RUN mkdir -p pytorch-ignite-examples && \

--- a/docker/msdp/Dockerfile.msdp-apex
+++ b/docker/msdp/Dockerfile.msdp-apex
@@ -65,8 +65,7 @@ RUN pip install --upgrade --no-cache-dir pytorch-ignite \
                                          tqdm
 
 # replace pillow with pillow-simd
-RUN apt-get update && apt-get -y install --no-install-recommends g++ && \
-    pip uninstall -y pillow && \
+RUN pip uninstall -y pillow && \
     CC="cc -mavx2" pip install --upgrade --no-cache-dir --force-reinstall pillow-simd
 
 # Checkout Ignite examples only


### PR DESCRIPTION
Fixes #1710 

Description:

Prevents `nvcc` from being removed by excluding `g++` removing step from Docker file

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
