### PR TITLE
ci: add timeout-mintues in linkcheck job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,7 @@ jobs:
 
   linkcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
 
   linkcheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes https://github.com/pytorch/ignite/runs/2066997659?check_suite_focus=true

Description: `linkcheck` job is probably hanging now maybe due to some network requests issues.
At most it should run completely within a couple of minutes. Adding `timeout-minutes` 10 mins for the job to prevent long hanging CI check.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
