### PR TITLE
Add integration test to MaximumAbsoluteError

### DIFF
--- a/tests/ignite/contrib/metrics/regression/test_maximum_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_maximum_absolute_error.py
@@ -82,12 +82,9 @@ def test_integration():
         data = list(range(y_pred.shape[0] // batch_size))
         mae = engine.run(data, max_epochs=1).metrics["mae"]
 
-        np_ans = -1
-
         np_max = np.max(np.abs((np_y_pred - np_y)))
-        np_ans = np_max if np_max > np_ans else np_ans
 
-        assert np_ans == pytest.approx(mae)
+        assert np_max == pytest.approx(mae)
 
     def get_test_cases():
         test_cases = [

--- a/tests/ignite/contrib/metrics/regression/test_maximum_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_maximum_absolute_error.py
@@ -69,11 +69,11 @@ def test_integration():
             idx = (engine.state.iteration - 1) * batch_size
             y_true_batch = np_y[idx : idx + batch_size]
             y_pred_batch = np_y_pred[idx : idx + batch_size]
-            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+            return torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
 
         engine = Engine(update_fn)
 
-        m = MaximumAbsoluteError(output_transform=lambda x: (x[1], x[2]))
+        m = MaximumAbsoluteError()
         m.attach(engine, "mae")
 
         np_y = y.numpy()


### PR DESCRIPTION
Adding integration test to [MaximumAbsoluteError](https://github.com/pytorch/ignite/blob/master/tests/ignite/contrib/metrics/regression/test_maximum_absolute_error.py)

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
