### PR TITLE
Extend `plot` method in LRFinder for multiple `param_groups`

### DIFF
--- a/tests/ignite/contrib/handlers/test_lr_finder.py
+++ b/tests/ignite/contrib/handlers/test_lr_finder.py
@@ -37,10 +37,35 @@ class DummyModel(nn.Module):
         return self.net(x)
 
 
+class DummyModelMulipleParamGroups(nn.Module):
+    def __init__(self):
+        super(DummyModelMulipleParamGroups, self).__init__()
+        self.fc1 = nn.Linear(10, 20)
+        self.fc2 = nn.Linear(20, 10)
+        self.fc3 = nn.Linear(10, 10)
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        return self.fc3(x)
+
+
 @pytest.fixture
 def model():
     model = DummyModel()
     yield model
+
+
+@pytest.fixture
+def model_single_param_groups():
+    model = DummyModel(out_channels=10)
+    yield model
+
+
+@pytest.fixture
+def model_multiple_param_groups():
+    model_multiple_param_groups = DummyModelMulipleParamGroups()
+    yield model_multiple_param_groups
 
 
 @pytest.fixture
@@ -55,6 +80,18 @@ def optimizer(model):
 
 
 @pytest.fixture
+def optimizer_mulitple_param_groups(model_multiple_param_groups):
+    optimizer_mulitple_param_groups = SGD(
+        [
+            {"params": model_multiple_param_groups.fc1.parameters(), "lr": 4e-1},
+            {"params": model_multiple_param_groups.fc2.parameters(), "lr": 3e-2},
+            {"params": model_multiple_param_groups.fc3.parameters(), "lr": 3e-3},
+        ]
+    )
+    yield optimizer_mulitple_param_groups
+
+
+@pytest.fixture
 def mnist_optimizer(mnist_model):
     yield SGD(mnist_model.parameters(), lr=1e-4, momentum=0.0)
 
@@ -62,6 +99,16 @@ def mnist_optimizer(mnist_model):
 @pytest.fixture
 def to_save(model, optimizer):
     yield {"model": model, "optimizer": optimizer}
+
+
+@pytest.fixture
+def to_save_single_param_groups(model_single_param_groups, optimizer):
+    yield {"model": model_single_param_groups, "optimizer": optimizer}
+
+
+@pytest.fixture
+def to_save_mulitple_param_groups(model_multiple_param_groups, optimizer_mulitple_param_groups):
+    yield {"model": model_multiple_param_groups, "optimizer": optimizer_mulitple_param_groups}
 
 
 @pytest.fixture
@@ -76,8 +123,27 @@ def dummy_engine(model, optimizer):
 
 
 @pytest.fixture
+def dummy_engine_single_param_groups(model_single_param_groups, optimizer):
+    engine_single_param_groups = create_supervised_trainer(model_single_param_groups, optimizer, nn.MSELoss())
+    yield engine_single_param_groups
+
+
+@pytest.fixture
+def dummy_engine_mulitple_param_groups(model_multiple_param_groups, optimizer_mulitple_param_groups):
+    engine_multiple_param_groups = create_supervised_trainer(
+        model_multiple_param_groups, optimizer_mulitple_param_groups, nn.MSELoss()
+    )
+    yield engine_multiple_param_groups
+
+
+@pytest.fixture
 def dataloader():
     yield torch.rand(100, 2, 10)
+
+
+@pytest.fixture
+def dataloader_plot():
+    yield torch.rand(500, 2, 10)
 
 
 @pytest.fixture
@@ -271,17 +337,21 @@ def test_lr_suggestion(lr_finder, to_save, dummy_engine, dataloader):
     assert 1e-4 <= lr_finder.lr_suggestion() <= 10
 
 
-def test_plot_single_param_group(lr_finder, to_save, dummy_engine, dataloader):
+def test_plot_single_param_group(
+    lr_finder, to_save_single_param_groups, dummy_engine_single_param_groups, dataloader_plot
+):
 
-    with lr_finder.attach(dummy_engine, to_save) as trainer_with_finder:
-        trainer_with_finder.run(dataloader)
+    with lr_finder.attach(
+        dummy_engine_single_param_groups, to_save_single_param_groups, end_lr=20, smooth_f=0.04
+    ) as trainer_with_finder:
+        trainer_with_finder.run(dataloader_plot)
 
     # Avoid RuntimeError
-    if torch.tensor(lr_finder._history["loss"]).argmin() < 2:
-        lr_finder._history["loss"].insert(0, 10)
-        lr_finder._history["loss"].insert(0, 100)
-        lr_finder._history["lr"].insert(0, 10)
-        lr_finder._history["lr"].insert(0, 100)
+    # if torch.tensor(lr_finder._history["loss"]).argmin() < 3:
+    #     lr_finder._history["loss"].insert(0, 10)
+    #     lr_finder._history["loss"].insert(0, 100)
+    #     lr_finder._history["lr"].insert(0, 10)
+    #     lr_finder._history["lr"].insert(0, 100)
 
     lr_finder.plot()
     lr_finder.plot(skip_end=0)
@@ -296,40 +366,21 @@ def test_plot_single_param_group(lr_finder, to_save, dummy_engine, dataloader):
     assert not path.exists("/nonexisting/dummy.jpg")
 
 
-def test_plot_multiple_param_groups(lr_finder, dataloader):
-    class Net(nn.Module):
-        def __init__(self):
-            super(Net, self).__init__()
-            self.fc1 = nn.Linear(10, 20)
-            self.fc2 = nn.Linear(20, 10)
-            self.fc3 = nn.Linear(10, 1)
+def test_plot_multiple_param_groups(
+    lr_finder, to_save_mulitple_param_groups, dummy_engine_mulitple_param_groups, dataloader_plot
+):
 
-        def forward(self, x):
-            x = F.relu(self.fc1(x))
-            x = F.relu(self.fc2(x))
-            return self.fc3(x)
-
-    model = Net()
-    optimizer = SGD(
-        [
-            {"params": model.fc1.parameters(), "lr": 4e-1},
-            {"params": model.fc2.parameters(), "lr": 3e-2},
-            {"params": model.fc3.parameters(), "lr": 3e-3},
-        ]
-    )
-
-    trainer = create_supervised_trainer(model, optimizer, nn.MSELoss())
-    to_save = {"model": model, "optimizer": optimizer}
-
-    with lr_finder.attach(trainer, to_save) as trainer_with_finder:
-        trainer_with_finder.run(dataloader)
+    with lr_finder.attach(
+        dummy_engine_mulitple_param_groups, to_save_mulitple_param_groups, end_lr=20, smooth_f=0.04
+    ) as trainer_with_finder:
+        trainer_with_finder.run(dataloader_plot)
 
     # Avoid RuntimeError
-    if torch.tensor(lr_finder._history["loss"]).argmin() < 2:
-        lr_finder._history["loss"].insert(0, 10)
-        lr_finder._history["loss"].insert(0, 100)
-        lr_finder._history["lr"].insert(0, [10, 10, 10])
-        lr_finder._history["lr"].insert(0, [100, 100, 100])
+    # if torch.tensor(lr_finder._history["loss"]).argmin() < 3:
+    #     lr_finder._history["loss"].insert(0, 10)
+    #     lr_finder._history["loss"].insert(0, 100)
+    #     lr_finder._history["lr"].insert(0, [10, 10, 10])
+    #     lr_finder._history["lr"].insert(0, [100, 100, 100])
 
     lr_finder.plot()
     lr_finder.plot(skip_end=0)

--- a/tests/ignite/contrib/metrics/test_average_precision.py
+++ b/tests/ignite/contrib/metrics/test_average_precision.py
@@ -87,13 +87,13 @@ def test_binary_and_multilabel_inputs():
 
         test_cases = [
             # Binary input data of shape (N,) or (N, 1)
-            (torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10,)).long(), 1),
-            (torch.randint(0, 2, size=(10, 1)).long(), torch.randint(0, 2, size=(10, 1)).long(), 1),
+            (torch.randint(0, 2, size=(50,)).long(), torch.randint(0, 2, size=(50,)).long(), 1),
+            (torch.randint(0, 2, size=(50, 1)).long(), torch.randint(0, 2, size=(50, 1)).long(), 1),
             # updated batches
             (torch.randint(0, 2, size=(50,)).long(), torch.randint(0, 2, size=(50,)).long(), 16),
             (torch.randint(0, 2, size=(50, 1)).long(), torch.randint(0, 2, size=(50, 1)).long(), 16),
             # Binary input data of shape (N, L)
-            (torch.randint(0, 2, size=(10, 4)).long(), torch.randint(0, 2, size=(10, 4)).long(), 1),
+            (torch.randint(0, 2, size=(50, 4)).long(), torch.randint(0, 2, size=(50, 4)).long(), 1),
             (torch.randint(0, 2, size=(50, 7)).long(), torch.randint(0, 2, size=(50, 7)).long(), 1),
             # updated batches
             (torch.randint(0, 2, size=(50, 4)).long(), torch.randint(0, 2, size=(50, 4)).long(), 16),


### PR DESCRIPTION
`plot` had issues handling multiple `suggested_lrs`, this PR fixes this issue, and added `display_legends` arg.

Some explanations for the updates:
- Added `display_legends` to make it more clear to know which `suggested_lr` belongs to which `param_group`, and make it optional for the users to enable or disable it, in more complex cases maybe a lot legends would affect the plot it would make less clear.
- Ignored `plt.xlim()` in case of multiple `param_groups`, as we see in this picture it may we should keep as it is will make it more cleaner, I tried this:
```python
if isinstance(lrs[0], list):
     xlim1 = lrs[0].index(min(lrs[0]))
     xlim2 = lrs[-1].index(max(lrs[-1]))
     plt.xlim([lrs[0][xlim1], lrs[-1][xlim2]])
else:
     plt.xlim([lrs[0], lrs[-1]])
```
But I thought no need to add additional check as the result will be almost the same, as the other curves may start from another point.
- In `test_plot_multiple_param_groups()` I didn't make the model or anything else `pytest.fixtures()`, as we won't use them again, no need for that.

![adsfasdfa](https://user-images.githubusercontent.com/54319724/116765699-bfe70680-aa26-11eb-854b-7c378f7b6dbe.png)


For more details about the experimentation: https://colab.research.google.com/drive/1xJfh8kMe3h7Ceyo9B4W4QSbxp-jUJwFT?usp=sharing

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
