### PR TITLE
Fix tcp error with pytorch 1.9.1

### DIFF
--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -204,8 +204,7 @@ def test_auto_methods_gloo(distributed_context_single_node_gloo):
     _test_auto_model_optimizer(ws, device)
 
     if ws > 1 and device.type == "cpu":
-        error_type = AssertionError if LooseVersion(torch.__version__) <= LooseVersion("1.9.0") else ValueError
-        with pytest.raises(error_type, match=r"SyncBatchNorm layers only work with GPU modules"):
+        with pytest.raises(AssertionError, match=r"SyncBatchNorm layers only work with GPU modules"):
             model = nn.Sequential(nn.Linear(20, 100), nn.BatchNorm1d(100))
             auto_model(model, sync_bn=True)
 

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -1,5 +1,4 @@
 import os
-from distutils.version import LooseVersion
 
 import pytest
 import torch

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -1,4 +1,5 @@
 import os
+from distutils.version import LooseVersion
 
 import pytest
 import torch
@@ -203,7 +204,8 @@ def test_auto_methods_gloo(distributed_context_single_node_gloo):
     _test_auto_model_optimizer(ws, device)
 
     if ws > 1 and device.type == "cpu":
-        with pytest.raises(AssertionError, match=r"SyncBatchNorm layers only work with GPU modules"):
+        error_type = AssertionError if "dev" not in torch.__version__ else ValueError
+        with pytest.raises(error_type, match=r"SyncBatchNorm layers only work with GPU modules"):
             model = nn.Sequential(nn.Linear(20, 100), nn.BatchNorm1d(100))
             auto_model(model, sync_bn=True)
 

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -87,7 +87,7 @@ def _test_check_idist_parallel_torch_launch(init_method, fp, backend, nprocs):
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip because test uses torch launch")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:29500", "FILE"])
 def test_check_idist_parallel_torch_launch_n_procs_gloo(init_method, dirname, exec_filepath):
     if init_method == "FILE":
         init_method = f"file://{dirname}/shared"
@@ -102,7 +102,7 @@ def test_check_idist_parallel_torch_launch_n_procs_gloo(init_method, dirname, ex
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip because test uses torch launch")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:29500", "FILE"])
 def test_check_idist_parallel_torch_launch_n_procs_nccl(init_method, dirname, exec_filepath):
     if init_method == "FILE":
         init_method = f"file://{dirname}/shared"
@@ -198,7 +198,7 @@ def _test_func(index, ws, device, backend, true_init_method):
 @pytest.mark.distributed
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.parametrize("init_method", ["env://", "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", ["env://", "tcp://0.0.0.0:29500", "FILE"])
 @pytest.mark.parametrize(
     "backend",
     ["gloo", pytest.param("nccl", marks=pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU"))],
@@ -216,7 +216,7 @@ def test_idist_parallel_spawn_n_procs_native(init_method, backend, dirname):
 @pytest.mark.distributed
 @pytest.mark.skipif("WORLD_SIZE" not in os.environ, reason="Skip if not launched as multiproc")
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.parametrize("init_method", ["env://", "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", ["env://", "tcp://0.0.0.0:29500", "FILE"])
 @pytest.mark.parametrize(
     "backend",
     ["gloo", pytest.param("nccl", marks=pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU"))],


### PR DESCRIPTION
Fixes #2210

Description:

It seems that using PyTorch 1.9.1, `tcp` port should have the same value than `master_port`. Default is `29500`.  

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
