### PR TITLE
Fix for tpu test failure CI job

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           
           ## Install openblas, mkl, gsutil
+          sudo apt-get install -y libomp5-10
           sudo apt-get install -y libopenblas-dev libomp5
           pip install mkl requests gsutil
 

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -53,8 +53,7 @@ jobs:
         run: |
           
           ## Install openblas, mkl, gsutil
-          sudo apt-get install -y libomp5-10
-          sudo apt-get install -y libopenblas-dev libomp5
+          sudo apt-get install -y libopenblas-dev libomp5-10 libomp5
           pip install mkl requests gsutil
 
           ## Install torch & xla


### PR DESCRIPTION

Description:

All tpu tests are failing on PRs and master due to the following exception

`The following packages have unmet dependencies:
 libomp5 : Depends: libomp5-10 (>= 10~) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
Error: Process completed with exit code 100.`

For example here https://github.com/pytorch/ignite/pull/1887/checks?check_run_id=2345750111

I am investigating if this change can fix the issue.



Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
