### PR TITLE
[skip ci] Updated nightly to latest stable pytorch-xla in teaser notebook

### DIFF
--- a/assets/tldr/teaser.ipynb
+++ b/assets/tldr/teaser.ipynb
@@ -48,9 +48,7 @@
     "with_torch_launch = \"WORLD_SIZE\" in os.environ\n",
     "\n",
     "if in_colab:\n",
-    "    VERSION = \"nightly\"\n",
-    "    !curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py\n",
-    "    !python pytorch-xla-env-setup.py --version $VERSION"
+    "    !pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.8.1-cp37-cp37m-linux_x86_64.whl"
    ]
   },
   {

--- a/assets/tldr/teaser.ipynb
+++ b/assets/tldr/teaser.ipynb
@@ -48,8 +48,8 @@
     "with_torch_launch = \"WORLD_SIZE\" in os.environ\n",
     "\n",
     "if in_colab:\n",
-    "    VERSION = !curl -s https://api.github.com/repos/pytorch/xla/releases/latest | awk -F '\"' '/tag_name/{print $4}' | cut -c 2-\n",
-    "    !pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-${VERSION[0]}-cp37-cp37m-linux_x86_64.whl"
+    "    VERSION = !curl -s https://api.github.com/repos/pytorch/xla/releases/latest | grep -Po '\"tag_name\": \"v\\K.*?(?=\")'\n",
+    "    !pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-{VERSION[0]}-cp37-cp37m-linux_x86_64.whl"
    ]
   },
   {

--- a/assets/tldr/teaser.ipynb
+++ b/assets/tldr/teaser.ipynb
@@ -48,7 +48,8 @@
     "with_torch_launch = \"WORLD_SIZE\" in os.environ\n",
     "\n",
     "if in_colab:\n",
-    "    !pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.8.1-cp37-cp37m-linux_x86_64.whl"
+    "    VERSION = !curl -s https://api.github.com/repos/pytorch/xla/releases/latest | awk -F '\"' '/tag_name/{print $4}' | cut -c 2-\n",
+    "    !pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-${VERSION[0]}-cp37-cp37m-linux_x86_64.whl"
    ]
   },
   {


### PR DESCRIPTION
Description:
With the nightly version of xla, the notebook produced the following error during installation - `OSError: libmkl_intel_lp64.so.1: cannot open shared object file: No such file or directory.`
The workarounds are too complicated for a simple teaser notebook. Therefore, changing the unstable nightly version to the stable one looked like the best option.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
