### PR TITLE
fix `Scheduled workflow failed` error

### DIFF
--- a/tests/ignite/engine/test_create_supervised.py
+++ b/tests/ignite/engine/test_create_supervised.py
@@ -460,35 +460,32 @@ def test_create_supervised_trainer_on_cuda_with_model_on_cpu():
 def test_create_supervised_evaluator():
     _test_create_supervised_evaluator()
     _test_mocked_supervised_evaluator()
-    try:
-        # older versions didn't have the autocast method so we skip the test
+
+    # older versions didn't have the autocast method so we skip the test for older builds
+    if LooseVersion(torch.__version__) > LooseVersion("1.6.0"):
         with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
             _test_create_evaluation_step_amp(mock_torch_cuda_amp_module)
-    except AttributeError:
-        pass
 
 
 def test_create_supervised_evaluator_on_cpu():
     _test_create_supervised_evaluator(evaluator_device="cpu")
     _test_mocked_supervised_evaluator(evaluator_device="cpu")
-    try:
-        # older versions didn't have the autocast method so we skip the test
+
+    # older versions didn't have the autocast method so we skip the test for older builds
+    if LooseVersion(torch.__version__) > LooseVersion("1.6.0"):
         with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
             _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu")
             _test_create_evaluation_step_amp(mock_torch_cuda_amp_module, evaluator_device="cpu")
-    except AttributeError:
-        pass
 
 
 def test_create_supervised_evaluator_traced_on_cpu():
     _test_create_supervised_evaluator(evaluator_device="cpu", trace=True)
     _test_mocked_supervised_evaluator(evaluator_device="cpu", trace=True)
-    try:
-        # older versions didn't have the autocast method so we skip the test
+
+    # older versions didn't have the autocast method so we skip the test for older builds
+    if LooseVersion(torch.__version__) > LooseVersion("1.6.0"):
         with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
             _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu", trace=True)
-    except AttributeError:
-        pass
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU")

--- a/tests/ignite/engine/test_create_supervised.py
+++ b/tests/ignite/engine/test_create_supervised.py
@@ -460,23 +460,35 @@ def test_create_supervised_trainer_on_cuda_with_model_on_cpu():
 def test_create_supervised_evaluator():
     _test_create_supervised_evaluator()
     _test_mocked_supervised_evaluator()
-    with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
-        _test_create_evaluation_step_amp(mock_torch_cuda_amp_module)
+    try:
+        # older versions didn't have the autocast method so we skip the test
+        with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
+            _test_create_evaluation_step_amp(mock_torch_cuda_amp_module)
+    except AttributeError:
+        pass
 
 
 def test_create_supervised_evaluator_on_cpu():
     _test_create_supervised_evaluator(evaluator_device="cpu")
     _test_mocked_supervised_evaluator(evaluator_device="cpu")
-    with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
-        _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu")
-        _test_create_evaluation_step_amp(mock_torch_cuda_amp_module, evaluator_device="cpu")
+    try:
+        # older versions didn't have the autocast method so we skip the test
+        with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
+            _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu")
+            _test_create_evaluation_step_amp(mock_torch_cuda_amp_module, evaluator_device="cpu")
+    except AttributeError:
+        pass
 
 
 def test_create_supervised_evaluator_traced_on_cpu():
     _test_create_supervised_evaluator(evaluator_device="cpu", trace=True)
     _test_mocked_supervised_evaluator(evaluator_device="cpu", trace=True)
-    with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
-        _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu", trace=True)
+    try:
+        # older versions didn't have the autocast method so we skip the test
+        with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
+            _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu", trace=True)
+    except AttributeError:
+        pass
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU")

--- a/tests/ignite/engine/test_create_supervised.py
+++ b/tests/ignite/engine/test_create_supervised.py
@@ -462,7 +462,7 @@ def test_create_supervised_evaluator():
     _test_mocked_supervised_evaluator()
 
     # older versions didn't have the autocast method so we skip the test for older builds
-    if LooseVersion(torch.__version__) > LooseVersion("1.6.0"):
+    if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
         with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
             _test_create_evaluation_step_amp(mock_torch_cuda_amp_module)
 
@@ -472,7 +472,7 @@ def test_create_supervised_evaluator_on_cpu():
     _test_mocked_supervised_evaluator(evaluator_device="cpu")
 
     # older versions didn't have the autocast method so we skip the test for older builds
-    if LooseVersion(torch.__version__) > LooseVersion("1.6.0"):
+    if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
         with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
             _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu")
             _test_create_evaluation_step_amp(mock_torch_cuda_amp_module, evaluator_device="cpu")
@@ -483,7 +483,7 @@ def test_create_supervised_evaluator_traced_on_cpu():
     _test_mocked_supervised_evaluator(evaluator_device="cpu", trace=True)
 
     # older versions didn't have the autocast method so we skip the test for older builds
-    if LooseVersion(torch.__version__) > LooseVersion("1.6.0"):
+    if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
         with mock.patch("torch.cuda.amp.autocast") as mock_torch_cuda_amp_module:
             _test_create_evaluation_step(mock_torch_cuda_amp_module, evaluator_device="cpu", trace=True)
 


### PR DESCRIPTION
Fixes #1852

Description: One of the workflows were failing because the old versions didn't have the autocast method - https://github.com/pytorch/ignite/runs/2171095975?check_suite_focus=true - 
To allow backward compatibility I've added a try block to catch that attribute error so that it won't break the tests for the older versions.


Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
