### PR TITLE
feat(docs): navigation with left/right arrow keys

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,6 +107,7 @@ html_theme_options = {
     "collapse_navigation": False,
     "display_version": True,
     "logo_only": True,
+    "navigation_with_keys": True,
 }
 
 html_logo = "_templates/_static/img/ignite_logo.svg"

--- a/ignite/contrib/handlers/lr_finder.py
+++ b/ignite/contrib/handlers/lr_finder.py
@@ -270,7 +270,7 @@ class FastaiLRFinder:
 
             to_save = {"model": model, "optimizer": optimizer}
             with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
-                trainer_with_lr_finder.run(dataloader)`
+                trainer_with_lr_finder.run(dataloader)
 
         Args:
             trainer: lr_finder is attached to this trainer. Please, keep in mind that all attached handlers

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -69,7 +69,7 @@ def apply_to_type(
 
 def to_onehot(indices: torch.Tensor, num_classes: int) -> torch.Tensor:
     """Convert a tensor of indices of any shape `(N, ...)` to a
-    tensor of one-hot indicators of shape `(N, num_classes, ...) and of type uint8. Output's device is equal to the
+    tensor of one-hot indicators of shape `(N, num_classes, ...)` and of type uint8. Output's device is equal to the
     input's device`.
 
     Args:


### PR DESCRIPTION
Fixes #{issue number}

Description:
- Add `navigation_with_keys` config to be able to visit the docs with left/right arrow keys (https://github.com/sphinx-doc/sphinx/pull/2064)
- Fix WARNING docstring

https://deploy-preview-1726--pytorch-ignite-preview.netlify.app

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
