### PR TITLE
Add output detach for Canberra metric

### DIFF
--- a/ignite/contrib/metrics/regression/canberra_metric.py
+++ b/ignite/contrib/metrics/regression/canberra_metric.py
@@ -48,7 +48,7 @@ class CanberraMetric(_BaseRegression):
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
 
     def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
-        y_pred, y = output
+        y_pred, y = output[0].detach(), output[1].detach()
         errors = torch.abs(y - y_pred) / (torch.abs(y_pred) + torch.abs(y) + 1e-15)
         self._sum_of_errors += torch.sum(errors).to(self._device)
 


### PR DESCRIPTION
Add `output.detach()` in `CanberraMetric`

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
