### PR TITLE
Refactor stable release workflow [skip netlify]

### DIFF
--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash -l {0}
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          UPLOAD_USER: "pytorch"
+          UPLOAD_USER: ${{ secrets.UPLOAD_USER }}
         run: |
           chmod +x ./conda.recipe/build_and_upload.sh
           ./conda.recipe/build_and_upload.sh

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -20,8 +20,6 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -y pytorch torchvision cpuonly -c pytorch
-          pip install -r requirements-dev.txt
-          pip install --upgrade --no-cache-dir twine
           python setup.py install
 
       - name: Build and Publish Conda binaries

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -1,7 +1,8 @@
 name: Anaconda Stable Releases
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   conda-build-publish:

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -1,6 +1,7 @@
 name: Anaconda Stable Releases
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
 
 jobs:
   conda-build-publish:

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -1,7 +1,6 @@
 name: Anaconda Stable Releases
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   conda-build-publish:

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -1,8 +1,7 @@
 name: Anaconda Stable Releases
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   conda-build-publish:

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash -l {0}
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          UPLOAD_USER: ${{ secrets.UPLOAD_USER }}
+          UPLOAD_USER: "pytorch"
         run: |
           chmod +x ./conda.recipe/build_and_upload.sh
           ./conda.recipe/build_and_upload.sh

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -1,0 +1,34 @@
+name: Anaconda Stable Releases
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  conda-build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          python-version: 3.8
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          conda install -y pytorch torchvision cpuonly -c pytorch
+          pip install -r requirements-dev.txt
+          pip install --upgrade --no-cache-dir twine
+          python setup.py install
+
+      - name: Build and Publish Conda binaries
+        shell: bash -l {0}
+        env:
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          UPLOAD_USER: "pytorch"
+        run: |
+          chmod +x ./conda.recipe/build_and_upload.sh
+          ./conda.recipe/build_and_upload.sh

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -1,4 +1,4 @@
-name: Stable Releases
+name: PyPI Stable Releases
 
 on:
   release:
@@ -23,15 +23,6 @@ jobs:
           pip install -r requirements-dev.txt
           pip install --upgrade --no-cache-dir twine
           python setup.py install
-
-      - name: Build and Publish Conda binaries
-        shell: bash -l {0}
-        env:
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          UPLOAD_USER: "pytorch"
-        run: |
-          chmod +x ./conda.recipe/build_and_upload.sh
-          ./conda.recipe/build_and_upload.sh
 
       - name: Build and Publish PyPI binaries
         shell: bash -l {0}

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           twine check dist/*
-          TWINE_USERNAME="${{ secrets.PYPI_USER }}" TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+          TWINE_USERNAME="${{ secrets.PYPI_USER }}" TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" twine upload --verbose dist/*
 
   docker-build-publish:
     name: Trigger Build and Push Docker images to Docker Hub

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -1,6 +1,8 @@
 name: PyPI Stable Releases
 
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
 
 jobs:
   build-publish:

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           twine check dist/*
-          TWINE_USERNAME="${{ secrets.PYPI_USER }}" TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" twine upload --verbose dist/*
+          TWINE_USERNAME="${{ secrets.PYPI_USER }}" TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
   docker-build-publish:
     name: Trigger Build and Push Docker images to Docker Hub

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -1,8 +1,6 @@
 name: PyPI Stable Releases
 
-on:
-  release:
-    types: [published]
+on: workflow_dispatch
 
 jobs:
   build-publish:


### PR DESCRIPTION
Fixes

Description:

This PR will split GH Action workflow for stable releases into 2 parallel workflows to increase "fault-tolerance" of the workflow:

- build  and publish on PyPI  -> trigger Docker builds and publish
- build  and publish on Anaconda

To 

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
