### PR TITLE
Remove TODO from engine.py

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -807,6 +807,7 @@ class Engine(Serializable):
                 )
 
             while True:
+                self.state.batch = self.state.output = None
                 try:
                     # Avoid Events.GET_BATCH_STARTED triggered twice when data iter is restarted
                     if self.last_event_name != Events.DATALOADER_STOP_ITERATION:
@@ -851,9 +852,6 @@ class Engine(Serializable):
                 self._fire_event(Events.ITERATION_STARTED)
                 self.state.output = self._process_function(self, self.state.batch)
                 self._fire_event(Events.ITERATION_COMPLETED)
-
-                # TODO: remove refs on batch to avoid high mem consumption ? -> need verification
-                # self.state.batch = None
 
                 if self.should_terminate or self.should_terminate_single_epoch:
                     self._fire_event(Events.TERMINATE_SINGLE_EPOCH, iter_counter=iter_counter)

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -938,7 +938,7 @@ def test_is_done_with_max_iters():
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-def test_batch_is_released_before_new_one_is_loaded_cuda():
+def test_batch_is_released_before_new_one_is_loaded_on_cuda():
     torch.cuda.empty_cache()
 
     engine = Engine(lambda e, b: None)

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -967,7 +967,7 @@ def test_batch_is_released_before_new_one_is_loaded_on_cuda():
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-def test_output_is_released_before_new_one_is_assigned_cuda():
+def test_output_is_released_before_new_one_is_assigned_on_cuda():
     torch.cuda.empty_cache()
 
     def _test():


### PR DESCRIPTION
I tested this - no change in GPU memory consumption regardless of whether the deleted line is uncommented or not.

When the batch is getting assigned to it lives in computer RAM, it only gets moved to `device` later. Meaning, the only memory that would be consumed here and not freed up would be computer RAM. From a design perspective, I am not sure that having `output.batch` set to None and having this additional line here would be worth it to collect whatever memory a single batch occupies.

But if that is something that would be believed to be worth it, I can run some tests to see what difference it makes wrt computer RAM consumption and report here.