### PR TITLE
docs: add `TimeLimit` back to handlers

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -17,6 +17,7 @@ Complete list of handlers
     early_stopping.EarlyStopping
     lr_finder.FastaiLRFinder
     terminate_on_nan.TerminateOnNan
+    TimeLimit
     time_profilers.BasicTimeProfiler
     time_profilers.HandlersTimeProfiler
     timing.Timer


### PR DESCRIPTION
It was removed in [#2132-diff](https://github.com/pytorch/ignite/pull/2132/files#diff-fed20f17bf0c40747938f76730fe5cdc467c919bd185eeb9fe0870b861379681).

I think it was an accident.

/cc @KickItLikeShika 

