### PR TITLE
Added full read permissions to saved file (1876)

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -1,6 +1,7 @@
 import collections.abc as collections
 import numbers
 import os
+import stat
 import tempfile
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -708,7 +709,9 @@ class DiskSaver(BaseSaveHandler):
             else:
                 if tmp is not None:
                     tmp.close()
-                    os.rename(tmp.name, path)
+                    os.replace(tmp.name, path)
+                    # append group/others read mode
+                    os.chmod(path, os.stat(path).st_mode | stat.S_IRGRP | stat.S_IROTH)
 
     @idist.one_rank_only()
     def remove(self, filename: str) -> None:

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import warnings
 from collections import OrderedDict
 from unittest.mock import MagicMock
@@ -581,6 +582,12 @@ def test_disk_saver_atomic(dirname):
             pass
         fp = os.path.join(saver.dirname, fname)
         assert os.path.exists(fp) == expected
+
+        if expected:
+            # related to https://github.com/pytorch/ignite/issues/1876
+            mode = stat.filemode(os.stat(fp).st_mode)
+            assert [mode[1], mode[4], mode[7]] == ["r", "r", "r"], mode
+
         if expected:
             saver.remove(fname)
 


### PR DESCRIPTION
Fixes #1876 

Description:
- Added full read rights to saved file when atomic=True

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
