### PR TITLE
fix: Update circle CI pytorch images 1.8.1 -> 1.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ parameters:
     default: "1.9.0-cuda11.1-cudnn8"
   build_docker_image_hvd_version:
     type: string
-    default: "v0.21.3"
+    default: "v0.22.1"
   build_docker_image_msdp_version:
     type: string
-    default: "v0.3.10"
+    default: "v0.4.0"
 
 # -------------------------------------------------------------------------------------
 # Environments to run the jobs in

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ parameters:
   pytorch_stable_image:
     type: string
     # https://hub.docker.com/r/pytorch/pytorch/tags
-    default: "pytorch/pytorch:1.8.1-cuda11.1-cudnn8-runtime"
+    default: "pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime"
   pytorch_stable_image_devel:
     type: string
     # https://hub.docker.com/r/pytorch/pytorch/tags
-    default: "pytorch/pytorch:1.8.1-cuda11.1-cudnn8-devel"
+    default: "pytorch/pytorch:1.9.0-cuda11.1-cudnn8-devel"
   workingdir:
     type: string
     default: "/tmp/ignite"
@@ -20,7 +20,7 @@ parameters:
     default: false
   build_docker_image_pytorch_version:
     type: string
-    default: "1.8.1-cuda11.1-cudnn8"
+    default: "1.9.0-cuda11.1-cudnn8"
   build_docker_image_hvd_version:
     type: string
     default: "v0.21.3"


### PR DESCRIPTION
Fixes #2065

Description:
Refactored the CI-build parameters i.e. pytorch images 1.8.1 -> 1.9

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
