### PR TITLE
Fix docker builds order

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,8 +21,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get a list of modified files
         run: echo "modified=${{ steps.files.outputs.files_created }} ${{ steps.files.outputs.files_updated }}" >> $GITHUB_ENV
-      - name: Debug Step
-        run: echo "${{ env.modified }}"
       - name: Set outputs
         id: set-modified
         run: echo "::set-output name=modified::${{ env.modified }}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,13 +9,9 @@ on:
 jobs:
   setup:
     name: Setup
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     outputs:
       modified: ${{ steps.set-modified.outputs.modified }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-
     steps:
       - uses: actions/checkout@v2
       - name: Changed Files Exporter
@@ -23,13 +19,10 @@ jobs:
         uses: futuratrepadeira/changed-files@v3.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Get a list of modified files
         run: echo "modified=${{ steps.files.outputs.files_created }} ${{ steps.files.outputs.files_updated }}" >> $GITHUB_ENV
-
       - name: Debug Step
         run: echo "${{ env.modified }}"
-
       - name: Set outputs
         id: set-modified
         run: echo "::set-output name=modified::${{ env.modified }}"
@@ -38,116 +31,157 @@ jobs:
     name: Build all Horovod flavoured PyTorch-Ignite images
     needs: setup
     if: contains(needs.setup.outputs.modified, 'hvd/')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        type: [hvd]
-        flavour: [hvd-base, hvd-vision, hvd-nlp]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: "Build ${{ matrix.type }} ${{ matrix.flavour }}"
+      - name: Build hvd hvd-base
         run: |
           pip install PyYAML
           export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
           export HVD_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_hvd_version']['default'])"`
-          cd docker
           docker system prune -a -f
-          bash build.sh "${{ matrix.type }}" "${{ matrix.flavour }}"
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          cd docker
+          bash build.sh hvd hvd-base
+      - name: Build hvd hvd-vision
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          export HVD_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_hvd_version']['default'])"`
+          cd docker
+          bash build.sh hvd hvd-vision
+      - name: Build hvd hvd-nlp
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          export HVD_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_hvd_version']['default'])"`
+          cd docker
+          bash build.sh hvd hvd-nlp
 
   build-hvd-apex:
     name: Build all Horovod + Apex flavoured PyTorch-Ignite images
     needs: setup
     if: contains(needs.setup.outputs.modified, 'hvd/')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        type: [hvd]
-        flavour: [hvd-apex, hvd-apex-vision, hvd-apex-nlp]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: "Build ${{ matrix.type }} ${{ matrix.flavour }}"
+      - name: Build hvd hvd-apex
         run: |
           pip install PyYAML
           export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
           export HVD_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_hvd_version']['default'])"`
-          cd docker
           docker system prune -a -f
-          bash build.sh "${{ matrix.type }}" "${{ matrix.flavour }}"
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          cd docker
+          bash build.sh hvd hvd-apex
+      - name: Build hvd hvd-apex-vision
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          export HVD_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_hvd_version']['default'])"`
+          cd docker
+          bash build.sh hvd hvd-apex-vision
+      - name: Build hvd hvd-apex-nlp
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          export HVD_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_hvd_version']['default'])"`
+          cd docker
+          bash build.sh hvd hvd-apex-nlp
 
   build-main:
     name: Build all PyTorch-Ignite images
     needs: setup
     if: contains(needs.setup.outputs.modified, 'main/')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        type: [main]
-        flavour: [base, vision, nlp]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: "Build ${{ matrix.type }} ${{ matrix.flavour }}"
+      - name: Build main base
         run: |
           pip install PyYAML
           export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
-          cd docker
           docker system prune -a -f
-          bash build.sh "${{ matrix.type }}" "${{ matrix.flavour }}"
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          cd docker
+          bash build.sh main base
+      - name: Build main vision
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          cd docker
+          bash build.sh main vision
+      - name: Build main nlp
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          cd docker
+          bash build.sh main nlp
 
   build-main-apex:
     name: Build all PyTorch-Ignite images with Apex
     needs: setup
     if: contains(needs.setup.outputs.modified, 'main/')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        type: [main]
-        flavour: [apex, apex-vision, apex-nlp]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: "Build ${{ matrix.type }} ${{ matrix.flavour }}"
+      - name: Build main apex
         run: |
           pip install PyYAML
           export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
-          cd docker
           docker system prune -a -f
-          bash build.sh "${{ matrix.type }}" "${{ matrix.flavour }}"
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          cd docker
+          bash build.sh main apex
+      - name: Build main apex-vision
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          cd docker
+          bash build.sh main apex-vision
+      - name: Build main apex-nlp
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          cd docker
+          bash build.sh main apex-nlp
 
   build-msdp-apex:
     name: Build all MS DeepSpeed flavoured PyTorch-Ignite images
     needs: setup
     if: contains(needs.setup.outputs.modified, 'msdp/')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        type: [msdp]
-        flavour: [msdp-apex, msdp-apex-vision, msdp-apex-nlp]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: "Build ${{ matrix.type }} ${{ matrix.flavour }}"
+      - name: Build msdp msdp-apex
         run: |
           pip install PyYAML
           export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
           export MSDP_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_msdp_version']['default'])"`     
-          cd docker
           docker system prune -a -f
-          bash build.sh "${{ matrix.type }}" "${{ matrix.flavour }}"
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          cd docker
+          bash build.sh msdp msdp-apex
+      - name: Build msdp msdp-apex-vision
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          export MSDP_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_msdp_version']['default'])"`     
+          cd docker
+          bash build.sh msdp msdp-apex-vision
+      - name: Build msdp msdp-apex-nlp
+        run: |
+          export PTH_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_pytorch_version']['default'])"`
+          export MSDP_VERSION=`python -c "import yaml; f=open('.circleci/config.yml'); d=yaml.safe_load(f); print(d['parameters']['build_docker_image_msdp_version']['default'])"`     
+          cd docker
+          bash build.sh msdp msdp-apex-nlp

--- a/docker/hvd/Dockerfile.hvd-base
+++ b/docker/hvd/Dockerfile.hvd-base
@@ -32,7 +32,7 @@ RUN pip install --upgrade --no-cache-dir pytorch-ignite \
                                          tensorboard \
                                          tqdm
 
-# replace pillow with pillow-simd
+# Replace pillow with pillow-simd
 RUN apt-get update && apt-get -y install --no-install-recommends g++ && \
     pip uninstall -y pillow && \
     CC="cc -mavx2" pip install --upgrade --no-cache-dir --force-reinstall pillow-simd && \

--- a/docker/main/Dockerfile.base
+++ b/docker/main/Dockerfile.base
@@ -17,7 +17,7 @@ RUN pip install --upgrade --no-cache-dir pytorch-ignite \
                                          tensorboard \
                                          tqdm
 
-# replace pillow with pillow-simd
+# Replace pillow with pillow-simd
 RUN apt-get update && apt-get -y install --no-install-recommends g++ && \
     pip uninstall -y pillow && \
     CC="cc -mavx2" pip install --upgrade --no-cache-dir --force-reinstall pillow-simd && \

--- a/docker/msdp/Dockerfile.msdp-apex
+++ b/docker/msdp/Dockerfile.msdp-apex
@@ -64,7 +64,7 @@ RUN pip install --upgrade --no-cache-dir pytorch-ignite \
                                          tensorboard \
                                          tqdm
 
-# replace pillow with pillow-simd
+# Replace pillow with pillow-simd
 RUN pip uninstall -y pillow && \
     CC="cc -mavx2" pip install --upgrade --no-cache-dir --force-reinstall pillow-simd
 


### PR DESCRIPTION
The PR Fixes docker builds order as discussed here #1724 

Description:

Current setup looks like this:

```yml
jobs:
  setup:
    ...
  ...
  build-main:
    steps:
      - build base
        ...
      - build vision
        ...
      - build nlp
        ...
  ...
 ```

- 5 parallel build jobs + setup job
- each of 5 jobs builds 3 images: base + vision + nlp
- no artifacts
 
Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
