### PR TITLE
Add integration test to FractionalAbsoluteError

### DIFF
--- a/tests/ignite/contrib/metrics/regression/test_fractional_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_fractional_absolute_error.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 from ignite.contrib.metrics.regression import FractionalAbsoluteError
+from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
 
 
@@ -62,3 +63,44 @@ def test_compute():
     np_len += len(d)
     np_ans = np_sum / np_len
     assert m.compute() == pytest.approx(np_ans)
+
+
+def test_integration():
+    def _test(y_pred, y, batch_size):
+        def update_fn(engine, batch):
+            idx = (engine.state.iteration - 1) * batch_size
+            y_true_batch = np_y[idx : idx + batch_size]
+            y_pred_batch = np_y_pred[idx : idx + batch_size]
+            return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+
+        engine = Engine(update_fn)
+
+        m = FractionalAbsoluteError(output_transform=lambda x: (x[1], x[2]))
+        m.attach(engine, "fab")
+
+        np_y = y.numpy()
+        np_y_pred = y_pred.numpy()
+
+        data = list(range(y_pred.shape[0] // batch_size))
+        fab = engine.run(data, max_epochs=1).metrics["fab"]
+
+        np_sum = (2 * np.abs((np_y_pred - np_y)) / (np.abs(np_y_pred) + np.abs(np_y))).sum()
+        np_len = len(y_pred)
+        np_ans = np_sum / np_len
+
+        assert np_ans == pytest.approx(fab)
+
+    def get_test_cases():
+        test_cases = [
+            (torch.rand(size=(100,)), torch.rand(size=(100,)), 10),
+            (torch.rand(size=(200,)), torch.rand(size=(200,)), 10),
+            (torch.rand(size=(100,)), torch.rand(size=(100,)), 20),
+            (torch.rand(size=(200,)), torch.rand(size=(200,)), 20),
+        ]
+        return test_cases
+
+    for _ in range(10):
+        # check multiple random inputs as random exact occurencies are rare
+        test_cases = get_test_cases()
+        for y_pred, y, batch_size in test_cases:
+            _test(y_pred, y, batch_size)


### PR DESCRIPTION
Adding Integration test to [FractionalAbsoluteError](https://github.com/pytorch/ignite/blob/master/tests/ignite/contrib/metrics/regression/test_fractional_absolute_error.py)

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
