### PR TITLE
script: add code style bash script 

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,14 +9,14 @@ on:
       - "docs/**"
       - "conda.recipe"
       - "**.md"
-#   pull_request:
-#     paths-ignore:
-#       - "assets/**"
-#       - ".circleci/**"
-#       - "docker/**"
-#       - "docs/**"
-#       - "conda.recipe"
-#       - "**.md"
+  #   pull_request:
+  #     paths-ignore:
+  #       - "assets/**"
+  #       - ".circleci/**"
+  #       - "docker/**"
+  #       - "docs/**"
+  #       - "conda.recipe"
+  #       - "**.md"
   pull_request_target:
     paths-ignore:
       - "assets/**"
@@ -32,10 +32,10 @@ jobs:
     steps:
       - if: github.event_name == 'push'
         uses: actions/checkout@v2
-#       - if: github.event_name == 'pull_request'
-#         uses: actions/checkout@v2
-#         with:
-#           ref: ${{ github.head_ref }}
+      #       - if: github.event_name == 'pull_request'
+      #         uses: actions/checkout@v2
+      #         with:
+      #           ref: ${{ github.head_ref }}
       - if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
@@ -46,10 +46,8 @@ jobs:
         with:
           python-version: "3.8"
       - run: |
-          python -m pip install autopep8 "black==19.10b0" "isort==5.7.0"
-          autopep8 --recursive --in-place --aggressive --aggressive .
-          black .
-          isort --profile black .
+          bash ./tests/run_code_style.sh install
+          bash ./tests/run_code_style.sh fmt
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -86,7 +86,7 @@ jobs:
         shell: bash -l {0}
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          pip install mypy
+           bash ./tests/run_code_style.sh install
           bash ./tests/run_code_style.sh mypy
 
       - name: Run Tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -79,17 +79,15 @@ jobs:
       - name: Check code formatting
         shell: bash -l {0}
         run: |
-          pip install flake8 "black==19.10b0" "isort==5.7.0"
-          flake8 ignite/ tests/ examples/
-          black --check .
-          isort -c --profile black .
+          bash ./tests/run_code_style.sh install
+          bash ./tests/run_code_style.sh lint
 
       - name: Run Mypy
         shell: bash -l {0}
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           pip install mypy
-          mypy --config-file mypy.ini
+          bash ./tests/run_code_style.sh mypy
 
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -86,7 +86,6 @@ jobs:
         shell: bash -l {0}
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-           bash ./tests/run_code_style.sh install
           bash ./tests/run_code_style.sh mypy
 
       - name: Run Tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,16 @@ repos:
     hooks:
       - id: black
         language_version: python3.8
+        args: ["--config", "pyproject.toml"]
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.7.0
     hooks:
       - id: isort
-        args: ["--profile", "black"]
+        args: ["--settings", "setup.cfg"]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8
-        args: [--append-config=tox.ini]
+        args: ["--config", "setup.cfg"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,11 +125,10 @@ If you choose not to use pre-commit, you can take advantage of IDE extensions co
 black manually to format files and commit them.
 
 ```bash
+# install required exact versions
+bash ./tests/run_code_style.sh install
 # This should autoformat the files
-black .
-isort --profile black .
-# Run lint checking
-flake8 ignite/ tests/ examples/
+bash ./tests/run_code_style.sh fmt
 # If everything is OK, then commit
 git add .
 git commit -m "Added awesome feature"
@@ -187,6 +186,7 @@ SKIP_DISTRIB_TESTS=1 bash tests/run_cpu_tests.sh
 ##### Run distributed tests only on CPU
 
 To run distributed tests only (assuming installed `pytest-xdist`):
+
 ```bash
 export WORLD_SIZE=2
 CUDA_VISIBLE_DEVICES="" pytest --dist=each --tx $WORLD_SIZE*popen//python=python tests/ -m distributed -vvv
@@ -197,7 +197,8 @@ CUDA_VISIBLE_DEVICES="" pytest --dist=each --tx $WORLD_SIZE*popen//python=python
 To run mypy to check the optional static type:
 
 ```bash
-mypy --config-file mypy.ini
+pip install mypy
+bash ./tests/run_code_style.sh mypy
 ```
 
 To change any config for specif folder, please see the file mypy.ini
@@ -215,11 +216,13 @@ If you are not familiar with creating a Pull Request, here are some guides:
 
 For example, typo changes in `CONTRIBUTING.md`, `README.md` are not required to run in the CI.
 So, please add `[skip ci]` in the PR title to save the resources. Ignite has setup 3 CIs.
+
 - GitHub Actions
 - CircleCI
 - Netlify
 
 CircleCI is disabled on forked PR. So, please add
+
 - `[skip actions]` for the changes which are not required to run on GitHub Actions,
 - `[skip netlify]` for the changes which are not required to run on Netlify PR Preview build, or
 - `[skip ci]` for the changes which are not required to run on any CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,8 @@ git clone https://github.com/pytorch/ignite.git
 cd ignite
 python setup.py develop
 pip install -r requirements-dev.txt
-pip install flake8 "black==19.10b0" "isort==5.7.0" mypy
+pip install mypy
+bash ./tests/run_code_style.sh install
 ```
 
 ### Code development
@@ -125,8 +126,6 @@ If you choose not to use pre-commit, you can take advantage of IDE extensions co
 black manually to format files and commit them.
 
 ```bash
-# install required exact versions
-bash ./tests/run_code_style.sh install
 # This should autoformat the files
 bash ./tests/run_code_style.sh fmt
 # If everything is OK, then commit
@@ -197,7 +196,6 @@ CUDA_VISIBLE_DEVICES="" pytest --dist=each --tx $WORLD_SIZE*popen//python=python
 To run mypy to check the optional static type:
 
 ```bash
-pip install mypy
 bash ./tests/run_code_style.sh mypy
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,6 @@ git clone https://github.com/pytorch/ignite.git
 cd ignite
 python setup.py develop
 pip install -r requirements-dev.txt
-pip install mypy
 bash ./tests/run_code_style.sh install
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ use_parentheses=True
 line_length=120
 skip_glob=docs/**
 filter_files=True
+profile=black
 
 [flake8]
 max-line-length = 120

--- a/tests/run_code_style.sh
+++ b/tests/run_code_style.sh
@@ -13,5 +13,5 @@ elif [ $1 = "fmt" ]; then
 elif [ $1 = "mypy" ]; then
     mypy --config-file mypy.ini
 elif [ $1 = "install" ]; then
-    pip install flake8 "black==19.10b0" "isort==5.7.0"
+    pip install flake8 "black==19.10b0" "isort==5.7.0" mypy
 fi

--- a/tests/run_code_style.sh
+++ b/tests/run_code_style.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -xeu
+
+if [ $1 = "lint" ]; then
+    flake8 ignite tests examples --config setup.cfg
+    isort . --check --settings setup.cfg
+    black . --check --config pyproject.toml
+elif [ $1 = "fmt" ]; then
+    flake8 ignite tests examples --config setup.cfg
+    isort . --settings setup.cfg
+    black . --config pyproject.toml
+elif [ $1 = "mypy" ]; then
+    mypy --config-file mypy.ini
+elif [ $1 = "install" ]; then
+    pip install flake8 "black==19.10b0" "isort==5.7.0"
+fi


### PR DESCRIPTION
Description: For those who don't use pre-commit and IDE extensions, a bash script for code formatting. And adding same args used in `unit-test` in `pre-commit`

The rest files are modified by pre-commit.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
