### PR TITLE
Docs improvement and fixing bug with FID/IS metrics

### DIFF
--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -56,6 +56,8 @@ class FID(_BaseInceptionMetric):
 
     where :math:`\mu_1` and :math:`\sigma_1` refer to the mean and covariance of the train data and
     :math:`\mu_2` and :math:`\sigma_2` refer to the mean and covariance of the test data.
+    If you wish to use the default Inception Model for evaluation, it requires torchvision module.
+    Also, FID uses scipy module for matrix square root calculation.
 
     More details can be found in `Heusel et al. 2002`__
 

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -129,7 +129,7 @@ class FID(_BaseInceptionMetric):
 
         if num_features is None and feature_extractor is None:
             num_features = 1000
-            feature_extractor = InceptionModel(return_features=False)
+            feature_extractor = InceptionModel(return_features=False, device=device)
 
         self._eps = 1e-6
 

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -73,7 +73,7 @@ class FID(_BaseInceptionMetric):
 
     .. note::
         The default Inception model requires the `torchvision` module to be installed.
-        FID also requires `scipy` module for matrix square root calculations.
+        FID also requires `scipy` library for matrix square root calculations.
 
     Args:
         num_features: number of features predicted by the model or the reduced feature vector of the image.

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -57,11 +57,6 @@ class FID(_BaseInceptionMetric):
     where :math:`\mu_1` and :math:`\sigma_1` refer to the mean and covariance of the train data and
     :math:`\mu_2` and :math:`\sigma_2` refer to the mean and covariance of the test data.
 
-
-    .. note::
-        The default Inception model requires the `torchvision` module to be installed.
-        FID also requires `scipy` module for matrix square root calculations.
-
     More details can be found in `Heusel et al. 2002`__
 
     __ https://arxiv.org/pdf/1706.08500.pdf
@@ -75,6 +70,10 @@ class FID(_BaseInceptionMetric):
         This implementation is inspired by pytorch_fid package which can be found `here`__
 
         __ https://github.com/mseitzer/pytorch-fid
+
+    .. note::
+        The default Inception model requires the `torchvision` module to be installed.
+        FID also requires `scipy` module for matrix square root calculations.
 
     Args:
         num_features: number of features predicted by the model or the reduced feature vector of the image.

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -56,8 +56,11 @@ class FID(_BaseInceptionMetric):
 
     where :math:`\mu_1` and :math:`\sigma_1` refer to the mean and covariance of the train data and
     :math:`\mu_2` and :math:`\sigma_2` refer to the mean and covariance of the test data.
-    If you wish to use the default Inception Model for evaluation, it requires torchvision module.
-    Also, FID uses scipy module for matrix square root calculation.
+
+
+    .. note::
+        The default Inception model requires the `torchvision` module to be installed.
+        FID also requires `scipy` module for matrix square root calculations.
 
     More details can be found in `Heusel et al. 2002`__
 

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -20,7 +20,9 @@ class InceptionScore(_BaseInceptionMetric):
     where :math:`p(y|x)` is the conditional probability of image being the given object and
     :math:`p(y)` is the marginal probability that the given image is real, `G` refers to the
     generated image and :math:`D_{KL}` refers to KL Divergence of the above mentioned probabilities.
-    If you wish to use the default Inception Model for evaluation, it requires torchvision module.
+
+    .. note::
+        The default Inception model requires the `torchvision` module to be installed.
 
     More details can be found in `Barratt et al. 2018`__.
 

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -21,12 +21,12 @@ class InceptionScore(_BaseInceptionMetric):
     :math:`p(y)` is the marginal probability that the given image is real, `G` refers to the
     generated image and :math:`D_{KL}` refers to KL Divergence of the above mentioned probabilities.
 
-    .. note::
-        The default Inception model requires the `torchvision` module to be installed.
-
     More details can be found in `Barratt et al. 2018`__.
 
     __ https://arxiv.org/pdf/1801.01973.pdf
+
+    .. note::
+        The default Inception model requires the `torchvision` module to be installed.
 
 
     Args:

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -20,6 +20,7 @@ class InceptionScore(_BaseInceptionMetric):
     where :math:`p(y|x)` is the conditional probability of image being the given object and
     :math:`p(y)` is the marginal probability that the given image is real, `G` refers to the
     generated image and :math:`D_{KL}` refers to KL Divergence of the above mentioned probabilities.
+    If you wish to use the default Inception Model for evaluation, it requires torchvision module.
 
     More details can be found in `Barratt et al. 2018`__.
 

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -73,7 +73,7 @@ class InceptionScore(_BaseInceptionMetric):
 
         if num_features is None and feature_extractor is None:
             num_features = 1000
-            feature_extractor = InceptionModel(return_features=False)
+            feature_extractor = InceptionModel(return_features=False, device=device)
 
         self._eps = 1e-16
 

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -28,7 +28,6 @@ class InceptionScore(_BaseInceptionMetric):
     .. note::
         The default Inception model requires the `torchvision` module to be installed.
 
-
     Args:
         num_features: number of features predicted by the model or number of classes of the model. Default
             value is 1000.

--- a/ignite/metrics/gan/utils.py
+++ b/ignite/metrics/gan/utils.py
@@ -23,7 +23,6 @@ class InceptionModel(torch.nn.Module):
             raise RuntimeError("This module requires torchvision to be installed.")
         super(InceptionModel, self).__init__()
         self._device = device
-        self.return_features = return_features
         self.model = models.inception_v3(pretrained=True).to(self._device)
         if return_features:
             self.model.fc = torch.nn.Identity()

--- a/ignite/metrics/gan/utils.py
+++ b/ignite/metrics/gan/utils.py
@@ -23,6 +23,7 @@ class InceptionModel(torch.nn.Module):
             raise RuntimeError("This module requires torchvision to be installed.")
         super(InceptionModel, self).__init__()
         self._device = device
+        self.return_features = return_features
         self.model = models.inception_v3(pretrained=True).to(self._device)
         if return_features:
             self.model.fc = torch.nn.Identity()
@@ -37,9 +38,10 @@ class InceptionModel(torch.nn.Module):
         if data.device != torch.device(self._device):
             data = data.to(self._device)
         output = self.model(data)
-        if output.shape[1] == 1000:
+        if self.return_features:
+            return output
+        else:
             return torch.nn.functional.softmax(output, dim=0)
-        return output
 
 
 class _BaseInceptionMetric(Metric):

--- a/ignite/metrics/gan/utils.py
+++ b/ignite/metrics/gan/utils.py
@@ -41,7 +41,7 @@ class InceptionModel(torch.nn.Module):
         if self.return_features:
             return output
         else:
-            return torch.nn.functional.softmax(output, dim=0)
+            return torch.nn.functional.softmax(output, dim=1)
 
 
 class _BaseInceptionMetric(Metric):

--- a/ignite/metrics/gan/utils.py
+++ b/ignite/metrics/gan/utils.py
@@ -36,7 +36,10 @@ class InceptionModel(torch.nn.Module):
             raise ValueError(f"Inputs should be a tensor with 3 channels, got {data.shape}")
         if data.device != torch.device(self._device):
             data = data.to(self._device)
-        return self.model(data)
+        output = self.model(data)
+        if output.shape[1] == 1000:
+            return torch.nn.functional.softmax(output, dim=0)
+        return output
 
 
 class _BaseInceptionMetric(Metric):

--- a/ignite/metrics/gan/utils.py
+++ b/ignite/metrics/gan/utils.py
@@ -27,6 +27,8 @@ class InceptionModel(torch.nn.Module):
         self.model = models.inception_v3(pretrained=True).to(self._device)
         if return_features:
             self.model.fc = torch.nn.Identity()
+        else:
+            self.model.fc = torch.nn.Sequential(self.model.fc, torch.nn.Softmax(dim=1))
         self.model.eval()
 
     @torch.no_grad()
@@ -37,11 +39,7 @@ class InceptionModel(torch.nn.Module):
             raise ValueError(f"Inputs should be a tensor with 3 channels, got {data.shape}")
         if data.device != torch.device(self._device):
             data = data.to(self._device)
-        output = self.model(data)
-        if self.return_features:
-            return output
-        else:
-            return torch.nn.functional.softmax(output, dim=1)
+        return self.model(data)
 
 
 class _BaseInceptionMetric(Metric):

--- a/tests/ignite/metrics/gan/test_utils.py
+++ b/tests/ignite/metrics/gan/test_utils.py
@@ -65,6 +65,14 @@ def test_inception_extractor_wrong_inputs():
         InceptionModel(return_features=True)(torch.rand(2, 2, 2, 0))
 
 
+def test_inception_model_probability():
+    x = torch.rand(2, 3, 299, 299)
+    y = InceptionModel(return_features=False)(x)
+    assert pytest.approx(torch.sum(y[0]).item()) == 1.0
+    assert pytest.approx(torch.sum(y[1]).item()) == 1.0
+    assert torch.all(0 <= y)
+
+
 @pytest.fixture()
 def mock_no_torchvision():
     with patch.dict("sys.modules", {"torchvision": None}):


### PR DESCRIPTION
Description:
Added explicitly that torchvision and scipy are needed for FID and InceptionScore.
Found a bug in InceptionScore due to pre-trained model returning logits instead of probabilities.
Fixed it by applying softmax function to deduce probabilities.
Check list:
- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
