### PR TITLE
feat: set seed for xla in ignite.utils.manual_seed

### DIFF
--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -177,6 +177,9 @@ def manual_seed(seed: int) -> None:
 
     .. versionchanged:: 0.4.3
         Added ``torch.cuda.manual_seed_all(seed)``.
+
+    .. versionchanged:: 0.5.1
+        Added ``torch_xla.core.xla_model.set_rng_state(seed)``.
     """
     random.seed(seed)
     torch.manual_seed(seed)

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -185,6 +185,13 @@ def manual_seed(seed: int) -> None:
         torch.cuda.manual_seed_all(seed)
 
     try:
+        import torch_xla.core.xla_model as xm
+
+        xm.set_rng_state(seed)
+    except ImportError:
+        pass
+
+    try:
         import numpy as np
 
         np.random.seed(seed)


### PR DESCRIPTION
### Description

fix #1969 

- Added `torch_xla.core.xla_model.set_rng_state(seed)` if `torch_xla` is importable.
- Test is not needed since it will be run in metrics integration tests.
- Added version changed docs.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
