### PR TITLE
Fix MAPE test for GPU failure

### DIFF
--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -135,7 +135,7 @@ def _test_distrib_compute(device):
         np_res = 100.0 * np.median(e)
 
         e_prepend = np.insert(e, 0, e[0], axis=0)
-        np_res_prepend = 100.0 * np.median(e)
+        np_res_prepend = 100.0 * np.median(e_prepend)
 
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.
@@ -185,7 +185,7 @@ def _test_distrib_integration(device):
         np_res = 100.0 * np.median(e)
 
         e_prepend = np.insert(e, 0, e[0], axis=0)
-        np_res_prepend = 100.0 * np.median(e)
+        np_res_prepend = 100.0 * np.median(e_prepend)
 
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -138,7 +138,6 @@ def _test_distrib_compute(device):
 
         np_res_prepend = 100.0 * np.median(e_prepend)
 
-
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -135,7 +135,6 @@ def _test_distrib_compute(device):
         np_res = 100.0 * np.median(e)
 
         e_prepend = np.insert(e, 0, e[0], axis=0)
-
         np_res_prepend = 100.0 * np.median(e_prepend)
 
         # The results between numpy.median() and torch.median() are Inconsistant
@@ -189,7 +188,6 @@ def _test_distrib_integration(device):
         np_res = 100.0 * np.median(e)
 
         e_prepend = np.insert(e, 0, e[0], axis=0)
-
         np_res_prepend = 100.0 * np.median(e_prepend)
 
         # The results between numpy.median() and torch.median() are Inconsistant

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -126,20 +126,21 @@ def _test_distrib_compute(device):
         y_pred = idist.all_gather(y_pred)
         y = idist.all_gather(y)
 
-        np_y_pred = y_pred.cpu().numpy()
-        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy().ravel()
+        np_y = y.cpu().numpy().ravel()
 
         res = m.compute()
 
-        e = torch.abs(y - y_pred) / torch.abs(y)
-        np_res_like_torch = 100.0 * np.median(e.cpu().numpy())
+        e = np.abs(np_y - np_y_pred) / np.abs(np_y)
+        np_res = 100.0 * np.median(e)
 
-        np_res = 100.0 * np.median(np.abs(np_y - np_y_pred) / np.abs(np_y))
+        e_prepend = np.insert(e, 0, e[0], axis=0)
+        np_res_prepend = 100.0 * np.median(e)
 
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837
-        assert pytest.approx(res) in (np_res, np_res_like_torch)
+        assert pytest.approx(res) in (np_res, np_res_prepend)
 
     for _ in range(3):
         _test("cpu")
@@ -177,18 +178,19 @@ def _test_distrib_integration(device):
 
         res = engine.state.metrics["mape"]
 
-        np_y_true = y_true.cpu().numpy()
-        np_y_preds = y_preds.cpu().numpy()
+        np_y_true = y_true.cpu().numpy().ravel()
+        np_y_preds = y_preds.cpu().numpy().ravel()
 
-        np_res = 100.0 * np.median(np.abs(np_y_true - np_y_preds) / np.abs(np_y_true))
+        e = np.abs(np_y_true - np_y_preds) / np.abs(np_y_true)
+        np_res = 100.0 * np.median(e)
 
-        e = torch.abs(y_true - y_preds) / torch.abs(y_true)
-        np_res_like_torch = 100.0 * np.median(e.cpu().numpy())
+        e_prepend = np.insert(e, 0, e[0], axis=0)
+        np_res_prepend = 100.0 * np.median(e)
 
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837
-        assert pytest.approx(res) in (np_res, np_res_like_torch)
+        assert pytest.approx(res) in (np_res, np_res_prepend)
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -140,7 +140,10 @@ def _test_distrib_compute(device):
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837
-        assert pytest.approx(res) in (np_res, np_res_prepend)
+        if np_y_pred.shape[0] % 2 == 0:
+            assert pytest.approx(res) == np_res_prepend
+        else:
+            assert pytest.approx(res) == np_res
 
     for _ in range(3):
         _test("cpu")
@@ -190,7 +193,10 @@ def _test_distrib_integration(device):
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837
-        assert pytest.approx(res) in (np_res, np_res_prepend)
+        if np_y_preds.shape[0] % 2 == 0:
+            assert pytest.approx(res) == np_res_prepend
+        else:
+            assert pytest.approx(res) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":


### PR DESCRIPTION
Add a hack to avoid results inconsistency between `np.median()` and `torch.median()`
Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
