### PR TITLE
Fixes part of  #1725: [flake8] Remove unused imports in engine and contrib.engines

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -1,7 +1,7 @@
 import numbers
 import warnings
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence, Union, cast
 
 import torch
 import torch.nn as nn
@@ -18,7 +18,6 @@ from ignite.contrib.handlers import (
     PolyaxonLogger,
     ProgressBar,
     TensorboardLogger,
-    TrainsLogger,
     VisdomLogger,
     WandBLogger,
     global_step_from_engine,

--- a/ignite/engine/deterministic.py
+++ b/ignite/engine/deterministic.py
@@ -2,7 +2,7 @@ import random
 import warnings
 from collections import OrderedDict
 from functools import wraps
-from typing import Any, Callable, Generator, Iterator, List, Optional, cast
+from typing import Any, Callable, Generator, Iterator, List, Optional
 
 import torch
 from torch.utils.data import DataLoader

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -1,5 +1,4 @@
 import numbers
-import warnings
 import weakref
 from enum import Enum
 from types import DynamicClassAttribute


### PR DESCRIPTION
Fixes part of #1725 

Description:
Fixed all the unused import warnings present in ```ignite.engine``` and ```ignite.contrib.engines``` which were generated by flake8 when F401 was removed from ```setup.cfg```.

I have ignored the ```__init__.py``` file for ```ignite.contrib.engines```

Files Changed:
- [x] ```ignite.engine```
- [x] ```ignite.contrib.engines```

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
