### PR TITLE
chore: remove env.GITHUB_JOB [skip ci]

### DIFF
--- a/.github/failed_schedule_issue_template.md
+++ b/.github/failed_schedule_issue_template.md
@@ -4,7 +4,7 @@ labels:
   - bug
 ---
 
-Oh no, something went wrong in the scheduled workflow **{{ env.GITHUB_WORKFLOW }}/{{ env.GITHUB_JOB }} with commit {{ env.GITHUB_SHA }}**.
+Oh no, something went wrong in the scheduled workflow **{{ env.GITHUB_WORKFLOW }} with commit {{ env.GITHUB_SHA }}**.
 Please look into it:
 
 {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}


### PR DESCRIPTION
Remove `env.GITHUB_JOB` as there are two jobs in `PyTorch Version tests` workflow.
Otherwise created issue description is misleading. For example, see `PyTorch version tests/create-issue` in #1871, the real failing job is `build` not `create-issue`

Description:

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
