### PR TITLE
Bug Fix MBConv Class - EffNet_Cifar100_finetuning

### DIFF
--- a/examples/notebooks/EfficientNet_Cifar100_finetuning.ipynb
+++ b/examples/notebooks/EfficientNet_Cifar100_finetuning.ipynb
@@ -351,7 +351,7 @@
     "        # Add identity skip\n",
     "        if x.shape == z.shape and self.with_skip:            \n",
     "            if self.training and self.drop_connect_rate is not None:\n",
-    "                self._drop_connect(x)\n",
+    "                x = self._drop_connect(x)\n",
     "            x += z\n",
     "        return x"
    ],

--- a/examples/notebooks/EfficientNet_Cifar100_finetuning.ipynb
+++ b/examples/notebooks/EfficientNet_Cifar100_finetuning.ipynb
@@ -330,7 +330,7 @@
     "        )\n",
     "\n",
     "        self.with_skip = stride == 1\n",
-    "        self.drop_connect_rate = torch.tensor(drop_connect_rate, requires_grad=False)\n",
+    "        self.drop_connect_rate = drop_connect_rate\n",
     "    \n",
     "    def _drop_connect(self, x):        \n",
     "        keep_prob = 1.0 - self.drop_connect_rate\n",


### PR DESCRIPTION
Fixes https://github.com/pytorch/ignite/issues/2072

🐛 Bug description
In the iPython notebook "EfficientNet_Cifar100_finetuning.ipynb", there is a bug in the definition of the MBConv class:

In the third line after the sub-section # Add identity skip, the function _drop_connect is called without assigning the returned values to x. The code simply says self._drop_connect(x) instead of x = self._drop_connect(x). The final operation performed inside _drop_connect does not occur in-place.
