### PR TITLE
Enabled LRFinder to run multiple epochs

### DIFF
--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -98,26 +98,15 @@ class FastaiLRFinder:
         self._best_loss = None
         self._diverge_flag = False
 
-        # print(trainer.state.epoch_length)
-        # print(trainer.state.max_epochs)
-        # print(num_iter // trainer.state.epoch_length)
         # attach LRScheduler to trainer.
         if num_iter is None:
             num_iter = trainer.state.epoch_length * trainer.state.max_epochs
         else:
             max_iter = trainer.state.epoch_length * trainer.state.max_epochs  # type: ignore[operator]
-            print(f"max iters: {max_iter}")
             if max_iter < num_iter:
                 max_iter = num_iter
                 trainer.state.max_iters = num_iter
                 trainer.state.max_epochs = num_iter // trainer.state.epoch_length
-            print(f"max iters: {max_iter}")
-            if num_iter > max_iter:
-                warnings.warn(
-                    f"Desired num_iter {num_iter} is unreachable with the current run setup of {max_iter} iteration "
-                    f"({trainer.state.max_epochs} epochs)",
-                    UserWarning,
-                )
 
         if not trainer.has_event_handler(self._reached_num_iterations):
             trainer.add_event_handler(Events.ITERATION_COMPLETED, self._reached_num_iterations, num_iter)
@@ -504,7 +493,6 @@ class _ExponentialLR(_LRScheduler):
     def __init__(self, optimizer: Optimizer, start_lr: float, end_lr: float, num_iter: int, last_epoch: int = -1):
         self.end_lr = end_lr
         self.num_iter = num_iter
-        self.shit = 0
         super(_ExponentialLR, self).__init__(optimizer, last_epoch)
 
         # override base_lrs
@@ -512,8 +500,5 @@ class _ExponentialLR(_LRScheduler):
 
     def get_lr(self) -> List[float]:  # type: ignore
         curr_iter = self.last_epoch + 1  # type: ignore[attr-defined]
-        # print(self.num_iter)
-        self.shit += 1
-        print(self.shit)
         r = curr_iter / self.num_iter
         return [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]  # type: ignore[attr-defined]

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -106,7 +106,7 @@ class FastaiLRFinder:
             if max_iter < num_iter:
                 max_iter = num_iter
                 trainer.state.max_iters = num_iter
-                trainer.state.max_epochs = num_iter // trainer.state.epoch_length
+                trainer.state.max_epochs = num_iter // trainer.state.epoch_length  # type: ignore[operator]
 
         if not trainer.has_event_handler(self._reached_num_iterations):
             trainer.add_event_handler(Events.ITERATION_COMPLETED, self._reached_num_iterations, num_iter)

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -118,7 +118,6 @@ class FastaiLRFinder:
             )
 
         self.logger.debug(f"Running LR finder for {num_iter} iterations")
-        print(f"num_iter {num_iter}")
         if start_lr is None:
             start_lr = optimizer.param_groups[0]["lr"]
         # Initialize the proper learning rate policy

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -98,11 +98,20 @@ class FastaiLRFinder:
         self._best_loss = None
         self._diverge_flag = False
 
+        # print(trainer.state.epoch_length)
+        # print(trainer.state.max_epochs)
+        # print(num_iter // trainer.state.epoch_length)
         # attach LRScheduler to trainer.
         if num_iter is None:
             num_iter = trainer.state.epoch_length * trainer.state.max_epochs
         else:
             max_iter = trainer.state.epoch_length * trainer.state.max_epochs  # type: ignore[operator]
+            print(f"max iters: {max_iter}")
+            if max_iter < num_iter:
+                max_iter = num_iter
+                trainer.state.max_iters = num_iter
+                trainer.state.max_epochs = num_iter // trainer.state.epoch_length
+            print(f"max iters: {max_iter}")
             if num_iter > max_iter:
                 warnings.warn(
                     f"Desired num_iter {num_iter} is unreachable with the current run setup of {max_iter} iteration "
@@ -120,6 +129,7 @@ class FastaiLRFinder:
             )
 
         self.logger.debug(f"Running LR finder for {num_iter} iterations")
+        print(f"num_iter {num_iter}")
         if start_lr is None:
             start_lr = optimizer.param_groups[0]["lr"]
         # Initialize the proper learning rate policy
@@ -494,6 +504,7 @@ class _ExponentialLR(_LRScheduler):
     def __init__(self, optimizer: Optimizer, start_lr: float, end_lr: float, num_iter: int, last_epoch: int = -1):
         self.end_lr = end_lr
         self.num_iter = num_iter
+        self.shit = 0
         super(_ExponentialLR, self).__init__(optimizer, last_epoch)
 
         # override base_lrs
@@ -501,5 +512,8 @@ class _ExponentialLR(_LRScheduler):
 
     def get_lr(self) -> List[float]:  # type: ignore
         curr_iter = self.last_epoch + 1  # type: ignore[attr-defined]
+        # print(self.num_iter)
+        self.shit += 1
+        print(self.shit)
         r = curr_iter / self.num_iter
         return [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]  # type: ignore[attr-defined]

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 import tempfile
 import warnings
+from math import ceil
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
@@ -106,7 +107,7 @@ class FastaiLRFinder:
             if max_iter < num_iter:
                 max_iter = num_iter
                 trainer.state.max_iters = num_iter
-                trainer.state.max_epochs = num_iter // trainer.state.epoch_length  # type: ignore[operator]
+                trainer.state.max_epochs = ceil(num_iter / trainer.state.epoch_length)  # type: ignore[operator]
 
         if not trainer.has_event_handler(self._reached_num_iterations):
             trainer.add_event_handler(Events.ITERATION_COMPLETED, self._reached_num_iterations, num_iter)

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -946,7 +946,6 @@ class PiecewiseLinear(ParamScheduler):
         self.milestones = milestones
         self._index = 0
         self._state_attrs += ["values", "milestones", "_index"]
-        self.shit = 0
 
     def _get_start_end(self) -> Tuple[int, int, float, float]:
         if self.milestones[0] > self.event_index:
@@ -965,8 +964,6 @@ class PiecewiseLinear(ParamScheduler):
             return self._get_start_end()
 
     def get_param(self) -> float:
-        self.shit += 1
-        print(self.shit)
         start_index, end_index, start_value, end_value = self._get_start_end()
         return start_value + (end_value - start_value) * (self.event_index - start_index) / (end_index - start_index)
 

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -946,6 +946,7 @@ class PiecewiseLinear(ParamScheduler):
         self.milestones = milestones
         self._index = 0
         self._state_attrs += ["values", "milestones", "_index"]
+        self.shit = 0
 
     def _get_start_end(self) -> Tuple[int, int, float, float]:
         if self.milestones[0] > self.event_index:
@@ -964,6 +965,8 @@ class PiecewiseLinear(ParamScheduler):
             return self._get_start_end()
 
     def get_param(self) -> float:
+        self.shit += 1
+        print(self.shit)
         start_index, end_index, start_value, end_value = self._get_start_end()
         return start_value + (end_value - start_value) * (self.event_index - start_index) / (end_index - start_index)
 

--- a/tests/ignite/handlers/test_lr_finder.py
+++ b/tests/ignite/handlers/test_lr_finder.py
@@ -321,12 +321,16 @@ def test_detach_terminates(lr_finder, to_save, dummy_engine, dataloader, recwarn
     # assert len(recwarn) == 0
 
 
-def test_temp(lr_finder, to_save, dummy_engine, dataloader):
-    # we have 100 batches
-    with lr_finder.attach(dummy_engine, to_save) as trainer_with_finder:
+def test_different_num_iters(lr_finder, to_save, dummy_engine, dataloader):
+    with lr_finder.attach(dummy_engine, to_save, num_iter=200) as trainer_with_finder:
         trainer_with_finder.run(dataloader)
+    len_lrs_few_iters = len(lr_finder._history["lr"])
 
-    assert False
+    with lr_finder.attach(dummy_engine, to_save, num_iter=1000) as trainer_with_finder:
+        trainer_with_finder.run(dataloader)
+    len_lrs_many_iters = len(lr_finder._history["lr"])
+
+    assert len_lrs_many_iters - len_lrs_few_iters > 500
 
 
 @pytest.mark.parametrize("step_mode", ["exp", "linear"])

--- a/tests/ignite/handlers/test_lr_finder.py
+++ b/tests/ignite/handlers/test_lr_finder.py
@@ -321,6 +321,14 @@ def test_detach_terminates(lr_finder, to_save, dummy_engine, dataloader, recwarn
     # assert len(recwarn) == 0
 
 
+def test_temp(lr_finder, to_save, dummy_engine, dataloader):
+    # we have 100 batches
+    with lr_finder.attach(dummy_engine, to_save) as trainer_with_finder:
+        trainer_with_finder.run(dataloader)
+
+    assert False
+
+
 @pytest.mark.parametrize("step_mode", ["exp", "linear"])
 def test_start_lr(lr_finder, to_save, dummy_engine, dataloader, step_mode):
     with lr_finder.attach(


### PR DESCRIPTION
Fixes #1357

Previously LRFinder raises a warning if `num_iter` was equivalent to more than 1 epoch, fixed that, and it runs more than 1 epoch now.

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
