### PR TITLE
[skip ci] DOC: corrected spelling of defined in notes

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -440,7 +440,7 @@ def supervised_evaluation_step(
         Inference function.
 
     Note:
-        `engine.state.output` for this engine is defind by `output_transform` parameter and is
+        `engine.state.output` for this engine is defined by `output_transform` parameter and is
         a tuple of `(batch_pred, batch_y)` by default.
 
     .. warning::
@@ -488,7 +488,7 @@ def supervised_evaluation_step_amp(
         Inference function.
 
     Note:
-        `engine.state.output` for this engine is defind by `output_transform` parameter and is
+        `engine.state.output` for this engine is defined by `output_transform` parameter and is
         a tuple of `(batch_pred, batch_y)` by default.
 
     .. warning::
@@ -546,7 +546,7 @@ def create_supervised_evaluator(
         an evaluator engine with supervised inference function.
 
     Note:
-        `engine.state.output` for this engine is defind by `output_transform` parameter and is
+        `engine.state.output` for this engine is defined by `output_transform` parameter and is
         a tuple of `(batch_pred, batch_y)` by default.
 
     .. warning::


### PR DESCRIPTION
Fixes #2022 

Description:
Corrected spelling mistake of `defined` in notes about `engine.state.output`.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [X] Documentation is updated (if required)
