### PR TITLE
fix: run `test_auto_methods_nccl` if ws > 1 (#1842)

### DIFF
--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -158,8 +158,9 @@ def test_auto_methods_nccl(distributed_context_single_node_nccl):
 
     _test_auto_model_optimizer(ws, "cuda")
 
-    with pytest.raises(ValueError, match=r"Argument kwargs should not contain 'device_ids'"):
-        _test_auto_model(nn.Linear(1, 1), ws, "cpu", device_ids=1)
+    if ws > 1:
+        with pytest.raises(ValueError, match=r"Argument kwargs should not contain 'device_ids'"):
+            auto_model(nn.Linear(1, 1), device_ids=[0])
 
 
 @pytest.mark.distributed


### PR DESCRIPTION
Original PR : #1842 by @ydcjeff 

* fix: run test_auto_methods_nccl if ws > 1

* chore: use auto_model instead of _test_auto_model

Fixes #{issue number}

Description:

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
