### PR TITLE
Fixed `GMRAE` implementation + Improved for DDP

### DIFF
--- a/ignite/contrib/metrics/regression/geometric_mean_relative_absolute_error.py
+++ b/ignite/contrib/metrics/regression/geometric_mean_relative_absolute_error.py
@@ -1,4 +1,4 @@
-from typing import Tuple, cast
+from typing import List, Tuple, cast
 
 import torch
 
@@ -38,8 +38,8 @@ class GeometricMeanRelativeAbsoluteError(_BaseRegression):
 
     @reinit__is_reduced
     def reset(self) -> None:
-        self._predictions = []
-        self._targets = []
+        self._predictions = []  # type: List[torch.Tensor]
+        self._targets = []  # type: List[torch.Tensor]
 
     def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()

--- a/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
@@ -1,10 +1,10 @@
-import os
+# import os
 
 import numpy as np
 import pytest
 import torch
 
-import ignite.distributed as idist
+# import ignite.distributed as idist
 from ignite.contrib.metrics.regression import GeometricMeanRelativeAbsoluteError
 from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
@@ -45,66 +45,12 @@ def test_geometric_mean_relative_absolute_error():
     assert np_gmrae == pytest.approx(m.compute())
 
 
-def test_geometric_mean_relative_absolute_error_2():
-
-    np.random.seed(1)
-    size = 105
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.random.rand(size, 1)
-    np.random.shuffle(np_y)
-
-    np_y_sum = 0
-    num_examples = 0
-    num_sum_of_errors = 0
-    np_gmrae = 0
-
-    m = GeometricMeanRelativeAbsoluteError()
-    y_pred = torch.from_numpy(np_y_pred)
-    y = torch.from_numpy(np_y)
-
-    m.reset()
-    n_iters = 15
-    batch_size = size // n_iters
-    for i in range(n_iters + 1):
-        idx = i * batch_size
-        np_y_i = np_y[idx : idx + batch_size]
-        np_y_pred_i = np_y_pred[idx : idx + batch_size]
-
-        np_y_sum += np_y_i.sum()
-        num_examples += np_y_i.shape[0]
-        np_mean = np_y_sum / num_examples
-
-        np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
-        m.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
-
-    assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
-
-
 def test_integration_geometric_mean_relative_absolute_error():
 
-    np.random.seed(1)
-    size = 105
-    np_y_pred = np.random.rand(size, 1)
-    np_y = np.random.rand(size, 1)
-    np.random.shuffle(np_y)
+    y_pred = torch.rand(size=(100,))
+    y = torch.rand(size=(100,))
 
-    np_y_sum = 0
-    num_examples = 0
-    num_sum_of_errors = 0
-    np_gmrae = 0
-
-    n_iters = 15
-    batch_size = size // n_iters
-    for i in range(n_iters + 1):
-        idx = i * batch_size
-        np_y_i = np_y[idx : idx + batch_size]
-        np_y_pred_i = np_y_pred[idx : idx + batch_size]
-
-        np_y_sum += np_y_i.sum()
-        num_examples += np_y_i.shape[0]
-        np_mean = np_y_sum / num_examples
-
-        np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
+    batch_size = 10
 
     def update_fn(engine, batch):
         idx = (engine.state.iteration - 1) * batch_size
@@ -115,184 +61,269 @@ def test_integration_geometric_mean_relative_absolute_error():
     engine = Engine(update_fn)
 
     m = GeometricMeanRelativeAbsoluteError()
-    m.attach(engine, "geometric_mean_relative_absolute_error")
+    m.attach(engine, "gmrae")
 
-    data = list(range(size // batch_size))
-    gmrae = engine.run(data, max_epochs=1).metrics["geometric_mean_relative_absolute_error"]
+    np_y = y.numpy().ravel()
+    np_y_pred = y_pred.numpy().ravel()
 
-    assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
+    data = list(range(y_pred.shape[0] // batch_size))
+    gmrae = engine.run(data, max_epochs=1).metrics["gmrae"]
 
+    sum_errors = np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).sum()
+    np_len = len(y_pred)
+    np_ans = np.exp(sum_errors / np_len)
 
-def _test_distrib_compute(device):
-
-    rank = idist.get_rank()
-    torch.manual_seed(12)
-
-    def _test(metric_device):
-        metric_device = torch.device(metric_device)
-        m = GeometricMeanRelativeAbsoluteError(device=metric_device)
-        torch.manual_seed(10 + rank)
-
-        y_pred = torch.rand(size=(100,), device=device)
-        y = torch.rand(size=(100,), device=device)
-
-        m.update((y_pred, y))
-
-        y_pred = idist.all_gather(y_pred)
-        y = idist.all_gather(y)
-
-        np_y = y.cpu().numpy()
-        np_y_pred = y_pred.cpu().numpy()
-
-        np_gmrae = np.exp(np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).mean())
-
-        # sum_y = 0
-        # num_examples = 0
-        # sum_of_errors = 0
-        # np_gmrae = 0
-        # sum_y += np_y.sum()
-        # num_examples += np_y.shape[0]
-        # y_mean = sum_y / num_examples
-        # numerator = np.abs(y.view_as(y_pred) - y_pred)
-        # denominator = np.abs(y.view_as(y_pred) - y_mean)
-        # sum_of_errors += np.log(numerator / denominator).sum()
-        # np_gmrae += np.exp((sum_of_errors / num_examples).mean())
-
-        assert m.compute() == pytest.approx(np_gmrae)
-
-    for _ in range(3):
-        _test("cpu")
-        if device.type != "xla":
-            _test(idist.device())
+    assert np_ans == pytest.approx(gmrae)
 
 
-def _test_distrib_integration(device):
+# def test_geometric_mean_relative_absolute_error_2():
 
-    rank = idist.get_rank()
-    torch.manual_seed(12)
+#     np.random.seed(1)
+#     size = 105
+#     np_y_pred = np.random.rand(size, 1)
+#     np_y = np.random.rand(size, 1)
+#     np.random.shuffle(np_y)
 
-    def _test(n_epochs, metric_device):
-        metric_device = torch.device(metric_device)
-        n_iters = 80
-        s = 16
-        n_classes = 2
+#     np_y_sum = 0
+#     num_examples = 0
+#     num_sum_of_errors = 0
+#     np_gmrae = 0
 
-        offset = n_iters * s
-        y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
-        y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+#     m = GeometricMeanRelativeAbsoluteError()
+#     y_pred = torch.from_numpy(np_y_pred)
+#     y = torch.from_numpy(np_y)
 
-        def update(engine, i):
-            return (
-                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
-                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
-            )
+#     m.reset()
+#     n_iters = 15
+#     batch_size = size // n_iters
+#     for i in range(n_iters + 1):
+#         idx = i * batch_size
+#         np_y_i = np_y[idx : idx + batch_size]
+#         np_y_pred_i = np_y_pred[idx : idx + batch_size]
 
-        engine = Engine(update)
+#         np_y_sum += np_y_i.sum()
+#         num_examples += np_y_i.shape[0]
+#         np_mean = np_y_sum / num_examples
 
-        gmrae = GeometricMeanRelativeAbsoluteError(device=metric_device)
-        gmrae.attach(engine, "gmrae")
+#         np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
+#         m.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
 
-        data = list(range(n_iters))
-        engine.run(data=data, max_epochs=n_epochs)
-
-        assert "gmrae" in engine.state.metrics
-
-        res = engine.state.metrics["gmrae"]
-
-        np_y = y_true.cpu().numpy()
-        np_y_pred = y_preds.cpu().numpy()
-
-        np_y_sum = 0
-        num_examples = 0
-        np_gmrae = 0
-        for i in range(n_iters + 1):
-            np_y_i = np_y[i * s + rank * offset : (i + 1) * s + rank * offset]
-            np_y_pred_i = np_y_pred[i * s + rank * offset : (i + 1) * s + rank * offset]
-
-            np_y_sum += np_y_i.sum()
-            num_examples += np_y_i.shape[0]
-            np_mean = np_y_sum / num_examples
-
-            np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
-
-        assert pytest.approx(res, rel=1e-4) == np.exp(np_gmrae / num_examples)
-
-    metric_devices = ["cpu"]
-    if device.type != "xla":
-        metric_devices.append(idist.device())
-    for metric_device in metric_devices:
-        for _ in range(2):
-            _test(n_epochs=1, metric_device=metric_device)
-            _test(n_epochs=2, metric_device=metric_device)
+#     assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
 
 
-@pytest.mark.distributed
-@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-def test_distrib_nccl_gpu(distributed_context_single_node_nccl):
+# def test_integration_geometric_mean_relative_absolute_error():
 
-    device = idist.device()
-    _test_distrib_compute(device)
-    _test_distrib_integration(device)
+#     np.random.seed(1)
+#     size = 105
+#     np_y_pred = np.random.rand(size, 1)
+#     np_y = np.random.rand(size, 1)
+#     np.random.shuffle(np_y)
 
+#     np_y_sum = 0
+#     num_examples = 0
+#     num_sum_of_errors = 0
+#     np_gmrae = 0
 
-@pytest.mark.distributed
-@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-def test_distrib_gloo_cpu_or_gpu(distributed_context_single_node_gloo):
+#     n_iters = 15
+#     batch_size = size // n_iters
+#     for i in range(n_iters + 1):
+#         idx = i * batch_size
+#         np_y_i = np_y[idx : idx + batch_size]
+#         np_y_pred_i = np_y_pred[idx : idx + batch_size]
 
-    device = idist.device()
-    _test_distrib_compute(device)
-    _test_distrib_integration(device)
+#         np_y_sum += np_y_i.sum()
+#         num_examples += np_y_i.shape[0]
+#         np_mean = np_y_sum / num_examples
 
+#         np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
 
-@pytest.mark.distributed
-@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
-@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
-def test_distrib_hvd(gloo_hvd_executor):
-    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
-    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+#     def update_fn(engine, batch):
+#         idx = (engine.state.iteration - 1) * batch_size
+#         y_true_batch = np_y[idx : idx + batch_size]
+#         y_pred_batch = np_y_pred[idx : idx + batch_size]
+#         return torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
 
-    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
-    gloo_hvd_executor(_test_distrib_integration, (device,), np=nproc, do_init=True)
+#     engine = Engine(update_fn)
 
+#     m = GeometricMeanRelativeAbsoluteError()
+#     m.attach(engine, "geometric_mean_relative_absolute_error")
 
-@pytest.mark.multinode_distributed
-@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
-def test_multinode_distrib_gloo_cpu_or_gpu(distributed_context_multi_node_gloo):
+#     data = list(range(size // batch_size))
+#     gmrae = engine.run(data, max_epochs=1).metrics["geometric_mean_relative_absolute_error"]
 
-    device = idist.device()
-    _test_distrib_compute(device)
-    _test_distrib_integration(device)
-
-
-@pytest.mark.multinode_distributed
-@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
-def test_multinode_distrib_nccl_gpu(distributed_context_multi_node_nccl):
-
-    device = idist.device()
-    _test_distrib_compute(device)
+#     assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
 
 
-@pytest.mark.tpu
-@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
-@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
-def test_distrib_single_device_xla():
-    device = idist.device()
-    _test_distrib_compute(device)
-    _test_distrib_integration(device)
+# def _test_distrib_compute(device):
+
+#     rank = idist.get_rank()
+#     torch.manual_seed(12)
+
+#     def _test(metric_device):
+#         metric_device = torch.device(metric_device)
+#         m = GeometricMeanRelativeAbsoluteError(device=metric_device)
+#         torch.manual_seed(10 + rank)
+
+#         y_pred = torch.rand(size=(100,), device=device)
+#         y = torch.rand(size=(100,), device=device)
+
+#         m.update((y_pred, y))
+
+#         y_pred = idist.all_gather(y_pred)
+#         y = idist.all_gather(y)
+
+#         np_y = y.cpu().numpy()
+#         np_y_pred = y_pred.cpu().numpy()
+
+#         np_gmrae = np.exp(np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).mean())
+
+#         # sum_y = 0
+#         # num_examples = 0
+#         # sum_of_errors = 0
+#         # np_gmrae = 0
+#         # sum_y += np_y.sum()
+#         # num_examples += np_y.shape[0]
+#         # y_mean = sum_y / num_examples
+#         # numerator = np.abs(y.view_as(y_pred) - y_pred)
+#         # denominator = np.abs(y.view_as(y_pred) - y_mean)
+#         # sum_of_errors += np.log(numerator / denominator).sum()
+#         # np_gmrae += np.exp((sum_of_errors / num_examples).mean())
+
+#         assert m.compute() == pytest.approx(np_gmrae)
+
+#     for _ in range(3):
+#         _test("cpu")
+#         if device.type != "xla":
+#             _test(idist.device())
 
 
-def _test_distrib_xla_nprocs(index):
-    device = idist.device()
-    _test_distrib_compute(device)
-    _test_distrib_integration(device)
+# def _test_distrib_integration(device):
+
+#     rank = idist.get_rank()
+#     torch.manual_seed(12)
+
+#     def _test(n_epochs, metric_device):
+#         metric_device = torch.device(metric_device)
+#         n_iters = 80
+#         s = 16
+#         n_classes = 2
+
+#         offset = n_iters * s
+#         y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+#         y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+
+#         def update(engine, i):
+#             return (
+#                 y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+#                 y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+#             )
+
+#         engine = Engine(update)
+
+#         gmrae = GeometricMeanRelativeAbsoluteError(device=metric_device)
+#         gmrae.attach(engine, "gmrae")
+
+#         data = list(range(n_iters))
+#         engine.run(data=data, max_epochs=n_epochs)
+
+#         assert "gmrae" in engine.state.metrics
+
+#         res = engine.state.metrics["gmrae"]
+
+#         np_y = y_true.cpu().numpy()
+#         np_y_pred = y_preds.cpu().numpy()
+
+#         np_y_sum = 0
+#         num_examples = 0
+#         np_gmrae = 0
+#         for i in range(n_iters + 1):
+#             np_y_i = np_y[i * s + rank * offset : (i + 1) * s + rank * offset]
+#             np_y_pred_i = np_y_pred[i * s + rank * offset : (i + 1) * s + rank * offset]
+
+#             np_y_sum += np_y_i.sum()
+#             num_examples += np_y_i.shape[0]
+#             np_mean = np_y_sum / num_examples
+
+#             np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
+
+#         assert pytest.approx(res, rel=1e-4) == np.exp(np_gmrae / num_examples)
+
+#     metric_devices = ["cpu"]
+#     if device.type != "xla":
+#         metric_devices.append(idist.device())
+#     for metric_device in metric_devices:
+#         for _ in range(2):
+#             _test(n_epochs=1, metric_device=metric_device)
+#             _test(n_epochs=2, metric_device=metric_device)
 
 
-@pytest.mark.tpu
-@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
-@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
-def test_distrib_xla_nprocs(xmp_executor):
-    n = int(os.environ["NUM_TPU_WORKERS"])
-    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)
+# @pytest.mark.distributed
+# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+# @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+# def test_distrib_nccl_gpu(distributed_context_single_node_nccl):
+
+#     device = idist.device()
+#     _test_distrib_compute(device)
+#     _test_distrib_integration(device)
+
+
+# @pytest.mark.distributed
+# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+# def test_distrib_gloo_cpu_or_gpu(distributed_context_single_node_gloo):
+
+#     device = idist.device()
+#     _test_distrib_compute(device)
+#     _test_distrib_integration(device)
+
+
+# @pytest.mark.distributed
+# @pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+# @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+# def test_distrib_hvd(gloo_hvd_executor):
+#     device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+#     nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+#     gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+#     gloo_hvd_executor(_test_distrib_integration, (device,), np=nproc, do_init=True)
+
+
+# @pytest.mark.multinode_distributed
+# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+# @pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+# def test_multinode_distrib_gloo_cpu_or_gpu(distributed_context_multi_node_gloo):
+
+#     device = idist.device()
+#     _test_distrib_compute(device)
+#     _test_distrib_integration(device)
+
+
+# @pytest.mark.multinode_distributed
+# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+# @pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+# def test_multinode_distrib_nccl_gpu(distributed_context_multi_node_nccl):
+
+#     device = idist.device()
+#     _test_distrib_compute(device)
+
+
+# @pytest.mark.tpu
+# @pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+# @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+# def test_distrib_single_device_xla():
+#     device = idist.device()
+#     _test_distrib_compute(device)
+#     _test_distrib_integration(device)
+
+
+# def _test_distrib_xla_nprocs(index):
+#     device = idist.device()
+#     _test_distrib_compute(device)
+#     _test_distrib_integration(device)
+
+
+# @pytest.mark.tpu
+# @pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+# @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+# def test_distrib_xla_nprocs(xmp_executor):
+#     n = int(os.environ["NUM_TPU_WORKERS"])
+#     xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)

--- a/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
@@ -1,7 +1,10 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 
+import ignite.distributed as idist
 from ignite.contrib.metrics.regression import GeometricMeanRelativeAbsoluteError
 from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
@@ -77,7 +80,7 @@ def test_geometric_mean_relative_absolute_error_2():
     assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
 
 
-def test_integration_geometric_mean_relative_absolute_error_with_output_transform():
+def test_integration_geometric_mean_relative_absolute_error():
 
     np.random.seed(1)
     size = 105
@@ -107,14 +110,189 @@ def test_integration_geometric_mean_relative_absolute_error_with_output_transfor
         idx = (engine.state.iteration - 1) * batch_size
         y_true_batch = np_y[idx : idx + batch_size]
         y_pred_batch = np_y_pred[idx : idx + batch_size]
-        return idx, torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+        return torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
 
     engine = Engine(update_fn)
 
-    m = GeometricMeanRelativeAbsoluteError(output_transform=lambda x: (x[1], x[2]))
+    m = GeometricMeanRelativeAbsoluteError()
     m.attach(engine, "geometric_mean_relative_absolute_error")
 
     data = list(range(size // batch_size))
     gmrae = engine.run(data, max_epochs=1).metrics["geometric_mean_relative_absolute_error"]
 
     assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
+
+
+def _test_distrib_compute(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        m = GeometricMeanRelativeAbsoluteError(device=metric_device)
+        torch.manual_seed(10 + rank)
+
+        y_pred = torch.rand(size=(100,), device=device)
+        y = torch.rand(size=(100,), device=device)
+
+        m.update((y_pred, y))
+
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
+
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
+
+        np_gmrae = np.exp(np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).mean())
+
+        # sum_y = 0
+        # num_examples = 0
+        # sum_of_errors = 0
+        # np_gmrae = 0
+        # sum_y += np_y.sum()
+        # num_examples += np_y.shape[0]
+        # y_mean = sum_y / num_examples
+        # numerator = np.abs(y.view_as(y_pred) - y_pred)
+        # denominator = np.abs(y.view_as(y_pred) - y_mean)
+        # sum_of_errors += np.log(numerator / denominator).sum()
+        # np_gmrae += np.exp((sum_of_errors / num_examples).mean())
+
+        assert m.compute() == pytest.approx(np_gmrae)
+
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
+
+
+def _test_distrib_integration(device):
+
+    rank = idist.get_rank()
+    torch.manual_seed(12)
+
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
+
+        offset = n_iters * s
+        y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            )
+
+        engine = Engine(update)
+
+        gmrae = GeometricMeanRelativeAbsoluteError(device=metric_device)
+        gmrae.attach(engine, "gmrae")
+
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
+
+        assert "gmrae" in engine.state.metrics
+
+        res = engine.state.metrics["gmrae"]
+
+        np_y = y_true.cpu().numpy()
+        np_y_pred = y_preds.cpu().numpy()
+
+        np_y_sum = 0
+        num_examples = 0
+        np_gmrae = 0
+        for i in range(n_iters + 1):
+            np_y_i = np_y[i * s + rank * offset : (i + 1) * s + rank * offset]
+            np_y_pred_i = np_y_pred[i * s + rank * offset : (i + 1) * s + rank * offset]
+
+            np_y_sum += np_y_i.sum()
+            num_examples += np_y_i.shape[0]
+            np_mean = np_y_sum / num_examples
+
+            np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
+
+        assert pytest.approx(res, rel=1e-4) == np.exp(np_gmrae / num_examples)
+
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_nccl_gpu(distributed_context_single_node_nccl):
+
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_gloo_cpu_or_gpu(distributed_context_single_node_gloo):
+
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration, (device,), np=nproc, do_init=True)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gloo_cpu_or_gpu(distributed_context_multi_node_gloo):
+
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_nccl_gpu(distributed_context_multi_node_nccl):
+
+    device = idist.device()
+    _test_distrib_compute(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
+
+
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)

--- a/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
@@ -99,7 +99,7 @@ def _test_distrib_compute(device):
 
         np_gmrae = np.exp(np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).mean())
 
-        assert m.compute() == pytest.approx(np_gmrae)
+        assert m.compute() == pytest.approx(np_gmrae, rel=1e-4)
 
     for _ in range(3):
         _test("cpu")

--- a/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_geometric_mean_relative_absolute_error.py
@@ -1,10 +1,10 @@
-# import os
+import os
 
 import numpy as np
 import pytest
 import torch
 
-# import ignite.distributed as idist
+import ignite.distributed as idist
 from ignite.contrib.metrics.regression import GeometricMeanRelativeAbsoluteError
 from ignite.engine import Engine
 from ignite.exceptions import NotComputableError
@@ -29,7 +29,7 @@ def test_wrong_input_shapes():
         m.update((torch.rand(4, 1), torch.rand(4,)))
 
 
-def test_geometric_mean_relative_absolute_error():
+def test_compute():
     size = 51
     np_y_pred = np.random.rand(size,)
     np_y = np.random.rand(size,)
@@ -45,7 +45,7 @@ def test_geometric_mean_relative_absolute_error():
     assert np_gmrae == pytest.approx(m.compute())
 
 
-def test_integration_geometric_mean_relative_absolute_error():
+def test_integration():
 
     y_pred = torch.rand(size=(100,))
     y = torch.rand(size=(100,))
@@ -76,254 +76,153 @@ def test_integration_geometric_mean_relative_absolute_error():
     assert np_ans == pytest.approx(gmrae)
 
 
-# def test_geometric_mean_relative_absolute_error_2():
+def _test_distrib_compute(device):
 
-#     np.random.seed(1)
-#     size = 105
-#     np_y_pred = np.random.rand(size, 1)
-#     np_y = np.random.rand(size, 1)
-#     np.random.shuffle(np_y)
+    rank = idist.get_rank()
+    torch.manual_seed(12)
 
-#     np_y_sum = 0
-#     num_examples = 0
-#     num_sum_of_errors = 0
-#     np_gmrae = 0
+    def _test(metric_device):
+        metric_device = torch.device(metric_device)
+        m = GeometricMeanRelativeAbsoluteError(device=metric_device)
+        torch.manual_seed(10 + rank)
 
-#     m = GeometricMeanRelativeAbsoluteError()
-#     y_pred = torch.from_numpy(np_y_pred)
-#     y = torch.from_numpy(np_y)
+        y_pred = torch.rand(size=(100,), device=device)
+        y = torch.rand(size=(100,), device=device)
 
-#     m.reset()
-#     n_iters = 15
-#     batch_size = size // n_iters
-#     for i in range(n_iters + 1):
-#         idx = i * batch_size
-#         np_y_i = np_y[idx : idx + batch_size]
-#         np_y_pred_i = np_y_pred[idx : idx + batch_size]
+        m.update((y_pred, y))
 
-#         np_y_sum += np_y_i.sum()
-#         num_examples += np_y_i.shape[0]
-#         np_mean = np_y_sum / num_examples
+        y_pred = idist.all_gather(y_pred)
+        y = idist.all_gather(y)
 
-#         np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
-#         m.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+        np_y = y.cpu().numpy()
+        np_y_pred = y_pred.cpu().numpy()
 
-#     assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
+        np_gmrae = np.exp(np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).mean())
 
+        assert m.compute() == pytest.approx(np_gmrae)
 
-# def test_integration_geometric_mean_relative_absolute_error():
+    for _ in range(3):
+        _test("cpu")
+        if device.type != "xla":
+            _test(idist.device())
 
-#     np.random.seed(1)
-#     size = 105
-#     np_y_pred = np.random.rand(size, 1)
-#     np_y = np.random.rand(size, 1)
-#     np.random.shuffle(np_y)
 
-#     np_y_sum = 0
-#     num_examples = 0
-#     num_sum_of_errors = 0
-#     np_gmrae = 0
+def _test_distrib_integration(device):
 
-#     n_iters = 15
-#     batch_size = size // n_iters
-#     for i in range(n_iters + 1):
-#         idx = i * batch_size
-#         np_y_i = np_y[idx : idx + batch_size]
-#         np_y_pred_i = np_y_pred[idx : idx + batch_size]
+    rank = idist.get_rank()
+    torch.manual_seed(12)
 
-#         np_y_sum += np_y_i.sum()
-#         num_examples += np_y_i.shape[0]
-#         np_mean = np_y_sum / num_examples
+    def _test(n_epochs, metric_device):
+        metric_device = torch.device(metric_device)
+        n_iters = 80
+        s = 16
+        n_classes = 2
 
-#         np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
+        offset = n_iters * s
+        y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
 
-#     def update_fn(engine, batch):
-#         idx = (engine.state.iteration - 1) * batch_size
-#         y_true_batch = np_y[idx : idx + batch_size]
-#         y_pred_batch = np_y_pred[idx : idx + batch_size]
-#         return torch.from_numpy(y_pred_batch), torch.from_numpy(y_true_batch)
+        def update(engine, i):
+            return (
+                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
+                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            )
 
-#     engine = Engine(update_fn)
+        engine = Engine(update)
 
-#     m = GeometricMeanRelativeAbsoluteError()
-#     m.attach(engine, "geometric_mean_relative_absolute_error")
+        gmrae = GeometricMeanRelativeAbsoluteError(device=metric_device)
+        gmrae.attach(engine, "gmrae")
 
-#     data = list(range(size // batch_size))
-#     gmrae = engine.run(data, max_epochs=1).metrics["geometric_mean_relative_absolute_error"]
+        data = list(range(n_iters))
+        engine.run(data=data, max_epochs=n_epochs)
 
-#     assert np.exp(np_gmrae / num_examples) == pytest.approx(m.compute())
+        assert "gmrae" in engine.state.metrics
 
+        res = engine.state.metrics["gmrae"]
 
-# def _test_distrib_compute(device):
+        np_y = y_true.cpu().numpy()
+        np_y_pred = y_preds.cpu().numpy()
 
-#     rank = idist.get_rank()
-#     torch.manual_seed(12)
+        np_gmrae = np.exp(np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).mean())
 
-#     def _test(metric_device):
-#         metric_device = torch.device(metric_device)
-#         m = GeometricMeanRelativeAbsoluteError(device=metric_device)
-#         torch.manual_seed(10 + rank)
+        assert pytest.approx(res, rel=1e-4) == np_gmrae
 
-#         y_pred = torch.rand(size=(100,), device=device)
-#         y = torch.rand(size=(100,), device=device)
+    metric_devices = ["cpu"]
+    if device.type != "xla":
+        metric_devices.append(idist.device())
+    for metric_device in metric_devices:
+        for _ in range(2):
+            _test(n_epochs=1, metric_device=metric_device)
+            _test(n_epochs=2, metric_device=metric_device)
 
-#         m.update((y_pred, y))
 
-#         y_pred = idist.all_gather(y_pred)
-#         y = idist.all_gather(y)
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
+def test_distrib_nccl_gpu(distributed_context_single_node_nccl):
 
-#         np_y = y.cpu().numpy()
-#         np_y_pred = y_pred.cpu().numpy()
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
 
-#         np_gmrae = np.exp(np.log(np.abs(np_y - np_y_pred) / np.abs(np_y - np_y.mean())).mean())
 
-#         # sum_y = 0
-#         # num_examples = 0
-#         # sum_of_errors = 0
-#         # np_gmrae = 0
-#         # sum_y += np_y.sum()
-#         # num_examples += np_y.shape[0]
-#         # y_mean = sum_y / num_examples
-#         # numerator = np.abs(y.view_as(y_pred) - y_pred)
-#         # denominator = np.abs(y.view_as(y_pred) - y_mean)
-#         # sum_of_errors += np.log(numerator / denominator).sum()
-#         # np_gmrae += np.exp((sum_of_errors / num_examples).mean())
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+def test_distrib_gloo_cpu_or_gpu(distributed_context_single_node_gloo):
 
-#         assert m.compute() == pytest.approx(np_gmrae)
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
 
-#     for _ in range(3):
-#         _test("cpu")
-#         if device.type != "xla":
-#             _test(idist.device())
 
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
+@pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
+def test_distrib_hvd(gloo_hvd_executor):
+    device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
+    nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
 
-# def _test_distrib_integration(device):
+    gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
+    gloo_hvd_executor(_test_distrib_integration, (device,), np=nproc, do_init=True)
 
-#     rank = idist.get_rank()
-#     torch.manual_seed(12)
 
-#     def _test(n_epochs, metric_device):
-#         metric_device = torch.device(metric_device)
-#         n_iters = 80
-#         s = 16
-#         n_classes = 2
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_gloo_cpu_or_gpu(distributed_context_multi_node_gloo):
 
-#         offset = n_iters * s
-#         y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
-#         y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
 
-#         def update(engine, i):
-#             return (
-#                 y_preds[i * s + rank * offset : (i + 1) * s + rank * offset],
-#                 y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
-#             )
 
-#         engine = Engine(update)
+@pytest.mark.multinode_distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
+def test_multinode_distrib_nccl_gpu(distributed_context_multi_node_nccl):
 
-#         gmrae = GeometricMeanRelativeAbsoluteError(device=metric_device)
-#         gmrae.attach(engine, "gmrae")
+    device = idist.device()
+    _test_distrib_compute(device)
 
-#         data = list(range(n_iters))
-#         engine.run(data=data, max_epochs=n_epochs)
 
-#         assert "gmrae" in engine.state.metrics
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_single_device_xla():
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
 
-#         res = engine.state.metrics["gmrae"]
 
-#         np_y = y_true.cpu().numpy()
-#         np_y_pred = y_preds.cpu().numpy()
+def _test_distrib_xla_nprocs(index):
+    device = idist.device()
+    _test_distrib_compute(device)
+    _test_distrib_integration(device)
 
-#         np_y_sum = 0
-#         num_examples = 0
-#         np_gmrae = 0
-#         for i in range(n_iters + 1):
-#             np_y_i = np_y[i * s + rank * offset : (i + 1) * s + rank * offset]
-#             np_y_pred_i = np_y_pred[i * s + rank * offset : (i + 1) * s + rank * offset]
 
-#             np_y_sum += np_y_i.sum()
-#             num_examples += np_y_i.shape[0]
-#             np_mean = np_y_sum / num_examples
-
-#             np_gmrae += np.log(np.abs(np_y_i - np_y_pred_i) / np.abs(np_y_i - np_mean)).sum()
-
-#         assert pytest.approx(res, rel=1e-4) == np.exp(np_gmrae / num_examples)
-
-#     metric_devices = ["cpu"]
-#     if device.type != "xla":
-#         metric_devices.append(idist.device())
-#     for metric_device in metric_devices:
-#         for _ in range(2):
-#             _test(n_epochs=1, metric_device=metric_device)
-#             _test(n_epochs=2, metric_device=metric_device)
-
-
-# @pytest.mark.distributed
-# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-# @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-# def test_distrib_nccl_gpu(distributed_context_single_node_nccl):
-
-#     device = idist.device()
-#     _test_distrib_compute(device)
-#     _test_distrib_integration(device)
-
-
-# @pytest.mark.distributed
-# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-# def test_distrib_gloo_cpu_or_gpu(distributed_context_single_node_gloo):
-
-#     device = idist.device()
-#     _test_distrib_compute(device)
-#     _test_distrib_integration(device)
-
-
-# @pytest.mark.distributed
-# @pytest.mark.skipif(not idist.has_hvd_support, reason="Skip if no Horovod dist support")
-# @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
-# def test_distrib_hvd(gloo_hvd_executor):
-#     device = torch.device("cpu" if not torch.cuda.is_available() else "cuda")
-#     nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
-
-#     gloo_hvd_executor(_test_distrib_compute, (device,), np=nproc, do_init=True)
-#     gloo_hvd_executor(_test_distrib_integration, (device,), np=nproc, do_init=True)
-
-
-# @pytest.mark.multinode_distributed
-# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-# @pytest.mark.skipif("MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
-# def test_multinode_distrib_gloo_cpu_or_gpu(distributed_context_multi_node_gloo):
-
-#     device = idist.device()
-#     _test_distrib_compute(device)
-#     _test_distrib_integration(device)
-
-
-# @pytest.mark.multinode_distributed
-# @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-# @pytest.mark.skipif("GPU_MULTINODE_DISTRIB" not in os.environ, reason="Skip if not multi-node distributed")
-# def test_multinode_distrib_nccl_gpu(distributed_context_multi_node_nccl):
-
-#     device = idist.device()
-#     _test_distrib_compute(device)
-
-
-# @pytest.mark.tpu
-# @pytest.mark.skipif("NUM_TPU_WORKERS" in os.environ, reason="Skip if NUM_TPU_WORKERS is in env vars")
-# @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
-# def test_distrib_single_device_xla():
-#     device = idist.device()
-#     _test_distrib_compute(device)
-#     _test_distrib_integration(device)
-
-
-# def _test_distrib_xla_nprocs(index):
-#     device = idist.device()
-#     _test_distrib_compute(device)
-#     _test_distrib_integration(device)
-
-
-# @pytest.mark.tpu
-# @pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
-# @pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
-# def test_distrib_xla_nprocs(xmp_executor):
-#     n = int(os.environ["NUM_TPU_WORKERS"])
-#     xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)
+@pytest.mark.tpu
+@pytest.mark.skipif("NUM_TPU_WORKERS" not in os.environ, reason="Skip if no NUM_TPU_WORKERS in env vars")
+@pytest.mark.skipif(not idist.has_xla_support, reason="Skip if no PyTorch XLA package")
+def test_distrib_xla_nprocs(xmp_executor):
+    n = int(os.environ["NUM_TPU_WORKERS"])
+    xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)


### PR DESCRIPTION
Fixes #2087, #1284 

- Fixed GMRAE implementation to be somehow similar to EpochMetric, all the `predictions` and `targets` gathered first then compute the GMRAE on all the gathered values to avoid the misleading results because of computing the mean over a single batch.
- Updated the integration tests.
- Made the metric compatible with DDP and added the necessary tests.

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
