### PR TITLE
Move `DeterministicEngine` rng states tensor to cpu on checkpoint loading

### DIFF
--- a/ignite/engine/deterministic.py
+++ b/ignite/engine/deterministic.py
@@ -98,6 +98,10 @@ def _get_rng_states() -> List[Any]:
 
 def _set_rng_states(rng_states: List[Any]) -> None:
     random.setstate(rng_states[0])
+
+    if "cpu" not in rng_states[1].device.type:
+        rng_states[1] = rng_states[1].cpu()
+
     torch.set_rng_state(rng_states[1])
     try:
         import numpy as np

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -17,6 +17,7 @@ from ignite.engine.deterministic import (
     ReproducibleBatchSampler,
     keep_random_state,
     update_dataloader,
+    _set_rng_states,
 )
 from ignite.utils import manual_seed
 from tests.ignite.engine import BatchChecker, setup_sampler
@@ -885,3 +886,12 @@ def test_dataloader_no_dataset_kind():
     dataloader = OldDataLoader(dataloader)
 
     engine.run(dataloader)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU")
+def test__set_rng_states_cuda():
+    # Checks https://github.com/pytorch/ignite/issues/2076
+
+    rng_states = [random.getstate(), torch.get_rng_state().cuda(), np.random.get_state()]
+    _set_rng_states(rng_states)
+    assert rng_states[1].device.type == "cpu"

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -15,9 +15,9 @@ from ignite.engine import Events
 from ignite.engine.deterministic import (
     DeterministicEngine,
     ReproducibleBatchSampler,
+    _set_rng_states,
     keep_random_state,
     update_dataloader,
-    _set_rng_states,
 )
 from ignite.utils import manual_seed
 from tests.ignite.engine import BatchChecker, setup_sampler


### PR DESCRIPTION
Fixes #2076 

Description:

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
