### PR TITLE
chore: version change in EOS core handler [skip ci]

### DIFF
--- a/ignite/handlers/stores.py
+++ b/ignite/handlers/stores.py
@@ -34,7 +34,7 @@ class EpochOutputStore:
             # output = [(y_pred0, y0), (y_pred1, y1), ...]
             # do something with output, e.g., plotting
 
-    .. versionadded:: 0.4.2
+    .. versionadded:: 0.5.0
     .. versionchanged:: 0.5.0
         `attach` now accepts an optional argument `name`
     """


### PR DESCRIPTION
### Description

`EpochOutputStore` has been moved from contrib to core in #1982.
But the docstring said that this is new in v0.4.2 in core while it is actually moved in v0.5.0.

Check list:

- [ ] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
