### PR TITLE
enable metric ordering on ProgressBar

### DIFF
--- a/ignite/contrib/handlers/base_logger.py
+++ b/ignite/contrib/handlers/base_logger.py
@@ -85,7 +85,7 @@ class BaseOutputHandler(BaseHandler):
         metrics = OrderedDict()
         if self.metric_names is not None:
             if isinstance(self.metric_names, str) and self.metric_names == "all":
-                metrics = engine.state.metrics
+                metrics = OrderedDict(engine.state.metrics)
             else:
                 for name in self.metric_names:
                     if name not in engine.state.metrics:

--- a/ignite/contrib/handlers/base_logger.py
+++ b/ignite/contrib/handlers/base_logger.py
@@ -2,6 +2,7 @@
 import numbers
 import warnings
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import torch
@@ -81,7 +82,7 @@ class BaseOutputHandler(BaseHandler):
     def _setup_output_metrics(self, engine: Engine) -> Dict[str, Any]:
         """Helper method to setup metrics to log
         """
-        metrics = {}
+        metrics = OrderedDict()
         if self.metric_names is not None:
             if isinstance(self.metric_names, str) and self.metric_names == "all":
                 metrics = engine.state.metrics

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -285,7 +285,7 @@ class _OutputHandler(BaseOutputHandler):
                 rendered_metrics[key] = value
 
         if rendered_metrics:
-            logger.pbar.set_postfix(**rendered_metrics)  # type: ignore[attr-defined]
+            logger.pbar.set_postfix(rendered_metrics)  # type: ignore[attr-defined]
 
         global_step = engine.state.get_event_attrib_value(event_name)
         if pbar_total is not None:

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """TQDM logger."""
 import warnings
+from collections import OrderedDict
 from typing import Any, Callable, List, Optional, Union
 
 import torch
@@ -270,7 +271,7 @@ class _OutputHandler(BaseOutputHandler):
 
         metrics = self._setup_output_metrics(engine)
 
-        rendered_metrics = {}
+        rendered_metrics = OrderedDict()
         for key, value in metrics.items():
             if isinstance(value, torch.Tensor):
                 if value.ndimension() == 0:

--- a/tests/ignite/contrib/handlers/test_tqdm_logger.py
+++ b/tests/ignite/contrib/handlers/test_tqdm_logger.py
@@ -203,9 +203,9 @@ def test_pbar_with_all_metric(capsys):
     err = list(filter(None, err))
     actual = err[-1]
     if get_tqdm_version() < LooseVersion("4.49.0"):
-        expected = "Iteration: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<00:00]"
+        expected = "Iteration: [1/2]  50%|█████     , batchloss=0.5, another batchloss=1.5 [00:00<00:00]"
     else:
-        expected = "Iteration: [1/2]  50%|█████     , another batchloss=1.5, batchloss=0.5 [00:00<?]"
+        expected = "Iteration: [1/2]  50%|█████     , batchloss=0.5, another batchloss=1.5 [00:00<?]"
     assert actual == expected
 
 


### PR DESCRIPTION
**Description**: 

This allows for ordering of metrics on ProgressBar. The metrics will be displayed in the order that they are attached to the `Engine`.

I have not done any of the tasks from the checklist as I am not sure they are applicable here - happy to work on them if any would be needed!

Additional details on this change: #1936 

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
