### PR TITLE
 [flake8] remove unused imports in contrib/handlers

### DIFF
--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -7,7 +7,6 @@ import torch
 import torch.nn as nn
 from torch.optim import Optimizer
 
-import ignite
 import ignite.distributed as idist
 from ignite.contrib.handlers.base_logger import (
     BaseLogger,


### PR DESCRIPTION
Addresses part of #1725

Description:

   1. removed F401 from setup.cfg
   2. run flake8 on ignite/contrib/handlers
   3. Remove unused imports
   4. Revert setup.cfg


- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
