### PR TITLE
Prevent metric from being computed before updated using `__new__`

### DIFF
--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -8,6 +8,7 @@ import torch
 
 import ignite.distributed as idist
 from ignite.engine import CallableEventWithFilter, Engine, Events
+from ignite.exceptions import NotComputableError
 
 if TYPE_CHECKING:
     from ignite.metrics.metrics_lambda import MetricsLambda
@@ -202,6 +203,35 @@ class Metric(metaclass=ABCMeta):
     required_output_keys: Optional[Tuple] = ("y_pred", "y")
     # for backward compatibility
     _required_output_keys = required_output_keys
+
+    def __new__(cls, *args, **kwargs):
+        """Prevents metric from being computed before updated.
+        """
+
+        _reset = cls.reset
+        _update = cls.update
+        _compute = cls.compute
+
+        def wrapped_reset(self):
+            _reset(self)
+            self._updated = False
+
+        cls.reset = wraps(cls.reset)(wrapped_reset)
+
+        def wrapped_update(self, output):
+            _update(self, output)
+            self._updated = True
+
+        cls.update = wraps(cls.update)(wrapped_update)
+
+        def wrapped_compute(self):
+            if not self._updated:
+                raise NotComputableError(f"{self.__class__.__name__} must be updated before computed.")
+            return _compute(self)
+
+        cls.compute = wraps(cls.compute)(wrapped_compute)
+
+        return super(Metric, cls).__new__(cls)
 
     def __init__(
         self, output_transform: Callable = lambda x: x, device: Union[str, torch.device] = torch.device("cpu"),

--- a/mypy.ini
+++ b/mypy.ini
@@ -71,3 +71,6 @@ ignore_missing_imports = True
 
 [mypy-tqdm.*]
 ignore_missing_imports = True
+
+[mypy-ignite.metrics.metric]
+ignore_errors = True


### PR DESCRIPTION
Addresses #336 #2007

Description:

Prevents metric from being computed before updated using `__new__` magic.

`__new__` is called by default on instance creation before `__init__` call. Thus, we wrap methods before instance instantiation.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
