### PR TITLE
Any parameter scheduler

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -40,6 +40,13 @@ Parameter scheduler
     :nosignatures:
     :toctree: generated
 
+    AnyParameterScheduler
+    LambdaAnyParameterScheduler
+    LinearAnyParameterScheduler
+    ExponentialAnyParameterScheduler
+    StepAnyParameterScheduler
+    MultiStepAnyParameterScheduler
+    OptimizerParamScheduler
     ConcatScheduler
     CosineAnnealingScheduler
     CyclicalScheduler

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -137,6 +137,7 @@ class AnyParameterScheduler(ParamScheduler):
 class LambdaAnyParameterScheduler(AnyParameterScheduler):
     """Update a parameter during training by using a user defined function.
         User defined function is taking an event index as input and returns a float value.
+
     Args:
         parameter_setter: function that sets the required parameter value.
         lambda_fn: user defined parameter update function.
@@ -157,8 +158,7 @@ class LambdaAnyParameterScheduler(AnyParameterScheduler):
 
 
 class LinearAnyParameterScheduler(AnyParameterScheduler):
-    """
-    Update a parameter during training by using linear function.
+    """Update a parameter during training by using linear function.
     The function keeps the parameter value to zero until step_zero steps passed and then linearly increases it to 1
     until an additional step_one steps passed. Continues the trend until it reaches max_value.
 
@@ -208,8 +208,7 @@ class LinearAnyParameterScheduler(AnyParameterScheduler):
 
 
 class ExponentialAnyParameterScheduler(AnyParameterScheduler):
-    """
-    Update a parameter during training by using exponential function.
+    """Update a parameter during training by using exponential function.
     The function decays the parameter value by gamma every step.
     Based on the closed form of ExponentialLR from Pytorch
     https://github.com/pytorch/pytorch/blob/master/torch/optim/lr_scheduler.py#L457
@@ -243,8 +242,7 @@ class ExponentialAnyParameterScheduler(AnyParameterScheduler):
 
 
 class StepAnyParameterScheduler(AnyParameterScheduler):
-    """
-    Update a parameter during training by using a step function.
+    """Update a parameter during training by using a step function.
     This function decays the parameter value by gamma every step_size.
     Based on StepLR from Pytorch.
     https://github.com/pytorch/pytorch/blob/master/torch/optim/lr_scheduler.py#L377
@@ -281,8 +279,7 @@ class StepAnyParameterScheduler(AnyParameterScheduler):
 
 
 class MultiStepAnyParameterScheduler(AnyParameterScheduler):
-    """
-    Update a parameter during training by using a multi step function.
+    """Update a parameter during training by using a multi step function.
     The function decays the parameter value by gamma once the number of steps reaches one of the milestones.
     Based on MultiStepLR from Pytorch.
     https://github.com/pytorch/pytorch/blob/master/torch/optim/lr_scheduler.py#L424

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -13,7 +13,6 @@ from ignite.handlers.param_scheduler import (
     LRScheduler,
     OptimizerParamScheduler,
     ParamGroupScheduler,
-    ParamScheduler,
     PiecewiseLinear,
     create_lr_scheduler_with_warmup,
 )

--- a/tests/ignite/contrib/handlers/test_param_scheduler.py
+++ b/tests/ignite/contrib/handlers/test_param_scheduler.py
@@ -11,6 +11,7 @@ from ignite.handlers.param_scheduler import (
     CosineAnnealingScheduler,
     LinearCyclicalScheduler,
     LRScheduler,
+    OptimizerParamScheduler,
     ParamGroupScheduler,
     ParamScheduler,
     PiecewiseLinear,
@@ -29,7 +30,7 @@ else:
     has_multiplicative_lr = LooseVersion(torch.__version__) >= LooseVersion("1.5.0")
 
 
-class FakeParamScheduler(ParamScheduler):
+class FakeParamScheduler(OptimizerParamScheduler):
     def get_param(self):
         return [0]
 

--- a/tests/ignite/handlers/test_any_param_scheduler.py
+++ b/tests/ignite/handlers/test_any_param_scheduler.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from torch.nn import Module
 
@@ -25,21 +24,6 @@ class ToyNet(Module):
 
     def set_value(self, value):
         self.value = value
-
-
-def test_any_parameter_scheduler_assert():
-    with pytest.raises(
-        ValueError, match=r"Parameter name should be set to log the parameter values to engine.state.param_history"
-    ):
-        net = ToyNet(value=-1)
-        linear_any_parameter_scheduler = LinearAnyParameterScheduler(
-            parameter_setter=net.set_value,
-            initial_value=0,
-            step_constant=2,
-            step_max_value=5,
-            max_value=10,
-            save_history=True,
-        )
 
 
 def test_linear_scheduler_linear_increase_history():

--- a/tests/ignite/handlers/test_any_param_scheduler.py
+++ b/tests/ignite/handlers/test_any_param_scheduler.py
@@ -1,0 +1,168 @@
+import pytest
+import torch
+from torch.nn import Module
+
+from ignite.engine import Engine, Events
+from ignite.handlers.param_scheduler import (
+    ExponentialAnyParameterScheduler,
+    LambdaAnyParameterScheduler,
+    LinearAnyParameterScheduler,
+    MultiStepAnyParameterScheduler,
+    StepAnyParameterScheduler,
+)
+
+
+class ToyNet(Module):
+    def __init__(self, value):
+        super(ToyNet, self).__init__()
+        self.value = value
+
+    def forward(self, input):
+        return input
+
+    def get_value(self):
+        return self.value
+
+    def set_value(self, value):
+        self.value = value
+
+
+def test_any_parameter_scheduler_assert():
+    with pytest.raises(
+        ValueError, match=r"Parameter name should be set to log the parameter values to engine.state.param_history"
+    ):
+        net = ToyNet(value=-1)
+        linear_any_parameter_scheduler = LinearAnyParameterScheduler(
+            parameter_setter=net.set_value,
+            initial_value=0,
+            step_constant=2,
+            step_max_value=5,
+            max_value=10,
+            save_history=True,
+        )
+
+
+def test_linear_scheduler_linear_increase_history():
+    # Testing linear increase
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    linear_any_parameter_scheduler = LinearAnyParameterScheduler(
+        parameter_setter=net.set_value,
+        param_name="toy_net_param",
+        initial_value=0,
+        step_constant=2,
+        step_max_value=5,
+        max_value=10,
+        save_history=True,
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, linear_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=3)
+    print(engine.state.param_history)
+    expected_param_history = [0.0, 0.0, 3.3333333333333335]
+    assert hasattr(engine.state, "param_history")
+    state_param = engine.state.param_history["toy_net_param"]
+    assert len(state_param) == len(expected_param_history)
+    assert state_param == expected_param_history
+
+
+def test_linear_scheduler_step_constant():
+    # Testing step_constant
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    linear_any_parameter_scheduler = LinearAnyParameterScheduler(
+        parameter_setter=net.set_value,
+        param_name="toy_net_param",
+        initial_value=0,
+        step_constant=2,
+        step_max_value=5,
+        max_value=10,
+        save_history=True,
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, linear_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=2)
+    torch.testing.assert_allclose(net.get_value(), 0)
+
+
+def test_linear_scheduler_linear_increase():
+    # Testing linear increase
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    linear_any_parameter_scheduler = LinearAnyParameterScheduler(
+        parameter_setter=net.set_value,
+        param_name="toy_net_param",
+        initial_value=0,
+        step_constant=2,
+        step_max_value=5,
+        max_value=10,
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, linear_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=3)
+    torch.testing.assert_allclose(net.get_value(), 3.333333, atol=0.001, rtol=0.0)
+
+
+def test_linear_scheduler_max_value():
+    # Testing max_value
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    linear_any_parameter_scheduler = LinearAnyParameterScheduler(
+        parameter_setter=net.set_value,
+        param_name="toy_net_param",
+        initial_value=0,
+        step_constant=2,
+        step_max_value=5,
+        max_value=10,
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, linear_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=10)
+    torch.testing.assert_allclose(net.get_value(), 10)
+
+
+def test_exponential_scheduler():
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    exp_any_parameter_scheduler = ExponentialAnyParameterScheduler(
+        parameter_setter=net.set_value, param_name="toy_net_param", initial_value=10, gamma=0.99
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, exp_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=2)
+    torch.testing.assert_allclose(net.get_value(), 10 * 0.99 * 0.99)
+
+
+def test_step_scheduler():
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    step_any_parameter_scheduler = StepAnyParameterScheduler(
+        parameter_setter=net.set_value, param_name="toy_net_param", initial_value=10, gamma=0.99, step_size=5
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, step_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=10)
+    torch.testing.assert_allclose(net.get_value(), 10 * 0.99 * 0.99)
+
+
+def test_multistep_scheduler():
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    multi_step_any_parameter_scheduler = MultiStepAnyParameterScheduler(
+        parameter_setter=net.set_value, param_name="toy_net_param", initial_value=10, gamma=0.99, milestones=[3, 6],
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, multi_step_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=10)
+    torch.testing.assert_allclose(net.get_value(), 10 * 0.99 * 0.99)
+
+
+def test_custom_scheduler():
+    # def custom_logic(initial_value, gamma, current_step):
+    #    return initial_value * gamma ** (current_step % 9)
+
+    initial_value = 10
+    gamma = 0.99
+    net = ToyNet(value=-1)
+    engine = Engine(lambda e, b: None)
+    lambda_any_parameter_scheduler = LambdaAnyParameterScheduler(
+        parameter_setter=net.set_value,
+        param_name="toy_net_param",
+        lambda_fn=lambda event_index: initial_value * gamma ** (event_index % 9),
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, lambda_any_parameter_scheduler)
+    engine.run([0] * 8, max_epochs=2)
+    torch.testing.assert_allclose(net.get_value(), 10 * 0.99 * 0.99)


### PR DESCRIPTION
Fixes #1913

Description:
Enlarge the scope of `ParamScheduler` like it is done in MONAI to schedule any hyperparameter while ensuring backward compatibility.

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
