### PR TITLE
BUG: Fix the NVIDIA/Apex installation on Colab

### DIFF
--- a/examples/notebooks/Cifar100_bench_amp.ipynb
+++ b/examples/notebooks/Cifar100_bench_amp.ipynb
@@ -88,7 +88,10 @@
    },
    "source": [
     "# Install Apex:\n",
-    "!pip install --upgrade --no-cache-dir --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext\" git+https://github.com/NVIDIA/apex/"
+    "# If torch cuda version and nvcc version match:\n",
+    "!pip install --upgrade --no-cache-dir --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext\" git+https://github.com/NVIDIA/apex/\n",
+    "# if above command is failing, please install apex without c++/cuda extensions:\n",
+    "# !pip install --upgrade --no-cache-dir git+https://github.com/NVIDIA/apex/"
    ],
    "execution_count": null,
    "outputs": []

--- a/examples/notebooks/CycleGAN_with_nvidia_apex.ipynb
+++ b/examples/notebooks/CycleGAN_with_nvidia_apex.ipynb
@@ -147,7 +147,10 @@
    },
    "source": [
     "# Install Apex:\n",
-    "!pip install --upgrade --no-cache-dir --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext\" git+https://github.com/NVIDIA/apex/"
+    "# If torch cuda version and nvcc version match:\n",
+    "!pip install --upgrade --no-cache-dir --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext\" git+https://github.com/NVIDIA/apex/\n",
+    "# if above command is failing, please install apex without c++/cuda extensions:\n",
+    "# !pip install --upgrade --no-cache-dir git+https://github.com/NVIDIA/apex/"
    ],
    "execution_count": null,
    "outputs": []

--- a/examples/notebooks/EfficientNet_Cifar100_finetuning.ipynb
+++ b/examples/notebooks/EfficientNet_Cifar100_finetuning.ipynb
@@ -110,7 +110,10 @@
    },
    "source": [
     "# Install Apex:\n",
-    "!pip install --upgrade --no-cache-dir --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext\" git+https://github.com/NVIDIA/apex/"
+    "# If torch cuda version and nvcc version match:\n",
+    "!pip install --upgrade --no-cache-dir --global-option=\"--cpp_ext\" --global-option=\"--cuda_ext\" git+https://github.com/NVIDIA/apex/\n",
+    "# if above command is failing, please install apex without c++/cuda extensions:\n",
+    "# !pip install --upgrade --no-cache-dir git+https://github.com/NVIDIA/apex/"
    ],
    "execution_count": null,
    "outputs": []
@@ -589,9 +592,7 @@
    "metadata": {
     "id": "0CcItj-CsXp0"
    },
-   "source": [
-    ""
-   ],
+   "source": [],
    "execution_count": null,
    "outputs": []
   },


### PR DESCRIPTION
Fixes #2113 

Description: 
NVIDIA/Apex installation errored out because of a mismatch in torch cuda version and nvcc version on Google Colab.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
