### PR TITLE
Extended `MetricsLambda` to update its underlying metrics

### DIFF
--- a/ignite/metrics/metrics_lambda.py
+++ b/ignite/metrics/metrics_lambda.py
@@ -116,7 +116,7 @@ class MetricsLambda(Metric):
     def attach(self, engine: Engine, name: str, usage: Union[str, MetricUsage] = EpochWise()) -> None:
         if self._updated:
             raise ValueError(
-                "The underlying metrics are already updated, " "can't attach while using reset/update/compute API."
+                "The underlying metrics are already updated, can't attach while using reset/update/compute API."
             )
         usage = self._check_usage(usage)
         # recursively attach all its dependencies (partially)

--- a/ignite/metrics/metrics_lambda.py
+++ b/ignite/metrics/metrics_lambda.py
@@ -83,7 +83,7 @@ class MetricsLambda(Metric):
 
     @reinit__is_reduced
     def update(self, output: Any) -> None:
-        if self.engine is not None:
+        if self.engine:
             raise ValueError(
                 "MetricsLambda is already attached to an engine, "
                 "and MetricsLambda can't use update API while it's attached."


### PR DESCRIPTION
Fixes #1921 

Implemented the update method to make metrics lambda able to update its underlying methods, and I separated the attach from reset/update/compute API, then implemented the necessary tests.

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
