### PR TITLE
Raise error in DistributedProxySampler when sampler is already a DistributedSampler

### DIFF
--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -296,6 +296,9 @@ class DistributedProxySampler(DistributedSampler):
         if not isinstance(sampler, Sampler):
             raise TypeError(f"Argument sampler should be instance of torch Sampler, but given: {type(sampler)}")
 
+        if isinstance(sampler, DistributedSampler):
+            raise TypeError("Argument sampler must not be a distributed sampler already")
+
         if not hasattr(sampler, "__len__"):
             raise TypeError("Argument sampler should have length")
 

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -273,3 +273,6 @@ def test_dist_proxy_sampler():
 
     with pytest.raises(TypeError, match=r"Argument sampler should have length"):
         DistributedProxySampler(Sampler([1]))
+
+    with pytest.raises(TypeError, match=r"Argument sampler must not be a distributed sampler already"):
+        DistributedProxySampler(DistributedSampler(sampler, num_replicas=num_replicas, rank=0))


### PR DESCRIPTION
Raise TypeError when sampler passed on to DistributedProxySampler is of type DistributedSampler. See #2118.