### PR TITLE
cov: add tests for some contrib.handlers

### DIFF
--- a/ignite/contrib/handlers/time_profilers.py
+++ b/ignite/contrib/handlers/time_profilers.py
@@ -293,8 +293,7 @@ class BasicTimeProfiler:
         try:
             import pandas as pd
         except ImportError:
-            print("Need pandas to write results as files")
-            return
+            raise RuntimeError("Need pandas to write results as files")
 
         iters_per_epoch = self.total_num_iters // self.max_epochs
 
@@ -664,8 +663,7 @@ class HandlersTimeProfiler:
         try:
             import pandas as pd
         except ImportError:
-            print("Need pandas to write results as files")
-            return
+            raise RuntimeError("Need pandas to write results as files")
 
         processing_stats = torch.tensor(self.processing_times, dtype=torch.float32)
         dataflow_stats = torch.tensor(self.dataflow_times, dtype=torch.float32)

--- a/tests/ignite/contrib/handlers/test_lr_finder.py
+++ b/tests/ignite/contrib/handlers/test_lr_finder.py
@@ -93,8 +93,16 @@ def test_attach_incorrect_input_args(lr_finder, dummy_engine, model, optimizer, 
         with lr_finder.attach(dummy_engine, to_save=to_save, num_iter=0.0) as f:
             pass
 
-    with pytest.raises(ValueError, match="if provided, num_iter should be positive"):
+    with pytest.raises(ValueError, match=r"if provided, num_iter should be positive"):
         with lr_finder.attach(dummy_engine, to_save=to_save, num_iter=0) as f:
+            pass
+
+    with pytest.raises(TypeError, match=r"Object to_save\['optimizer'] should be torch optimizer"):
+        with lr_finder.attach(dummy_engine, {"model": to_save["model"], "optimizer": to_save["model"]}):
+            pass
+
+    with pytest.raises(ValueError, match=r"step_mode should be 'exp' or 'linear'"):
+        with lr_finder.attach(dummy_engine, to_save=to_save, step_mode="abc") as f:
             pass
 
     with lr_finder.attach(dummy_engine, to_save) as trainer_with_finder:

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -898,6 +898,15 @@ def test_simulate_and_plot_values():
         milestones_values=[(10, 0.5), (20, 0.45), (21, 0.3), (30, 0.1), (40, 0.1)],
     )
 
+    with pytest.raises(RuntimeError, match=r"This method requires matplotlib to be installed."):
+        with patch.dict("sys.modules", {"matplotlib.pylab": None}):
+            _test(
+                PiecewiseLinear,
+                optimizer=optimizer,
+                param_name="lr",
+                milestones_values=[(10, 0.5), (20, 0.45), (21, 0.3), (30, 0.1), (40, 0.1)],
+            )
+
 
 def test_create_lr_scheduler_with_warmup():
 
@@ -1147,6 +1156,9 @@ def test_param_group_scheduler_asserts():
         ParamGroupScheduler(schedulers=[lr_scheduler1, lr_scheduler2], names=["a"])
 
     scheduler = ParamGroupScheduler(schedulers=[lr_scheduler1, lr_scheduler2], names=["a", "b"])
+    with pytest.raises(TypeError, match=r"Argument state_dict should be a dictionary"):
+        scheduler.load_state_dict(None)
+
     with pytest.raises(ValueError, match=r"Required state attribute 'schedulers' is absent in provided state_dict"):
         scheduler.load_state_dict({"a": 1})
 

--- a/tests/ignite/contrib/handlers/test_time_profilers.py
+++ b/tests/ignite/contrib/handlers/test_time_profilers.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+from unittest.mock import patch
 
 import pytest
 from pytest import approx
@@ -115,6 +116,24 @@ def get_prepared_engine_for_handlers_profiler(true_event_handler_time):
         time.sleep(true_event_handler_time)
 
     return dummy_trainer, HANDLERS_SLEEP_COUNT, PROCESSING_SLEEP_COUNT
+
+
+def test_profilers_wrong_inputs():
+    profiler = BasicTimeProfiler()
+    with pytest.raises(TypeError, match=r"Argument engine should be ignite.engine.Engine"):
+        profiler.attach(None)
+
+    with pytest.raises(RuntimeError, match=r"Need pandas to write results as files"):
+        with patch.dict("sys.modules", {"pandas": None}):
+            profiler.write_results("")
+
+    profiler = HandlersTimeProfiler()
+    with pytest.raises(TypeError, match=r"Argument engine should be ignite.engine.Engine"):
+        profiler.attach(None)
+
+    with pytest.raises(RuntimeError, match=r"Need pandas to write results as files"):
+        with patch.dict("sys.modules", {"pandas": None}):
+            profiler.write_results("")
 
 
 def test_dataflow_timer_basic_profiler():

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import sys
 import time
+from argparse import Namespace
 from distutils.version import LooseVersion
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -26,6 +28,16 @@ def update_fn(engine, batch):
     a = 1
     engine.state.metrics["a"] = a
     return a
+
+
+def test_pbar_errors():
+    with pytest.raises(RuntimeError, match=r"This contrib module requires tqdm to be installed"):
+        with patch.dict("sys.modules", {"tqdm.autonotebook": None}):
+            ProgressBar()
+
+    pbar = ProgressBar()
+    with pytest.raises(ValueError, match=r"Logging event abc is not in allowed"):
+        pbar.attach(Engine(lambda e, b: None), event_name=Namespace(name="abc"))
 
 
 def test_pbar(capsys):

--- a/tests/ignite/contrib/handlers/test_visdom_logger.py
+++ b/tests/ignite/contrib/handlers/test_visdom_logger.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import ANY, MagicMock, call
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 import torch
@@ -953,3 +953,9 @@ def test_no_visdom(no_site_packages):
 
     with pytest.raises(RuntimeError, match=r"This contrib module requires visdom package"):
         VisdomLogger()
+
+
+def test_no_concurrent():
+    with pytest.raises(RuntimeError, match=r"This contrib module requires concurrent.futures"):
+        with patch.dict("sys.modules", {"concurrent.futures": None}):
+            VisdomLogger(num_workers=1)


### PR DESCRIPTION
Part of #1790 

Description: Add tests for 
- `tests/ignite/contrib/handlers/test_lr_finder.py`
- `tests/ignite/contrib/handlers/test_param_scheduler.py`
- `tests/ignite/contrib/handlers/test_time_profilers.py`
- `tests/ignite/contrib/handlers/test_tqdm_logger.py`
- `tests/ignite/contrib/handlers/test_visdom_logger.py`

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
