### PR TITLE
[flake8] remove unused imports in metrics

### DIFF
--- a/ignite/metrics/accumulation.py
+++ b/ignite/metrics/accumulation.py
@@ -1,5 +1,5 @@
 import numbers
-from typing import Any, Callable, Tuple, Union
+from typing import Callable, Tuple, Union
 
 import torch
 

--- a/ignite/metrics/epoch_metric.py
+++ b/ignite/metrics/epoch_metric.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, List, Sequence, Tuple, Union, cast
+from typing import Callable, List, Tuple, Union, cast
 
 import torch
 

--- a/ignite/metrics/frequency.py
+++ b/ignite/metrics/frequency.py
@@ -1,11 +1,11 @@
-from typing import Any, Callable, Union
+from typing import Callable, Union
 
 import torch
 
 import ignite.distributed as idist
 from ignite.engine import Engine, Events
 from ignite.handlers.timing import Timer
-from ignite.metrics.metric import EpochWise, Metric, MetricUsage, reinit__is_reduced, sync_all_reduce
+from ignite.metrics.metric import Metric, reinit__is_reduced, sync_all_reduce
 
 
 class Frequency(Metric):

--- a/ignite/metrics/metrics_lambda.py
+++ b/ignite/metrics/metrics_lambda.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional, Union
 
 import torch
 
-from ignite.engine import Engine, Events
+from ignite.engine import Engine
 from ignite.metrics.metric import EpochWise, Metric, MetricUsage, reinit__is_reduced
 
 __all__ = ["MetricsLambda"]

--- a/ignite/metrics/multilabel_confusion_matrix.py
+++ b/ignite/metrics/multilabel_confusion_matrix.py
@@ -1,11 +1,9 @@
-import numbers
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Callable, Sequence, Union
 
 import torch
 
 from ignite.exceptions import NotComputableError
 from ignite.metrics.metric import Metric, reinit__is_reduced, sync_all_reduce
-from ignite.metrics.metrics_lambda import MetricsLambda
 
 __all__ = ["MultiLabelConfusionMatrix"]
 

--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Callable, Sequence, Union, cast
 
 import torch

--- a/ignite/metrics/psnr.py
+++ b/ignite/metrics/psnr.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Sequence, Union
 
 import torch
 


### PR DESCRIPTION
Fixes #1752

Description:

1. removed F401 from setup.cfg
2. run flake8 on `ignite/metrics`
3. Remove unused imports
4. Revert `setup.cfg`

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
