### PR TITLE
give an option to store `EpochOutputStore` data on `engine.state`

### DIFF
--- a/ignite/contrib/handlers/stores.py
+++ b/ignite/contrib/handlers/stores.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 from ignite.engine import Engine, Events
 
@@ -45,8 +45,15 @@ class EpochOutputStore:
         output = self.output_transform(engine.state.output)
         self.data.append(output)
 
-    def attach(self, engine: Engine) -> None:
+    def store(self, engine: Engine) -> None:
+        """Store `self.data` on `engine.state.{self.name}`"""
+        setattr(engine.state, self.name, self.data)
+
+    def attach(self, engine: Engine, name: Optional[str] = None) -> None:
         """Attaching `reset` method at EPOCH_STARTED and
         `update` method at ITERATION_COMPLETED."""
         engine.add_event_handler(Events.EPOCH_STARTED, self.reset)
         engine.add_event_handler(Events.ITERATION_COMPLETED, self.update)
+        if name:
+            self.name = name
+            engine.add_event_handler(Events.EPOCH_COMPLETED, self.store)

--- a/ignite/contrib/handlers/stores.py
+++ b/ignite/contrib/handlers/stores.py
@@ -21,12 +21,12 @@ class EpochOutputStore:
         eos = EpochOutputStore()
         trainer = create_supervised_trainer(model, optimizer, loss)
         train_evaluator = create_supervised_evaluator(model, metrics)
-        eos.attach(train_evaluator)
+        eos.attach(train_evaluator, 'output')
 
         @trainer.on(Events.EPOCH_COMPLETED)
         def log_training_results(engine):
             train_evaluator.run(train_loader)
-            output = eos.data
+            output = train_evaluator.output
             # do something with output, e.g., plotting
 
     .. versionadded:: 0.4.2

--- a/ignite/contrib/handlers/stores.py
+++ b/ignite/contrib/handlers/stores.py
@@ -30,6 +30,8 @@ class EpochOutputStore:
             # do something with output, e.g., plotting
 
     .. versionadded:: 0.4.2
+    .. versionchanged:: 0.5.0
+        `attach` now accepts an optional argument `name`
     """
 
     def __init__(self, output_transform: Callable = lambda x: x):
@@ -51,7 +53,11 @@ class EpochOutputStore:
 
     def attach(self, engine: Engine, name: Optional[str] = None) -> None:
         """Attaching `reset` method at EPOCH_STARTED and
-        `update` method at ITERATION_COMPLETED."""
+        `update` method at ITERATION_COMPLETED.
+
+        If `name` is passed, will store `self.data` on `engine.state`
+        under `name`.
+        """
         engine.add_event_handler(Events.EPOCH_STARTED, self.reset)
         engine.add_event_handler(Events.ITERATION_COMPLETED, self.update)
         if name:

--- a/tests/ignite/contrib/handlers/test_stores.py
+++ b/tests/ignite/contrib/handlers/test_stores.py
@@ -25,7 +25,7 @@ def test_no_transform(dummy_evaluator, eos):
     assert eos.data == [(1, 0)]
 
 
-def test_tranform(dummy_evaluator):
+def test_transform(dummy_evaluator):
     eos = EpochOutputStore(output_transform=lambda x: x[0])
     eos.attach(dummy_evaluator)
 

--- a/tests/ignite/contrib/handlers/test_stores.py
+++ b/tests/ignite/contrib/handlers/test_stores.py
@@ -56,3 +56,9 @@ def test_attatch(dummy_evaluator, eos):
     eos.attach(dummy_evaluator)
     assert dummy_evaluator.has_event_handler(eos.reset, Events.EPOCH_STARTED)
     assert dummy_evaluator.has_event_handler(eos.update, Events.ITERATION_COMPLETED)
+
+
+def test_store_data(dummy_evaluator, eos):
+    eos.attach(dummy_evaluator, name="eval_data")
+    dummy_evaluator.run(range(1))
+    assert dummy_evaluator.state.eval_data == eos.data


### PR DESCRIPTION
Implements #1939

Description: When `EpochOutputStore` is attached and a `name` is provided, at `EPOCH_COMPLETED` `engine.state.{name}` is set to `eos.data` (in other words, `eos.data` is stored on `engine.state`).

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
