### PR TITLE
[Pytorch-nightly] Update dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,3 +25,4 @@ nltk
 # Examples dependencies
 pandas
 gym
+mkl


### PR DESCRIPTION
Description:

I noticed that recently some of the pytorch-nightly builds were failing with the error

`ERROR  - OSError: libmkl_intel_lp64.so.1: cannot open shared object file: No ...`
for example here https://github.com/pytorch/ignite/pull/1758/checks?check_run_id=2442186485

I found out that we need to update the dependencies as in here https://github.com/pytorch/xla/issues/1666

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
