### PR TITLE
Handled different `engine.state.output` types for LRFinder

### DIFF
--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -137,6 +137,14 @@ class FastaiLRFinder:
     def _log_lr_and_loss(self, trainer: Engine, output_transform: Callable, smooth_f: float, diverge_th: float) -> None:
         output = trainer.state.output
         loss = output_transform(output)
+        if not isinstance(loss, float):
+            if isinstance(loss, torch.Tensor):
+                loss = loss.item()
+            else:
+                raise TypeError(
+                    "output of the engine should be of type float or torch.tensor, "
+                    f"but got output of type {type(loss).__name__}"
+                )
         loss = idist.all_reduce(loss)
         lr = self._lr_schedule.get_param()  # type: ignore[union-attr]
         self._history["lr"].append(lr)

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -138,11 +138,14 @@ class FastaiLRFinder:
         output = trainer.state.output
         loss = output_transform(output)
         if not isinstance(loss, float):
-            if isinstance(loss, torch.Tensor) and (loss.ndimension() == 0):
+            if isinstance(loss, torch.Tensor) and (
+                (loss.ndimension() == 0) or (loss.ndimension() == 1 and len(loss) == 1)
+            ):
                 loss = loss.item()
             else:
                 raise TypeError(
-                    "output of the engine should be of type float or 0d torch.Tensor, "
+                    "output of the engine should be of type float or 0d torch.Tensor "
+                    "or 1d torch.Tensor with 1 element, "
                     f"but got output of type {type(loss).__name__}"
                 )
         loss = idist.all_reduce(loss)

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -142,7 +142,7 @@ class FastaiLRFinder:
                 loss = loss.item()
             else:
                 raise TypeError(
-                    "output of the engine should be of type float or torch.tensor, "
+                    "output of the engine should be of type float or torch.Tensor, "
                     f"but got output of type {type(loss).__name__}"
                 )
         loss = idist.all_reduce(loss)

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -138,10 +138,15 @@ class FastaiLRFinder:
         output = trainer.state.output
         loss = output_transform(output)
         if not isinstance(loss, float):
-            if isinstance(loss, torch.Tensor) and (
-                (loss.ndimension() == 0) or (loss.ndimension() == 1 and len(loss) == 1)
-            ):
-                loss = loss.item()
+            if isinstance(loss, torch.Tensor):
+                if (loss.ndimension() == 0) or (loss.ndimension() == 1 and len(loss) == 1):
+                    loss = loss.item()
+                else:
+                    raise ValueError(
+                        "if output of the engine is torch.Tensor, then "
+                        "it must be 0d torch.Tensor or 1d torch.Tensor with 1 element, "
+                        f"but got torch.Tensor of shape {loss.shape}"
+                    )
             else:
                 raise TypeError(
                     "output of the engine should be of type float or 0d torch.Tensor "

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -138,11 +138,11 @@ class FastaiLRFinder:
         output = trainer.state.output
         loss = output_transform(output)
         if not isinstance(loss, float):
-            if isinstance(loss, torch.Tensor):
+            if isinstance(loss, torch.Tensor) and (loss.ndimension() == 0):
                 loss = loss.item()
             else:
                 raise TypeError(
-                    "output of the engine should be of type float or torch.Tensor, "
+                    "output of the engine should be of type float or 0d torch.Tensor, "
                     f"but got output of type {type(loss).__name__}"
                 )
         loss = idist.all_reduce(loss)

--- a/tests/ignite/contrib/handlers/test_lr_finder.py
+++ b/tests/ignite/contrib/handlers/test_lr_finder.py
@@ -320,6 +320,10 @@ def test_engine_output_type(lr_finder, dummy_engine, optimizer):
     with pytest.raises(TypeError, match=r"output of the engine should be of type float or 0d torch.Tensor"):
         lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
 
+    dummy_engine.state.output = torch.tensor([1, 2], dtype=torch.float32)
+    with pytest.raises(ValueError, match=r"if output of the engine is torch.Tensor"):
+        lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
+
     lr_finder._lr_schedule = PiecewiseLinear(
         optimizer, param_name="lr", milestones_values=[(0, optimizer.param_groups[0]["lr"]), (100, 10)]
     )

--- a/tests/ignite/contrib/handlers/test_lr_finder.py
+++ b/tests/ignite/contrib/handlers/test_lr_finder.py
@@ -313,11 +313,11 @@ def test_engine_output_type(lr_finder, dummy_engine, optimizer):
 
     dummy_engine.state.iteration = 1
     dummy_engine.state.output = [10]
-    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.Tensor"):
+    with pytest.raises(TypeError, match=r"output of the engine should be of type float or 0d torch.Tensor"):
         lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
 
     dummy_engine.state.output = (10, 5)
-    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.Tensor"):
+    with pytest.raises(TypeError, match=r"output of the engine should be of type float or 0d torch.Tensor"):
         lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
 
     lr_finder._lr_schedule = PiecewiseLinear(

--- a/tests/ignite/contrib/handlers/test_lr_finder.py
+++ b/tests/ignite/contrib/handlers/test_lr_finder.py
@@ -323,10 +323,17 @@ def test_engine_output_type(lr_finder, dummy_engine, optimizer):
     lr_finder._lr_schedule = PiecewiseLinear(
         optimizer, param_name="lr", milestones_values=[(0, optimizer.param_groups[0]["lr"]), (100, 10)]
     )
+
     dummy_engine.state.output = torch.tensor(10.0, dtype=torch.float32)
     lr_finder._history = {"lr": [], "loss": []}
     lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
-    loss = lr_finder._history["loss"][0]
+    loss = lr_finder._history["loss"][-1]
+    assert type(loss) == float
+
+    dummy_engine.state.output = torch.tensor([10.0], dtype=torch.float32)
+    lr_finder._history = {"lr": [], "loss": []}
+    lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
+    loss = lr_finder._history["loss"][-1]
     assert type(loss) == float
 
 

--- a/tests/ignite/contrib/handlers/test_lr_finder.py
+++ b/tests/ignite/contrib/handlers/test_lr_finder.py
@@ -313,11 +313,11 @@ def test_engine_output_type(lr_finder, dummy_engine, optimizer):
 
     dummy_engine.state.iteration = 1
     dummy_engine.state.output = [10]
-    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.tensor"):
+    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.Tensor"):
         lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
 
     dummy_engine.state.output = (10, 5)
-    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.tensor"):
+    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.Tensor"):
         lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
 
     lr_finder._lr_schedule = PiecewiseLinear(

--- a/tests/ignite/contrib/handlers/test_lr_finder.py
+++ b/tests/ignite/contrib/handlers/test_lr_finder.py
@@ -308,6 +308,28 @@ def test_detach_terminates(lr_finder, to_save, dummy_engine, dataloader, recwarn
     assert len(recwarn) == 0
 
 
+def test_engine_output_type(lr_finder, dummy_engine, optimizer):
+    from ignite.handlers.param_scheduler import PiecewiseLinear
+
+    dummy_engine.state.iteration = 1
+    dummy_engine.state.output = [10]
+    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.tensor"):
+        lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
+
+    dummy_engine.state.output = (10, 5)
+    with pytest.raises(TypeError, match=r"output of the engine should be of type float or torch.tensor"):
+        lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
+
+    lr_finder._lr_schedule = PiecewiseLinear(
+        optimizer, param_name="lr", milestones_values=[(0, optimizer.param_groups[0]["lr"]), (100, 10)]
+    )
+    dummy_engine.state.output = torch.tensor(10.0, dtype=torch.float32)
+    lr_finder._history = {"lr": [], "loss": []}
+    lr_finder._log_lr_and_loss(dummy_engine, output_transform=lambda x: x, smooth_f=0, diverge_th=1)
+    loss = lr_finder._history["loss"][0]
+    assert type(loss) == float
+
+
 def test_lr_suggestion_unexpected_curve(lr_finder, to_save, dummy_engine, dataloader):
     with lr_finder.attach(dummy_engine, to_save) as trainer_with_finder:
         trainer_with_finder.run(dataloader)


### PR DESCRIPTION
Handled tensors and floats from `engine.state.output` for LRFinder, and cover this with test.

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
