### PR TITLE
add match pytest for metrics

### DIFF
--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -13,43 +13,43 @@ torch.manual_seed(12)
 
 def test_no_update():
     acc = Accuracy()
-    with pytest.raises(NotComputableError):
+    with pytest.raises(NotComputableError, match=r"Accuracy must have at least one example before it can be computed"):
         acc.compute()
 
 
 def test__check_shape():
     acc = Accuracy()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y and y_pred must have compatible shapes"):
         acc._check_shape((torch.randint(0, 2, size=(10, 1, 5, 12)).long(), torch.randint(0, 2, size=(10, 5, 6)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y and y_pred must have compatible shapes"):
         acc._check_shape((torch.randint(0, 2, size=(10, 1, 6)).long(), torch.randint(0, 2, size=(10, 5, 6)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y and y_pred must have compatible shapes"):
         acc._check_shape((torch.randint(0, 2, size=(10, 1)).long(), torch.randint(0, 2, size=(10, 5)).long()))
 
 
 def test_binary_wrong_inputs():
     acc = Accuracy()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"For binary cases, y must be comprised of 0's and 1's"):
         # y has not only 0 or 1 values
         acc.update((torch.randint(0, 2, size=(10,)).long(), torch.arange(0, 10).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"For binary cases, y_pred must be comprised of 0's and 1's"):
         # y_pred values are not thresholded to 0, 1 values
-        acc.update((torch.rand(10,), torch.randint(0, 2, size=(10,)).long()))
+        acc.update((torch.rand(10,), torch.randint(0, 2, size=(10,)).long(),))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of "):
         # incompatible shapes
         acc.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of "):
         # incompatible shapes
         acc.update((torch.randint(0, 2, size=(10, 5, 6)).long(), torch.randint(0, 2, size=(10,)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of "):
         # incompatible shapes
         acc.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5, 6)).long()))
 

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -15,7 +15,7 @@ torch.manual_seed(12)
 
 def test_no_update():
     cm = ConfusionMatrix(10)
-    with pytest.raises(NotComputableError):
+    with pytest.raises(NotComputableError, match=r"Confusion matrix must have at least one example before it "):
         cm.compute()
 
 

--- a/tests/ignite/metrics/test_loss.py
+++ b/tests/ignite/metrics/test_loss.py
@@ -13,7 +13,7 @@ from ignite.metrics import Loss
 
 def test_zero_div():
     loss = Loss(nll_loss)
-    with pytest.raises(NotComputableError):
+    with pytest.raises(NotComputableError, match=r"Loss must have at least one example before it can be computed"):
         loss.compute()
 
 

--- a/tests/ignite/metrics/test_mean_absolute_error.py
+++ b/tests/ignite/metrics/test_mean_absolute_error.py
@@ -10,7 +10,9 @@ from ignite.metrics import MeanAbsoluteError
 
 def test_zero_div():
     mae = MeanAbsoluteError()
-    with pytest.raises(NotComputableError):
+    with pytest.raises(
+        NotComputableError, match=r"MeanAbsoluteError must have at least one example before it can be computed"
+    ):
         mae.compute()
 
 

--- a/tests/ignite/metrics/test_mean_pairwise_distance.py
+++ b/tests/ignite/metrics/test_mean_pairwise_distance.py
@@ -11,7 +11,9 @@ from ignite.metrics import MeanPairwiseDistance
 
 def test_zero_div():
     mpd = MeanPairwiseDistance()
-    with pytest.raises(NotComputableError):
+    with pytest.raises(
+        NotComputableError, match=r"MeanAbsoluteError must have at least one example before it can be computed"
+    ):
         mpd.compute()
 
 

--- a/tests/ignite/metrics/test_mean_squared_error.py
+++ b/tests/ignite/metrics/test_mean_squared_error.py
@@ -10,7 +10,9 @@ from ignite.metrics import MeanSquaredError
 
 def test_zero_div():
     mse = MeanSquaredError()
-    with pytest.raises(NotComputableError):
+    with pytest.raises(
+        NotComputableError, match=r"MeanSquaredError must have at least one example before it can be computed"
+    ):
         mse.compute()
 
 

--- a/tests/ignite/metrics/test_multilabel_confusion_matrix.py
+++ b/tests/ignite/metrics/test_multilabel_confusion_matrix.py
@@ -12,7 +12,9 @@ torch.manual_seed(12)
 
 def test_no_update():
     cm = MultiLabelConfusionMatrix(10)
-    with pytest.raises(NotComputableError):
+    with pytest.raises(
+        NotComputableError, match=r"Confusion matrix must have at least one example before it can be computed"
+    ):
         cm.compute()
 
 

--- a/tests/ignite/metrics/test_precision.py
+++ b/tests/ignite/metrics/test_precision.py
@@ -15,7 +15,7 @@ torch.manual_seed(12)
 
 def test_no_update():
     precision = Precision()
-    with pytest.raises(NotComputableError):
+    with pytest.raises(NotComputableError, match=r"Precision must have at least one example before it can be computed"):
         precision.compute()
 
     precision = Precision(is_multilabel=True, average=True)
@@ -26,23 +26,23 @@ def test_no_update():
 def test_binary_wrong_inputs():
     pr = Precision()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"For binary cases, y must be comprised of 0's and 1's"):
         # y has not only 0 or 1 values
         pr.update((torch.randint(0, 2, size=(10,)).long(), torch.arange(0, 10).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"For binary cases, y_pred must be comprised of 0's and 1's"):
         # y_pred values are not thresholded to 0, 1 values
-        pr.update((torch.rand(10,), torch.randint(0, 2, size=(10,)).long()))
+        pr.update((torch.rand(10,), torch.randint(0, 2, size=(10,)).long(),))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of"):
         # incompatible shapes
         pr.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of"):
         # incompatible shapes
         pr.update((torch.randint(0, 2, size=(10, 5, 6)).long(), torch.randint(0, 2, size=(10,)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of"):
         # incompatible shapes
         pr.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5, 6)).long()))
 

--- a/tests/ignite/metrics/test_recall.py
+++ b/tests/ignite/metrics/test_recall.py
@@ -15,7 +15,7 @@ torch.manual_seed(12)
 
 def test_no_update():
     recall = Recall()
-    with pytest.raises(NotComputableError):
+    with pytest.raises(NotComputableError, match=r"Recall must have at least one example before it can be computed"):
         recall.compute()
 
     recall = Recall(is_multilabel=True, average=True)
@@ -26,23 +26,23 @@ def test_no_update():
 def test_binary_wrong_inputs():
     re = Recall()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"For binary cases, y must be comprised of 0's and 1's"):
         # y has not only 0 or 1 values
         re.update((torch.randint(0, 2, size=(10,)), torch.arange(0, 10).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"For binary cases, y_pred must be comprised of 0's and 1's"):
         # y_pred values are not thresholded to 0, 1 values
         re.update((torch.rand(10, 1), torch.randint(0, 2, size=(10,)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of"):
         # incompatible shapes
         re.update((torch.randint(0, 2, size=(10,)), torch.randint(0, 2, size=(10, 5)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of"):
         # incompatible shapes
         re.update((torch.randint(0, 2, size=(10, 5, 6)), torch.randint(0, 2, size=(10,)).long()))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"y must have shape of"):
         # incompatible shapes
         re.update((torch.randint(0, 2, size=(10,)), torch.randint(0, 2, size=(10, 5, 6)).long()))
 

--- a/tests/ignite/metrics/test_root_mean_squared_error.py
+++ b/tests/ignite/metrics/test_root_mean_squared_error.py
@@ -10,7 +10,9 @@ from ignite.metrics import RootMeanSquaredError
 
 def test_zero_div():
     rmse = RootMeanSquaredError()
-    with pytest.raises(NotComputableError):
+    with pytest.raises(
+        NotComputableError, match=r"MeanSquaredError must have at least one example before it can be computed"
+    ):
         rmse.compute()
 
 

--- a/tests/ignite/metrics/test_top_k_categorical_accuracy.py
+++ b/tests/ignite/metrics/test_top_k_categorical_accuracy.py
@@ -10,7 +10,9 @@ from ignite.metrics import TopKCategoricalAccuracy
 
 def test_zero_div():
     acc = TopKCategoricalAccuracy(2)
-    with pytest.raises(NotComputableError):
+    with pytest.raises(
+        NotComputableError, match=r"TopKCategoricalAccuracy must have at least one example before it can be computed"
+    ):
         acc.compute()
 
 


### PR DESCRIPTION
Added match for `pytest.raises` for most all the metrics don't have it

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
