### PR TITLE
fix: call `.cpu()` before `.numpy()`, use cuda device 0

### DIFF
--- a/tests/ignite/metrics/test_psnr.py
+++ b/tests/ignite/metrics/test_psnr.py
@@ -44,11 +44,11 @@ def _test_psnr(y_pred, y, data_range, device):
     assert isinstance(psnr_compute, torch.Tensor)
     assert psnr_compute.dtype == torch.float64
     assert psnr_compute.device == torch.device(device)
-    assert np.allclose(psnr_compute.numpy(), np_psnr / np_y.shape[0])
+    assert np.allclose(psnr_compute.cpu().numpy(), np_psnr / np_y.shape[0])
 
 
 def test_psnr():
-    device = idist.device()
+    device = "cuda" if torch.cuda.is_available() else "cpu"
 
     # test for float
     manual_seed(42)

--- a/tests/ignite/metrics/test_psnr.py
+++ b/tests/ignite/metrics/test_psnr.py
@@ -48,14 +48,14 @@ def _test_psnr(y_pred, y, data_range, device):
 
 
 def test_psnr():
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
     # test for float
     manual_seed(42)
     y_pred = torch.rand(8, 3, 28, 28, device=device)
     y = y_pred * 0.8
     data_range = (y.max() - y.min()).cpu().item()
-    _test_psnr(y_pred, y, y.max() - y.min(), device)
+    _test_psnr(y_pred, y, data_range, device)
 
     # test for YCbCr
     manual_seed(42)

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -90,7 +90,7 @@ def _test_ssim(y_pred, y, data_range, kernel_size, sigma, gaussian, use_sample_c
     assert isinstance(ignite_ssim, torch.Tensor)
     assert ignite_ssim.dtype == torch.float64
     assert ignite_ssim.device == torch.device(device)
-    assert np.allclose(ignite_ssim.numpy(), skimg_ssim, atol=atol)
+    assert np.allclose(ignite_ssim.cpu().numpy(), skimg_ssim, atol=atol)
 
 
 def test_ssim():

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -94,7 +94,7 @@ def _test_ssim(y_pred, y, data_range, kernel_size, sigma, gaussian, use_sample_c
 
 
 def test_ssim():
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
     y_pred = torch.rand(8, 3, 224, 224, device=device)
     y = y_pred * 0.8
     _test_ssim(


### PR DESCRIPTION
Fixes #1851 

Description:
- Call `.cpu` before `.numpy()`
- Force use `cuda:0`

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
