### PR TITLE
[flake8] [F401] Ignore flake8 F401 in all __init__ files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ filter_files=True
 [flake8]
 max-line-length = 120
 ignore = E722,F401,E203,E231,F841,W503,F403,E402
+per-file-ignores = __init__.py: F401
 
 [tool:pytest]
 markers =


### PR DESCRIPTION
Part of #1725 

Description:

Fixes flake8 F401 unused imports for all `__init__.py` files

E.g. This solves the case with the base module

https://github.com/pytorch/ignite/blob/771f0c71d6fa49142105aa33044be205cdba557c/ignite/base/__init__.py#L1

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
