### PR TITLE
added google analytics global tag for docs

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -105,6 +105,16 @@
   {%- block extrahead %} {% endblock %}
 
   {% include "fonts.html" %}
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-5FELLLFHCP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-5FELLLFHCP');
+  </script>
 </head>
 
 <div class="container-fluid header-holder tutorials-header" id="header-holder">


### PR DESCRIPTION
Description: 

As discussed earlier with @vfdev-5 this will give us detailed insights into the documentation experience of the user and the suitable place to add this tag was discussed with @ydcjeff.

Also according to this [article](https://support.google.com/analytics/answer/1008080#zippy=%2Cin-this-article) under Dynamic website -
> Link the include file so that the snippet appears before the closing </head> tag on every webpage you want to measure.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
