### PR TITLE
Improve `MRAE` for DDP

### DIFF
--- a/ignite/contrib/metrics/regression/median_relative_absolute_error.py
+++ b/ignite/contrib/metrics/regression/median_relative_absolute_error.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Union
 
 import torch
 
@@ -37,7 +37,12 @@ class MedianRelativeAbsoluteError(EpochMetric):
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
             By default, metrics require the output as ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``.
+        device: optional device specification for internal storage.
     """
 
-    def __init__(self, output_transform: Callable = lambda x: x):
-        super(MedianRelativeAbsoluteError, self).__init__(median_relative_absolute_error_compute_fn, output_transform)
+    def __init__(
+        self, output_transform: Callable = lambda x: x, device: Union[str, torch.device] = torch.device("cpu")
+    ):
+        super(MedianRelativeAbsoluteError, self).__init__(
+            median_relative_absolute_error_compute_fn, output_transform=output_transform, device=device
+        )

--- a/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
@@ -132,17 +132,16 @@ def _test_distrib_compute(device):
         res = m.compute()
 
         e = np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())
-        np_res = np.median(e)
-
-        e_prepend = np.insert(e, 0, e[0], axis=0)
-        np_res_prepend = np.median(e_prepend)
 
         # The results between numpy.median() and torch.median() are Inconsistant
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837
         if np_y_pred.shape[0] % 2 == 0:
+            e_prepend = np.insert(e, 0, e[0], axis=0)
+            np_res_prepend = np.median(e_prepend)
             assert pytest.approx(res) == np_res_prepend
         else:
+            np_res = np.median(e)
             assert pytest.approx(res) == np_res
 
     for _ in range(3):

--- a/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
@@ -1,7 +1,10 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 
+import ignite.distributed as idist
 from ignite.contrib.metrics.regression import MedianRelativeAbsoluteError
 from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
@@ -102,3 +105,174 @@ def test_integration_median_relative_absolute_error_with_output_transform():
     median_absolute_relative_error = engine.run(data, max_epochs=1).metrics["median_absolute_relative_error"]
 
     assert np_median_absolute_relative_error == pytest.approx(median_absolute_relative_error)
+
+
+def _test_distrib_compute(device):
+    rank = idist.get_rank()
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        m = MedianRelativeAbsoluteError(device=metric_device)
+        torch.manual_seed(10 + rank)
+
+        size = 151
+
+        y_pred = torch.randint(1, 10, size=(size, 1), dtype=torch.double, device=device)
+        y = torch.randint(1, 10, size=(size, 1), dtype=torch.double, device=device)
+
+        m.update((y_pred, y))
+
+        # gather y_pred, y
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y_pred = y_pred.cpu().numpy().ravel()
+        np_y = y.cpu().numpy().ravel()
+
+        res = m.compute()
+
+        e = np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())
+        np_res = np.median(e)
+
+        e_prepend = np.insert(e, 0, e[0], axis=0)
+        np_res_prepend = np.median(e_prepend)
+
+        # The results between numpy.median() and torch.median() are Inconsistant
+        # when the length of the array/tensor is even. So this is a hack to avoid that.
+        # issue: https://github.com/pytorch/pytorch/issues/1837
+        if np_y_pred.shape[0] % 2 == 0:
+            assert pytest.approx(res) == np_res_prepend
+        else:
+            assert pytest.approx(res) == np_res
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+def _test_distrib_integration(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        size = 151
+        y_true = torch.rand(size=(size,)).to(device)
+        y_preds = torch.rand(size=(size,)).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * size : (i + 1) * size],
+                y_true[i * size : (i + 1) * size],
+            )
+
+        engine = Engine(update)
+
+        m = MedianRelativeAbsoluteError(device=metric_device)
+        m.attach(engine, "mare")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "mare" in engine.state.metrics
+
+        res = engine.state.metrics["mare"]
+
+        np_y_true = y_true.cpu().numpy().ravel()
+        np_y_preds = y_preds.cpu().numpy().ravel()
+
+        e = np.abs(np_y_true - np_y_preds) / np.abs(np_y_true - np_y_true.mean())
+        np_res = np.median(e)
+
+        e_prepend = np.insert(e, 0, e[0], axis=0)
+        np_res_prepend = np.median(e_prepend)
+
+        # The results between numpy.median() and torch.median() are Inconsistant
+        # when the length of the array/tensor is even. So this is a hack to avoid that.
+        # issue: https://github.com/pytorch/pytorch/issues/1837
+        if np_y_preds.shape[0] % 2 == 0:
+            assert pytest.approx(res) == np_res_prepend
+        else:
+            assert pytest.approx(res) == np_res
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_gpu(distributed_context_single_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_single_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_cpu(distributed_context_single_node_gloo):
+
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration, (device,), np=nproc, do_init=True)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_cpu(distributed_context_multi_node_gloo):
+    device = torch.device("cpu")
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gpu(distributed_context_multi_node_nccl):
+    device = torch.device(f"cuda:{distributed_context_multi_node_nccl['local_rank']}")
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)

--- a/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
@@ -187,16 +187,7 @@ def _test_distrib_integration(device):
         e = np.abs(np_y_true - np_y_preds) / np.abs(np_y_true - np_y_true.mean())
         np_res = np.median(e)
 
-        e_prepend = np.insert(e, 0, e[0], axis=0)
-        np_res_prepend = np.median(e_prepend)
-
-        # The results between numpy.median() and torch.median() are Inconsistant
-        # when the length of the array/tensor is even. So this is a hack to avoid that.
-        # issue: https://github.com/pytorch/pytorch/issues/1837
-        if np_y_preds.shape[0] % 2 == 0:
-            assert pytest.approx(res) == np_res_prepend
-        else:
-            assert pytest.approx(res) == np_res
+        assert pytest.approx(res) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":


### PR DESCRIPTION
Improving `MedianRelativeAbsoluteError` implementation to be compatible with DDP and add the necessary tests.

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
