### PR TITLE
Turn-on new labels for PR Labeler

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -7,17 +7,17 @@ docs:
   - docs/**/*
 
 # Add 'ci' to any changes within 'circleci' and '.github' folder
-#ci:
-#  - .circleci/**/*
-#  - .github/**/*
+ci:
+  - .circleci/**/*
+  - .github/**/*
 
 # Add 'examples' to any changes within 'examples' folder
-#examples:
-#  - examples/**/*
+examples:
+  - examples/**/*
 
 # Add 'base' to any changes within 'base' folder
-#"module: base":
-#  - ignite/base/**/*
+"module: base":
+  - ignite/base/**/*
 
 # Add 'contrib' to any changes within 'contrib' folder
 "module: contrib":
@@ -40,5 +40,5 @@ docs:
   - ignite/metrics/**/*
 
 # Add 'utils' to any changes within 'utils' module
-#"module: utils":
-#  - ignite/utils.py
+"module: utils":
+  - ignite/utils.py


### PR DESCRIPTION
Fixes #{issue number}

Description:

This PR adds activates new labels for PR Labeler:

- ci
- examples
- module: base
- module: utils

Feel free to propose more or maybe, we need more specific ones: for example: "ci: actions", "ci: docs", "ci: circleci".

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
