### PR TITLE
Use cuda 10.1 on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
             conda --version
             # We have to use cuda 10.1 on Windows:
             # https://github.com/pytorch/ignite/issues/1843
-            conda install -y pytorch torchvision cudatoolkit=10.1 -c pytorch -c conda-forge
+            conda install -y pytorch torchvision cudatoolkit=10.1 -c pytorch
             pip install -r requirements-dev.txt
             pip install .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,9 @@ jobs:
           name: Install dependencies
           command: |
             conda --version
-            conda install -y pytorch torchvision cudatoolkit=11.1 -c pytorch -c conda-forge
+            # We have to use cuda 10.1 on Windows:
+            # https://github.com/pytorch/ignite/issues/1843
+            conda install -y pytorch torchvision cudatoolkit=10.1 -c pytorch -c conda-forge
             pip install -r requirements-dev.txt
             pip install .
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/ignite/issues/1843

Description:
- manually use cuda 10.1 instead of 11.1

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
