### PR TITLE
ci: do not fail codecov action if error

### DIFF
--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           file: ./coverage.xml
           flags: hvd-cpu
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -86,4 +86,4 @@ jobs:
         with:
           file: ./coverage.xml
           flags: tpu
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           file: ./coverage.xml
           flags: cpu
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Run MNIST Examples
         shell: bash -l {0}


### PR DESCRIPTION
Description:

Set `fail_ci_if_error` to `false` not to fail the CI if codecov error occurs.

fix #2043 

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
