### PR TITLE
docs: suppress warning for about page using :orphan: [skip ci]

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 About us
 ========
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -151,5 +151,5 @@ Library structure
    :maxdepth: 1
    :caption: Team
 
-   about <https://pytorch.org/ignite/master/about.html>
+   About us <https://pytorch.org/ignite/master/about.html>
    governance


### PR DESCRIPTION
Fixes failing `linkcheck` job

Description: Added sphinx directive `:orphan:` at the top of about page to suppress warning.
[More about orphaned pages](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingReST/Orphans.html)

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
