### PR TITLE
Reduce tolerence FB

### DIFF
--- a/tests/ignite/contrib/metrics/regression/test_fractional_bias.py
+++ b/tests/ignite/contrib/metrics/regression/test_fractional_bias.py
@@ -115,7 +115,7 @@ def test_error_is_not_nan():
     assert not (torch.isnan(m._sum_of_errors).any() or torch.isinf(m._sum_of_errors).any()), m._sum_of_errors
 
 
-def _test_distrib_compute(device, tol=1e-6):
+def _test_distrib_compute(device, tol=1e-5):
     rank = idist.get_rank()
 
     def _test(metric_device):
@@ -149,7 +149,7 @@ def _test_distrib_compute(device, tol=1e-6):
             _test(idist.device())
 
 
-def _test_distrib_integration(device, tol=1e-6):
+def _test_distrib_integration(device, tol=1e-5):
 
     rank = idist.get_rank()
     torch.manual_seed(12)


### PR DESCRIPTION
Reduce the tolerence for FB to `1e-5`.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
