### PR TITLE
[flake8] remove unused imports in contrib/metrics

### DIFF
--- a/ignite/contrib/metrics/regression/canberra_metric.py
+++ b/ignite/contrib/metrics/regression/canberra_metric.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Union
+from typing import Tuple
 
 import torch
 

--- a/ignite/contrib/metrics/regression/manhattan_distance.py
+++ b/ignite/contrib/metrics/regression/manhattan_distance.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Union
+from typing import Tuple
 
 import torch
 

--- a/ignite/contrib/metrics/regression/r2_score.py
+++ b/ignite/contrib/metrics/regression/r2_score.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Union
+from typing import Tuple
 
 import torch
 


### PR DESCRIPTION
Fixes #1752

Description:
1. removed F401 from setup.cfg
2. run flake8 on ignite/metrics
3. Remove unused imports [ I've excluded the warnings in `__init__.py` since those have to stay for later imports]
4. Revert setup.cfg


- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
