### PR TITLE
Modify auto_dataloader() to not wrap user provided DistributedSampler

### DIFF
--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -88,10 +88,7 @@ def auto_dataloader(dataset: Dataset, **kwargs: Any) -> Union[DataLoader, "_MpDe
                 sampler = kwargs.get("sampler", None)
                 if isinstance(sampler, DistributedSampler):
                     if sampler.rank != rank:
-                        warnings.warn(
-                            f"Found distributed sampler with rank={sampler.rank}, "
-                            f"but process rank is {rank}"
-                        )
+                        warnings.warn(f"Found distributed sampler with rank={sampler.rank}, but process rank is {rank}")
                     if sampler.num_replicas != world_size:
                         warnings.warn(
                             f"Found distributed sampler with num_replicas={sampler.num_replicas}, "

--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -27,7 +27,7 @@ def auto_dataloader(dataset: Dataset, **kwargs: Any) -> Union[DataLoader, "_MpDe
     - number of workers is scaled by number of local processes: ``num_workers / nprocs`` if larger or equal world size.
     - if no sampler provided by user, a `torch DistributedSampler`_ is setup.
     - if a `torch DistributedSampler`_ is provided by user, it is used without wrapping it.
-    - if another sampler is provided by user, it is wrapped by :class:`~ignite.distributed.auto.DistributedProxySampler`.
+    - if another sampler is provided, it is wrapped by :class:`~ignite.distributed.auto.DistributedProxySampler`.
     - if the default device is 'cuda', `pin_memory` is automatically set to `True`.
 
     .. warning::

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -107,7 +107,10 @@ def _test_auto_dataloader(ws, nproc, batch_size, num_workers=1, sampler_name=Non
         if isinstance(data, IterableDataset):
             sampler_type = _InfiniteConstantSampler
         elif ws > 1:
-            sampler_type = DistributedSampler if sampler is None else DistributedProxySampler
+            if sampler is None or isinstance(sampler, DistributedSampler):
+                sampler_type = DistributedSampler
+            else:
+                sampler_type = DistributedProxySampler
         else:
             sampler_type = RandomSampler if sampler is None else type(sampler)
 

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -62,9 +62,9 @@ def test_auto_dataloader_warning_distributed_sampler(distributed_context_single_
         expected_warning = f"Found distributed sampler with rank={wrong_rank}, but process rank is {rank}"
         with pytest.warns(UserWarning, match=expected_warning):
             auto_dataloader(dataset, sampler=DistributedSampler(dataset, num_replicas=world_size, rank=wrong_rank))
-        expected_warning = f"Found distributed sampler with num_replicas={world_size + 1}, but world size is {world_size}"
-        with pytest.warns(UserWarning, match=expected_warning):
-            auto_dataloader(dataset, sampler=DistributedSampler(dataset, num_replicas=world_size + 1, rank=rank))
+    expected_warning = f"Found distributed sampler with num_replicas={world_size + 1}, but world size is {world_size}"
+    with pytest.warns(UserWarning, match=expected_warning):
+        auto_dataloader(dataset, sampler=DistributedSampler(dataset, num_replicas=world_size + 1, rank=rank))
 
 
 @pytest.mark.tpu


### PR DESCRIPTION
Closes #2118

Description:
Pass user provided `DistributedSampler` on to data loader without wrapping it.

Check list:
- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
