### PR TITLE
ci: run `linkcheck` only on push and pull

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,6 @@ name: Build docs
 
 on:
   push:
-    branches: [master]
   pull_request:
     paths-ignore:
       - "tests/**"
@@ -12,7 +11,7 @@ on:
 
 jobs:
   build-deploy:
-    if: github.event_name != 'pull_request'
+    if: (github.ref == 'refs/heads/master' && github.event_name == 'push') || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
           force_orphan: true
 
   linkcheck:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
fix: #2066 

Description: Run `linkcheck` job only on push and pull events

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
