### PR TITLE
Make documentation subsection headers bold

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==3.4.3
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib-katex
+sphinx-copybutton==0.4.0

--- a/docs/source/_templates/_static/css/ignite_theme.css
+++ b/docs/source/_templates/_static/css/ignite_theme.css
@@ -209,3 +209,14 @@ so make sure not to go above that value */
   }
 }
 /* docsearch end */
+
+article.pytorch-article p.rubric {
+    font-weight: bold;
+    font-size: 19px;
+    margin: 15px 0 10px 0;
+}
+
+pre {
+    border: 1px solid rgba(0,0,0,0.15);
+    border-radius: 4px;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx_copybutton",
 ]
 
 # katex options
@@ -123,7 +124,7 @@ html_favicon = "_templates/_static/img/ignite_logomark.svg"
 html_static_path = ["_static", "_templates/_static"]
 
 html_context = {
-    "css_files": [
+    "extra_css_files": [
         # 'https://fonts.googleapis.com/css?family=Lato',
         # '_static/css/pytorch_theme.css'
         "_static/css/ignite_theme.css",

--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -60,7 +60,6 @@ class ClearMLLogger(BaseLogger):
             - ``TaskTypes.inference``
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -202,8 +201,22 @@ class ClearMLLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.clearml_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -284,23 +297,7 @@ class OutputHandler(BaseOutputHandler):
                 event_name=Events.ITERATION_COMPLETED
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.clearml_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-        Example of `global_step_transform`:
+        Example of `global_step_transform`
 
         .. code-block:: python
 
@@ -350,8 +347,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -375,12 +377,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):
@@ -407,8 +403,12 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -426,12 +426,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -460,8 +454,11 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
 class WeightsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's weights as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, 'generator'
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -479,11 +476,6 @@ class WeightsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, 'generator'
-
     """
 
     def __init__(self, model: Module, tag: Optional[str] = None):
@@ -514,8 +506,12 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -533,12 +529,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -566,8 +556,11 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
 class GradsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's gradients as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, 'generator'
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -585,11 +578,6 @@ class GradsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, 'generator'
-
     """
 
     def __init__(self, model: Module, tag: Optional[str] = None):
@@ -629,7 +617,6 @@ class ClearMLSaver(DiskSaver):
             directory will be created.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *

--- a/ignite/contrib/handlers/mlflow_logger.py
+++ b/ignite/contrib/handlers/mlflow_logger.py
@@ -26,7 +26,6 @@ class MLflowLogger(BaseLogger):
         tracking_uri: MLflow tracking uri. See MLflow docs for more details
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.mlflow_logger import *
@@ -122,8 +121,22 @@ class MLflowLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics.
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, 'training'
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{'loss': loss1, 'another_loss': loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.mlflow_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.mlflow_logger import *
@@ -193,24 +206,6 @@ class OutputHandler(BaseOutputHandler):
                 state_attributes=["alpha", "beta"],
             )
 
-
-    Args:
-        tag: common title for all produced plots. For example, 'training'
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{'loss': loss1, 'another_loss': loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.mlflow_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -271,8 +266,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, 'generator'
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.mlflow_logger import *
@@ -294,12 +294,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, 'generator'
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):

--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -63,7 +63,6 @@ class NeptuneLogger(BaseLogger):
            Tags are displayed in the experiment’s Details and can be viewed in experiments view as a column.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -214,8 +213,22 @@ class NeptuneLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.neptune_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -301,23 +314,6 @@ class OutputHandler(BaseOutputHandler):
                 state_attributes=["alpha", "beta"],
             )
 
-
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.neptune_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -363,8 +359,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -392,12 +393,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):
@@ -423,8 +418,12 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -446,12 +445,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -479,8 +472,12 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -502,12 +499,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -537,7 +528,6 @@ class NeptuneSaver(BaseSaveHandler):
             NeptuneLogger class.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *

--- a/ignite/contrib/handlers/polyaxon_logger.py
+++ b/ignite/contrib/handlers/polyaxon_logger.py
@@ -25,9 +25,13 @@ class PolyaxonLogger(BaseLogger):
 
         pip install polyaxon-client
 
+    Args:
+        args: Positional arguments accepted from
+            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
+        kwargs: Keyword arguments accepted from
+            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.polyaxon_logger import *
@@ -86,13 +90,6 @@ class PolyaxonLogger(BaseLogger):
             )
             # to manually end a run
             plx_logger.close()
-
-    Args:
-        args: Positional arguments accepted from
-            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
-        kwargs: Keyword arguments accepted from
-            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
-
     """
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -132,8 +129,22 @@ class PolyaxonLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics.
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.polyaxon_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.polyaxon_logger import *
@@ -203,23 +214,6 @@ class OutputHandler(BaseOutputHandler):
                 state_attributes=["alpha", "beta"],
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.polyaxon_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -266,8 +260,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.polyaxon_logger import *
@@ -287,12 +286,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -52,7 +52,6 @@ class TensorboardLogger(BaseLogger):
             For example, `log_dir` to setup path to the directory where to log.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -176,8 +175,22 @@ class TensorboardLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output, engine's state attributes and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.tensorboard_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -249,23 +262,6 @@ class OutputHandler(BaseOutputHandler):
                 event_name=Events.ITERATION_COMPLETED
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.tensorboard_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -310,8 +306,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -331,12 +332,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):
@@ -362,8 +357,12 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -377,12 +376,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -408,8 +401,11 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
 class WeightsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's weights as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -423,11 +419,6 @@ class WeightsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, tag: Optional[str] = None):
@@ -454,8 +445,12 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -469,12 +464,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -499,8 +488,11 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
 class GradsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's gradients as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -514,11 +506,6 @@ class GradsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, tag: Optional[str] = None):

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -27,7 +27,6 @@ class ProgressBar(BaseLogger):
             "Predictions [5/10]" if number of epochs is more than one otherwise it is simply "Predictions".
 
     Examples:
-
         Simple progress bar
 
         .. code-block:: python

--- a/ignite/contrib/handlers/visdom_logger.py
+++ b/ignite/contrib/handlers/visdom_logger.py
@@ -56,7 +56,6 @@ class VisdomLogger(BaseLogger):
         log less frequently or set `num_workers=1`.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -254,8 +253,23 @@ class _BaseVisDrawer:
 class OutputHandler(BaseOutputHandler, _BaseVisDrawer):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.visdom_logger.global_step_from_engine`.
+        show_legend: flag to show legend in the window
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -327,31 +341,12 @@ class OutputHandler(BaseOutputHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_COMPLETED
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.visdom_logger.global_step_from_engine`.
-        show_legend: flag to show legend in the window
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
 
             def global_step_transform(engine, event_name):
                 return engine.state.get_event_attrib_value(event_name)
-
     """
 
     def __init__(
@@ -392,8 +387,14 @@ class OutputHandler(BaseOutputHandler, _BaseVisDrawer):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler, _BaseVisDrawer):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
+        show_legend: flag to show legend in the window
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -413,13 +414,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
-        show_legend: flag to show legend in the window
     """
 
     def __init__(
@@ -450,8 +444,13 @@ class WeightsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
+        show_legend: flag to show legend in the window
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -465,12 +464,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-        show_legend: flag to show legend in the window
     """
 
     def __init__(
@@ -500,8 +493,13 @@ class GradsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
+        show_legend: flag to show legend in the window
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -515,13 +513,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-        show_legend: flag to show legend in the window
-
     """
 
     def __init__(

--- a/ignite/contrib/handlers/wandb_logger.py
+++ b/ignite/contrib/handlers/wandb_logger.py
@@ -27,7 +27,6 @@ class WandBLogger(BaseLogger):
             Please see `wandb.init <https://docs.wandb.ai/library/init>`_ for documentation of possible parameters.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.wandb_logger import *
@@ -151,8 +150,23 @@ class WandBLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.wandb_logger.global_step_from_engine`.
+        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
+            the default value of wandb.log.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.wandb_logger import *
@@ -240,24 +254,6 @@ class OutputHandler(BaseOutputHandler):
             )
 
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.wandb_logger.global_step_from_engine`.
-        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
-            the default value of wandb.log.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -300,8 +296,15 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
+        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
+            the default value of wandb.log.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.wandb_logger import *
@@ -329,14 +332,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
-        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
-            the default value of wandb.log.
     """
 
     def __init__(

--- a/ignite/contrib/metrics/average_precision.py
+++ b/ignite/contrib/metrics/average_precision.py
@@ -29,17 +29,18 @@ class AveragePrecision(EpochMetric):
             no issues. User will be warned in case there are any issues computing the function.
         device: optional device specification for internal storage.
 
-    AveragePrecision expects y to be comprised of 0's and 1's. y_pred must either be probability estimates or
-    confidence values. To apply an activation to y_pred, use output_transform as shown below:
+    Examples:
+        AveragePrecision expects y to be comprised of 0's and 1's. y_pred must either be probability estimates or
+        confidence values. To apply an activation to y_pred, use output_transform as shown below:
 
-    .. code-block:: python
+        .. code-block:: python
 
-        def activated_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.softmax(y_pred, dim=1)
-            return y_pred, y
+            def activated_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.softmax(y_pred, dim=1)
+                return y_pred, y
 
-        avg_precision = AveragePrecision(activated_output_transform)
+            avg_precision = AveragePrecision(activated_output_transform)
 
     """
 

--- a/ignite/contrib/metrics/gpu_info.py
+++ b/ignite/contrib/metrics/gpu_info.py
@@ -17,7 +17,6 @@ class GpuInfo(Metric):
         In case if gpu utilization reports "N/A" on a given GPU, corresponding metric value is not set.
 
     Examples:
-
         .. code-block:: python
 
             # Default GPU measurements

--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -35,21 +35,6 @@ def auto_dataloader(dataset: Dataset, **kwargs: Any) -> Union[DataLoader, "_MpDe
         Custom batch sampler is not adapted for distributed configuration. Please, make sure that provided batch
         sampler is compatible with distributed configuration.
 
-    Examples:
-
-    .. code-block:: python
-
-        import ignite.distribted as idist
-
-        train_loader = idist.auto_dataloader(
-            train_dataset,
-            batch_size=32,
-            num_workers=4,
-            shuffle=True,
-            pin_memory="cuda" in idist.device().type,
-            drop_last=True,
-        )
-
     Args:
         dataset: input torch dataset. If input dataset is `torch IterableDataset`_ then dataloader will be
             created without any distributed sampling. Please, make sure that the dataset itself produces
@@ -58,6 +43,20 @@ def auto_dataloader(dataset: Dataset, **kwargs: Any) -> Union[DataLoader, "_MpDe
 
     Returns:
         `torch DataLoader`_ or `XLA MpDeviceLoader`_ for XLA devices
+
+    Examples:
+        .. code-block:: python
+
+            import ignite.distribted as idist
+
+            train_loader = idist.auto_dataloader(
+                train_dataset,
+                batch_size=32,
+                num_workers=4,
+                shuffle=True,
+                pin_memory="cuda" in idist.device().type,
+                drop_last=True,
+            )
 
     .. _torch DataLoader: https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader
     .. _XLA MpDeviceLoader: https://github.com/pytorch/xla/blob/master/torch_xla/distributed/parallel_loader.py#L178
@@ -150,23 +149,6 @@ def auto_model(model: nn.Module, sync_bn: bool = False, **kwargs: Any) -> nn.Mod
     - wrap the model to `torch DataParallel`_ if no distributed context found and more than one CUDA devices available.
     - broadcast the initial variable states from rank 0 to all other processes if Horovod distributed framework is used.
 
-    Examples:
-
-    .. code-block:: python
-
-        import ignite.distribted as idist
-
-        model = idist.auto_model(model)
-
-    In addition with NVidia/Apex, it can be used in the following way:
-
-    .. code-block:: python
-
-        import ignite.distribted as idist
-
-        model, optimizer = amp.initialize(model, optimizer, opt_level=opt_level)
-        model = idist.auto_model(model)
-
     Args:
         model: model to adapt.
         sync_bn: if True, applies `torch convert_sync_batchnorm`_ to the model for native torch
@@ -177,6 +159,22 @@ def auto_model(model: nn.Module, sync_bn: bool = False, **kwargs: Any) -> nn.Mod
 
     Returns:
         torch.nn.Module
+
+    Examples:
+        .. code-block:: python
+
+            import ignite.distribted as idist
+
+            model = idist.auto_model(model)
+
+        In addition with NVidia/Apex, it can be used in the following way:
+
+        .. code-block:: python
+
+            import ignite.distribted as idist
+
+            model, optimizer = amp.initialize(model, optimizer, opt_level=opt_level)
+            model = idist.auto_model(model)
 
     .. _torch DistributedDataParallel: https://pytorch.org/docs/stable/generated/torch.nn.parallel.
         DistributedDataParallel.html
@@ -246,20 +244,19 @@ def auto_optim(optimizer: Optimizer, **kwargs: Any) -> Optimizer:
     For Horovod distributed configuration, optimizer is wrapped with Horovod Distributed Optimizer and
     its state is broadcasted from rank 0 to all other processes.
 
-    Examples:
-
-    .. code-block:: python
-
-        import ignite.distributed as idist
-
-        optimizer = idist.auto_optim(optimizer)
-
     Args:
         optimizer: input torch optimizer
         kwargs: kwargs to Horovod backend's DistributedOptimizer.
 
     Returns:
         Optimizer
+
+    Examples:
+        .. code-block:: python
+
+            import ignite.distributed as idist
+
+            optimizer = idist.auto_optim(optimizer)
 
     .. _xm.optimizer_step: http://pytorch.org/xla/release/1.5/index.html#torch_xla.core.xla_model.optimizer_step
 
@@ -289,15 +286,13 @@ class DistributedProxySampler(DistributedSampler):
 
     Code is based on https://github.com/pytorch/pytorch/issues/23430#issuecomment-562350407
 
-
-    .. note::
-        Input sampler is assumed to have a constant size.
-
     Args:
         sampler: Input torch data sampler.
         num_replicas: Number of processes participating in distributed training.
         rank: Rank of the current process within ``num_replicas``.
 
+    .. note::
+        Input sampler is assumed to have a constant size.
     """
 
     def __init__(self, sampler: Sampler, num_replicas: Optional[int] = None, rank: Optional[int] = None) -> None:

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -431,12 +431,12 @@ if has_native_dist_support:
 
         Source : https://github.com/LLNL/py-hostlist/blob/master/hostlist/hostlist.py
 
+        Args:
+            nodelist: Compressed hostlist string
+
         .. note::
             The host names can be composed by any character except the special ones `[`, `]`, `,`. Only one
             sequence `[...]` is supported per hostname.
-
-        Args:
-            nodelist: Compressed hostlist string
 
         .. versionadded:: 0.4.6
         """

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -434,8 +434,10 @@ def set_local_rank(index: int) -> None:
     """Method to hint the local rank in case if torch native distributed context is created by user
     without using :meth:`~ignite.distributed.utils.initialize` or :meth:`~ignite.distributed.utils.spawn`.
 
-    Usage:
+    Args:
+        index: local rank or current process index
 
+    Examples:
         User set up torch native distributed process group
 
         .. code-block:: python
@@ -448,10 +450,6 @@ def set_local_rank(index: int) -> None:
                 # ...
                 dist.init_process_group(**dist_info)
                 # ...
-
-    Args:
-        index: local rank or current process index
-
     """
     from ignite.distributed.comp_models.base import ComputationModel
 
@@ -570,19 +568,20 @@ def one_rank_only(rank: int = 0, with_barrier: bool = False) -> Callable:
         rank: rank number of the handler (default: 0).
         with_barrier: synchronisation with a barrier (default: False).
 
-    .. code-block:: python
+    Examples:
+        .. code-block:: python
 
-        engine = ...
+            engine = ...
 
-        @engine.on(...)
-        @one_rank_only() # means @one_rank_only(rank=0)
-        def some_handler(_):
-            ...
+            @engine.on(...)
+            @one_rank_only() # means @one_rank_only(rank=0)
+            def some_handler(_):
+                ...
 
-        @engine.on(...)
-        @one_rank_only(rank=1)
-        def some_handler(_):
-            ...
+            @engine.on(...)
+            @one_rank_only(rank=1)
+            def some_handler(_):
+                ...
     """
 
     def _one_rank_only(func: Callable) -> Callable:

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -206,8 +206,28 @@ def spawn(
     """Spawns ``nproc_per_node`` processes that run ``fn`` with ``args``/``kwargs_dict`` and initialize
     distributed configuration defined by ``backend``.
 
-    Examples:
+    Args:
+        backend: backend to use: `nccl`, `gloo`, `xla-tpu`, `horovod`
+        fn: function to called as the entrypoint of the spawned process.
+            This function must be defined at the top level of a module so it can be pickled and spawned.
+            This is a requirement imposed by multiprocessing. The function is called as ``fn(i, *args, **kwargs_dict)``,
+            where `i` is the process index and args is the passed through tuple of arguments.
+        args: arguments passed to `fn`.
+        kwargs_dict: kwargs passed to `fn`.
+        nproc_per_node: number of processes to spawn on a single node. Default, 1.
+        kwargs: acceptable kwargs according to provided backend:
 
+            - | "nccl" or "gloo" : ``nnodes`` (default, 1), ``node_rank`` (default, 0), ``master_addr``
+              | (default, "127.0.0.1"), ``master_port`` (default, 2222), ``init_method`` (default, "env://"),
+              | `timeout` to `dist.init_process_group`_ function
+              | and kwargs for `mp.start_processes`_ function.
+
+            - | "xla-tpu" : ``nnodes`` (default, 1), ``node_rank`` (default, 0) and kwargs to `xmp.spawn`_ function.
+
+            - | "horovod": ``hosts`` (default, None) and other kwargs to `hvd_run`_ function. Arguments ``nnodes=1``
+              | and ``node_rank=0`` are tolerated and ignored, otherwise an exception is raised.
+
+    Examples:
         1) Launch single node multi-GPU training using torch native distributed framework
 
         .. code-block:: python
@@ -282,27 +302,6 @@ def spawn(
 
 
             idist.spawn("xla-tpu", train_fn, args=(a, b, c), kwargs_dict={"d": 23}, nproc_per_node=8)
-
-    Args:
-        backend: backend to use: `nccl`, `gloo`, `xla-tpu`, `horovod`
-        fn: function to called as the entrypoint of the spawned process.
-            This function must be defined at the top level of a module so it can be pickled and spawned.
-            This is a requirement imposed by multiprocessing. The function is called as ``fn(i, *args, **kwargs_dict)``,
-            where `i` is the process index and args is the passed through tuple of arguments.
-        args: arguments passed to `fn`.
-        kwargs_dict: kwargs passed to `fn`.
-        nproc_per_node: number of processes to spawn on a single node. Default, 1.
-        kwargs: acceptable kwargs according to provided backend:
-
-            - | "nccl" or "gloo" : ``nnodes`` (default, 1), ``node_rank`` (default, 0), ``master_addr``
-              | (default, "127.0.0.1"), ``master_port`` (default, 2222), ``init_method`` (default, "env://"),
-              | `timeout` to `dist.init_process_group`_ function
-              | and kwargs for `mp.start_processes`_ function.
-
-            - | "xla-tpu" : ``nnodes`` (default, 1), ``node_rank`` (default, 0) and kwargs to `xmp.spawn`_ function.
-
-            - | "horovod": ``hosts`` (default, None) and other kwargs to `hvd_run`_ function. Arguments ``nnodes=1``
-              | and ``node_rank=0`` are tolerated and ignored, otherwise an exception is raised.
 
     .. _dist.init_process_group: https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group
     .. _mp.start_processes: https://pytorch.org/docs/stable/multiprocessing.html#torch.multiprocessing.spawn
@@ -381,7 +380,6 @@ def broadcast(
         torch.Tensor or string or number
 
     Examples:
-
         .. code-block:: python
 
             y = None
@@ -477,8 +475,17 @@ def _assert_backend(backend: str) -> None:
 def initialize(backend: str, **kwargs: Any) -> None:
     """Initializes distributed configuration according to provided ``backend``
 
-    Examples:
+    Args:
+        backend: backend: `nccl`, `gloo`, `xla-tpu`, `horovod`.
+        kwargs: acceptable kwargs according to provided backend:
 
+            - | "nccl" or "gloo" : ``timeout(=timedelta(minutes=30))``, ``init_method(=None)``,
+              | ``rank(=None)``, ``world_size(=None)``.
+              | By default, ``init_method`` will be "env://". See more info about parameters: `torch_init`_.
+
+            - | "horovod" : comm(=None), more info: `hvd_init`_.
+
+    Examples:
         Launch single node multi-GPU training with ``torch.distributed.launch`` utility.
 
         .. code-block:: python
@@ -506,16 +513,6 @@ def initialize(backend: str, **kwargs: Any) -> None:
             train_fn(local_rank, a, b, c)
             idist.finalize()
 
-
-    Args:
-        backend: backend: `nccl`, `gloo`, `xla-tpu`, `horovod`.
-        kwargs: acceptable kwargs according to provided backend:
-
-            - | "nccl" or "gloo" : ``timeout(=timedelta(minutes=30))``, ``init_method(=None)``,
-              | ``rank(=None)``, ``world_size(=None)``.
-              | By default, ``init_method`` will be "env://". See more info about parameters: `torch_init`_.
-
-            - | "horovod" : comm(=None), more info: `hvd_init`_.
 
     .. _torch_init: https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group
     .. _hvd_init: https://horovod.readthedocs.io/en/latest/api.html#module-horovod.torch

--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -71,16 +71,17 @@ def supervised_training_step(
     Returns:
         Callable: update function.
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step
+            from ignite.engine import Engine, supervised_training_step
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
+            model = ...
+            optimizer = ...
+            loss_fn = ...
 
-        update_fn = supervised_training_step(model, optimizer, loss_fn, 'cuda')
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step(model, optimizer, loss_fn, 'cuda')
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """
@@ -128,17 +129,18 @@ def supervised_training_step_amp(
     Returns:
         Callable: update function
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step_amp
+            from ignite.engine import Engine, supervised_training_step_amp
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
-        scaler = torch.cuda.amp.GradScaler(2**10)
+            model = ...
+            optimizer = ...
+            loss_fn = ...
+            scaler = torch.cuda.amp.GradScaler(2**10)
 
-        update_fn = supervised_training_step_amp(model, optimizer, loss_fn, 'cuda', scaler=scaler)
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step_amp(model, optimizer, loss_fn, 'cuda', scaler=scaler)
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """
@@ -195,16 +197,17 @@ def supervised_training_step_apex(
     Returns:
         Callable: update function.
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step_apex
+            from ignite.engine import Engine, supervised_training_step_apex
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
+            model = ...
+            optimizer = ...
+            loss_fn = ...
 
-        update_fn = supervised_training_step_apex(model, optimizer, loss_fn, 'cuda')
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step_apex(model, optimizer, loss_fn, 'cuda')
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """
@@ -256,16 +259,17 @@ def supervised_training_step_tpu(
     Returns:
         Callable: update function.
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step_tpu
+            from ignite.engine import Engine, supervised_training_step_tpu
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
+            model = ...
+            optimizer = ...
+            loss_fn = ...
 
-        update_fn = supervised_training_step_tpu(model, optimizer, loss_fn, 'xla')
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step_tpu(model, optimizer, loss_fn, 'xla')
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """

--- a/ignite/engine/deterministic.py
+++ b/ignite/engine/deterministic.py
@@ -39,21 +39,21 @@ class ReproducibleBatchSampler(BatchSampler):
     """Reproducible batch sampler. This class internally iterates and stores indices of the input batch sampler.
     This helps to start providing data batches from an iteration in a deterministic way.
 
-    Example:
-
-        Setup dataloader with `ReproducibleBatchSampler` and start providing data batches from an iteration
-
-    .. code-block:: python
-
-        from ignite.engine.deterministic import update_dataloader
-
-        dataloader = update_dataloader(dataloader, ReproducibleBatchSampler(dataloader.batch_sampler))
-        # rewind dataloader to a specific iteration:
-        dataloader.batch_sampler.start_iteration = start_iteration
-
     Args:
         batch_sampler: batch sampler same as used with `torch.utils.data.DataLoader`.
         start_iteration: optional start iteration.
+
+    Examples:
+        Setup dataloader with `ReproducibleBatchSampler` and start providing data batches from an iteration
+
+        .. code-block:: python
+
+            from ignite.engine.deterministic import update_dataloader
+
+            dataloader = update_dataloader(dataloader, ReproducibleBatchSampler(dataloader.batch_sampler))
+            # rewind dataloader to a specific iteration:
+            dataloader.batch_sampler.start_iteration = start_iteration
+
     """
 
     def __init__(self, batch_sampler: BatchSampler, start_iteration: Optional[int] = None):

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -31,7 +31,6 @@ class Engine(Serializable):
         last_event_name: last event name triggered by the engine.
 
     Examples:
-
         Create a basic trainer
 
         .. code-block:: python
@@ -158,63 +157,62 @@ class Engine(Serializable):
                 or an object derived from :class:`~ignite.engine.events.EventEnum`. See example below.
             event_to_attr: A dictionary to map an event to a state attribute.
 
-        Example usage:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                from ignite.engine import Engine, Events, EventEnum
 
-            from ignite.engine import Engine, Events, EventEnum
+                class CustomEvents(EventEnum):
+                    FOO_EVENT = "foo_event"
+                    BAR_EVENT = "bar_event"
 
-            class CustomEvents(EventEnum):
-                FOO_EVENT = "foo_event"
-                BAR_EVENT = "bar_event"
+                def process_function(e, batch):
+                    # ...
+                    trainer.fire_event("bwd_event")
+                    loss.backward()
+                    # ...
+                    trainer.fire_event("opt_event")
+                    optimizer.step()
 
-            def process_function(e, batch):
-                # ...
-                trainer.fire_event("bwd_event")
-                loss.backward()
-                # ...
-                trainer.fire_event("opt_event")
-                optimizer.step()
+                trainer = Engine(process_function)
+                trainer.register_events(*CustomEvents)
+                trainer.register_events("bwd_event", "opt_event")
 
-            trainer = Engine(process_function)
-            trainer.register_events(*CustomEvents)
-            trainer.register_events("bwd_event", "opt_event")
+                @trainer.on(Events.EPOCH_COMPLETED)
+                def trigger_custom_event():
+                    if required(...):
+                        trainer.fire_event(CustomEvents.FOO_EVENT)
+                    else:
+                        trainer.fire_event(CustomEvents.BAR_EVENT)
 
-            @trainer.on(Events.EPOCH_COMPLETED)
-            def trigger_custom_event():
-                if required(...):
-                    trainer.fire_event(CustomEvents.FOO_EVENT)
-                else:
-                    trainer.fire_event(CustomEvents.BAR_EVENT)
+                @trainer.on(CustomEvents.FOO_EVENT)
+                def do_foo_op():
+                    # ...
 
-            @trainer.on(CustomEvents.FOO_EVENT)
-            def do_foo_op():
-                # ...
+                @trainer.on(CustomEvents.BAR_EVENT)
+                def do_bar_op():
+                    # ...
 
-            @trainer.on(CustomEvents.BAR_EVENT)
-            def do_bar_op():
-                # ...
+            Example with State Attribute:
 
-        Example with State Attribute:
+            .. code-block:: python
 
-        .. code-block:: python
+                from enum import Enum
+                from ignite.engine import Engine, EventEnum
 
-            from enum import Enum
-            from ignite.engine import Engine, EventEnum
+                class TBPTT_Events(EventEnum):
+                    TIME_ITERATION_STARTED = "time_iteration_started"
+                    TIME_ITERATION_COMPLETED = "time_iteration_completed"
 
-            class TBPTT_Events(EventEnum):
-                TIME_ITERATION_STARTED = "time_iteration_started"
-                TIME_ITERATION_COMPLETED = "time_iteration_completed"
+                TBPTT_event_to_attr = {
+                    TBPTT_Events.TIME_ITERATION_STARTED: 'time_iteration',
+                    TBPTT_Events.TIME_ITERATION_COMPLETED: 'time_iteration'
+                }
 
-            TBPTT_event_to_attr = {
-                TBPTT_Events.TIME_ITERATION_STARTED: 'time_iteration',
-                TBPTT_Events.TIME_ITERATION_COMPLETED: 'time_iteration'
-            }
-
-            engine = Engine(process_function)
-            engine.register_events(*TBPTT_Events, event_to_attr=TBPTT_event_to_attr)
-            engine.run(data)
-            # engine.state contains an attribute time_iteration, which can be accessed using engine.state.time_iteration
+                engine = Engine(process_function)
+                engine.register_events(*TBPTT_Events, event_to_attr=TBPTT_event_to_attr)
+                engine.run(data)
+                # engine.state contains an attribute time_iteration, which can be accessed using engine.state.time_iteration
         """
         if not (event_to_attr is None or isinstance(event_to_attr, dict)):
             raise ValueError(f"Expected event_to_attr to be dictionary. Got {type(event_to_attr)}.")
@@ -266,24 +264,23 @@ class Engine(Serializable):
             Note that other arguments can be passed to the handler in addition to the `*args` and  `**kwargs`
             passed here, for example during :attr:`~ignite.engine.events.Events.EXCEPTION_RAISED`.
 
-        Example usage:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                engine = Engine(process_function)
 
-            engine = Engine(process_function)
+                def print_epoch(engine):
+                    print(f"Epoch: {engine.state.epoch}")
 
-            def print_epoch(engine):
-                print(f"Epoch: {engine.state.epoch}")
+                engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch)
 
-            engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch)
+                events_list = Events.EPOCH_COMPLETED | Events.COMPLETED
 
-            events_list = Events.EPOCH_COMPLETED | Events.COMPLETED
+                def execute_something():
+                    # do some thing not related to engine
+                    pass
 
-            def execute_something():
-                # do some thing not related to engine
-                pass
-
-            engine.add_event_handler(events_list, execute_something)
+                engine.add_event_handler(events_list, execute_something)
 
         Note:
             Since v0.3.0, Events become more flexible and allow to pass an event filter to the Engine.
@@ -379,20 +376,19 @@ class Engine(Serializable):
             args: optional args to be passed to `handler`.
             kwargs: optional keyword args to be passed to `handler`.
 
-        Example usage:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                engine = Engine(process_function)
 
-            engine = Engine(process_function)
+                @engine.on(Events.EPOCH_COMPLETED)
+                def print_epoch():
+                    print(f"Epoch: {engine.state.epoch}")
 
-            @engine.on(Events.EPOCH_COMPLETED)
-            def print_epoch():
-                print(f"Epoch: {engine.state.epoch}")
-
-            @engine.on(Events.EPOCH_COMPLETED | Events.COMPLETED)
-            def execute_something():
-                # do some thing not related to engine
-                pass
+                @engine.on(Events.EPOCH_COMPLETED | Events.COMPLETED)
+                def execute_something():
+                    # do some thing not related to engine
+                    pass
         """
 
         def decorator(f: Callable) -> Callable:
@@ -572,7 +568,7 @@ class Engine(Serializable):
         Args:
             data: Collection of batches allowing repeated iteration (e.g., list or `DataLoader`).
 
-        Example usage:
+        Examples:
             User can switch data provider during the training:
 
             .. code-block:: python

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -140,7 +140,10 @@ class CallableEventWithFilter:
 
 class EventEnum(CallableEventWithFilter, Enum):  # type: ignore[misc]
     """Base class for all :class:`~ignite.engine.events.Events`. User defined custom events should also inherit
-    this class. For example, Custom events based on the loss calculation and backward pass can be created as follows:
+    this class.
+
+     Examples:
+         Custom events based on the loss calculation and backward pass can be created as follows:
 
         .. code-block:: python
 
@@ -436,20 +439,19 @@ class RemovableEventHandle:
         handler: Registered event handler, stored as weakref.
         engine: Target engine, stored as weakref.
 
-    Example usage:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            engine = Engine()
 
-        engine = Engine()
+            def print_epoch(engine):
+                print(f"Epoch: {engine.state.epoch}")
 
-        def print_epoch(engine):
-            print(f"Epoch: {engine.state.epoch}")
+            with engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch):
+                # print_epoch handler registered for a single run
+                engine.run(data)
 
-        with engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch):
-            # print_epoch handler registered for a single run
-            engine.run(data)
-
-        # print_epoch handler is now unregistered
+            # print_epoch handler is now unregistered
     """
 
     def __init__(

--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -22,19 +22,18 @@ class EarlyStopping(Serializable):
             it defines an increase after the last event. Default value is False.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.engine import Engine, Events
+            from ignite.handlers import EarlyStopping
 
-        from ignite.engine import Engine, Events
-        from ignite.handlers import EarlyStopping
+            def score_function(engine):
+                val_loss = engine.state.metrics['nll']
+                return -val_loss
 
-        def score_function(engine):
-            val_loss = engine.state.metrics['nll']
-            return -val_loss
-
-        handler = EarlyStopping(patience=10, score_function=score_function, trainer=trainer)
-        # Note: the handler is attached to an *Evaluator* (runs one epoch on validation dataset).
-        evaluator.add_event_handler(Events.COMPLETED, handler)
+            handler = EarlyStopping(patience=10, score_function=score_function, trainer=trainer)
+            # Note: the handler is attached to an *Evaluator* (runs one epoch on validation dataset).
+            evaluator.add_event_handler(Events.COMPLETED, handler)
 
     """
 

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -26,29 +26,28 @@ class FastaiLRFinder:
     rates and what can be an optimal learning rate.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers import FastaiLRFinder
 
-        from ignite.handlers import FastaiLRFinder
+            trainer = ...
+            model = ...
+            optimizer = ...
 
-        trainer = ...
-        model = ...
-        optimizer = ...
+            lr_finder = FastaiLRFinder()
+            to_save = {"model": model, "optimizer": optimizer}
 
-        lr_finder = FastaiLRFinder()
-        to_save = {"model": model, "optimizer": optimizer}
+            with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
+                trainer_with_lr_finder.run(dataloader)
 
-        with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
-            trainer_with_lr_finder.run(dataloader)
+            # Get lr_finder results
+            lr_finder.get_results()
 
-        # Get lr_finder results
-        lr_finder.get_results()
+            # Plot lr_finder results (requires matplotlib)
+            lr_finder.plot()
 
-        # Plot lr_finder results (requires matplotlib)
-        lr_finder.plot()
-
-        # get lr_finder suggestion for lr
-        lr_finder.lr_suggestion()
+            # get lr_finder suggestion for lr
+            lr_finder.lr_suggestion()
 
 
     Note:
@@ -339,12 +338,11 @@ class FastaiLRFinder:
         """
         Applying the suggested learning rate(s) on the given optimizer.
 
-        Note:
-            The given optimizer must be the same as the one we before found the suggested learning rate for.
-
         Args:
             optimizer: the optimizer to apply the suggested learning rate(s) on.
 
+        Note:
+            The given optimizer must be the same as the one we before found the suggested learning rate for.
         """
         sug_lr = self.lr_suggestion()
         if not isinstance(sug_lr, list):
@@ -377,14 +375,6 @@ class FastaiLRFinder:
     ) -> Any:
         """Attaches lr_finder to a given trainer. It also resets model and optimizer at the end of the run.
 
-        Usage:
-
-        .. code-block:: python
-
-            to_save = {"model": model, "optimizer": optimizer}
-            with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
-                trainer_with_lr_finder.run(dataloader)
-
         Args:
             trainer: lr_finder is attached to this trainer. Please, keep in mind that all attached handlers
                 will be executed.
@@ -406,6 +396,13 @@ class FastaiLRFinder:
 
         Returns:
             trainer_with_lr_finder (trainer used for finding the lr)
+
+        Examples:
+            .. code-block:: python
+
+                to_save = {"model": model, "optimizer": optimizer}
+                with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
+                    trainer_with_lr_finder.run(dataloader)
 
         Note:
             lr_finder cannot be attached to more than one trainer at a time.

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -159,18 +159,16 @@ class ParamScheduler(metaclass=ABCMeta):
             event_index, value
 
         Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                lr_values = np.array(LinearCyclicalScheduler.simulate_values(num_events=50, param_name='lr',
+                                                                             start_value=1e-1, end_value=1e-3,
+                                                                             cycle_size=10))
 
-            lr_values = np.array(LinearCyclicalScheduler.simulate_values(num_events=50, param_name='lr',
-                                                                         start_value=1e-1, end_value=1e-3,
-                                                                         cycle_size=10))
-
-            plt.plot(lr_values[:, 0], lr_values[:, 1], label="learning rate")
-            plt.xlabel("events")
-            plt.ylabel("values")
-            plt.legend()
-
+                plt.plot(lr_values[:, 0], lr_values[:, 1], label="learning rate")
+                plt.xlabel("events")
+                plt.ylabel("values")
+                plt.legend()
         """
         keys_to_remove = ["optimizer", "save_history"]
         for key in keys_to_remove:
@@ -201,7 +199,6 @@ class ParamScheduler(metaclass=ABCMeta):
             matplotlib.lines.Line2D
 
         Examples:
-
             .. code-block:: python
 
                 import matplotlib.pylab as plt
@@ -328,17 +325,15 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         usually be the number of batches in an epoch.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import LinearCyclicalScheduler
 
-        from ignite.handlers.param_scheduler import LinearCyclicalScheduler
-
-        scheduler = LinearCyclicalScheduler(optimizer, 'lr', 1e-3, 1e-1, len(train_loader))
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
-        #
-        # Linearly increases the learning rate from 1e-3 to 1e-1 and back to 1e-3
-        # over the course of 1 epoch
-        #
+            scheduler = LinearCyclicalScheduler(optimizer, 'lr', 1e-3, 1e-1, len(train_loader))
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+            #
+            # Linearly increases the learning rate from 1e-3 to 1e-1 and back to 1e-3
+            # over the course of 1 epoch
 
     .. versionadded:: 0.4.5
     """
@@ -376,34 +371,33 @@ class CosineAnnealingScheduler(CyclicalScheduler):
         usually be the number of batches in an epoch.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import CosineAnnealingScheduler
 
-        from ignite.handlers.param_scheduler import CosineAnnealingScheduler
+            scheduler = CosineAnnealingScheduler(optimizer, 'lr', 1e-1, 1e-3, len(train_loader))
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+            #
+            # Anneals the learning rate from 1e-1 to 1e-3 over the course of 1 epoch.
+            #
 
-        scheduler = CosineAnnealingScheduler(optimizer, 'lr', 1e-1, 1e-3, len(train_loader))
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
-        #
-        # Anneals the learning rate from 1e-1 to 1e-3 over the course of 1 epoch.
-        #
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import CosineAnnealingScheduler
+            from ignite.handlers.param_scheduler import LinearCyclicalScheduler
 
-        from ignite.handlers.param_scheduler import CosineAnnealingScheduler
-        from ignite.handlers.param_scheduler import LinearCyclicalScheduler
+            optimizer = SGD(
+                [
+                    {"params": model.base.parameters(), 'lr': 0.001},
+                    {"params": model.fc.parameters(), 'lr': 0.01},
+                ]
+            )
 
-        optimizer = SGD(
-            [
-                {"params": model.base.parameters(), 'lr': 0.001},
-                {"params": model.fc.parameters(), 'lr': 0.01},
-            ]
-        )
+            scheduler1 = LinearCyclicalScheduler(optimizer, 'lr', 1e-7, 1e-5, len(train_loader), param_group_index=0)
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler1, "lr (base)")
 
-        scheduler1 = LinearCyclicalScheduler(optimizer, 'lr', 1e-7, 1e-5, len(train_loader), param_group_index=0)
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler1, "lr (base)")
-
-        scheduler2 = CosineAnnealingScheduler(optimizer, 'lr', 1e-5, 1e-3, len(train_loader), param_group_index=1)
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler2, "lr (fc)")
+            scheduler2 = CosineAnnealingScheduler(optimizer, 'lr', 1e-5, 1e-3, len(train_loader), param_group_index=1)
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler2, "lr (fc)")
 
     .. [Smith17] Smith, Leslie N. "Cyclical learning rates for training neural networks."
                  Applications of Computer Vision (WACV), 2017 IEEE Winter Conference on. IEEE, 2017
@@ -431,23 +425,21 @@ class ConcatScheduler(ParamScheduler):
             `engine.state.param_history`, (default=False).
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import ConcatScheduler
+            from ignite.handlers.param_scheduler import LinearCyclicalScheduler
+            from ignite.handlers.param_scheduler import CosineAnnealingScheduler
 
-        from ignite.handlers.param_scheduler import ConcatScheduler
-        from ignite.handlers.param_scheduler import LinearCyclicalScheduler
-        from ignite.handlers.param_scheduler import CosineAnnealingScheduler
+            scheduler_1 = LinearCyclicalScheduler(optimizer, "lr", start_value=0.1, end_value=0.5, cycle_size=60)
+            scheduler_2 = CosineAnnealingScheduler(optimizer, "lr", start_value=0.5, end_value=0.01, cycle_size=60)
 
-        scheduler_1 = LinearCyclicalScheduler(optimizer, "lr", start_value=0.1, end_value=0.5, cycle_size=60)
-        scheduler_2 = CosineAnnealingScheduler(optimizer, "lr", start_value=0.5, end_value=0.01, cycle_size=60)
-
-        combined_scheduler = ConcatScheduler(schedulers=[scheduler_1, scheduler_2], durations=[30, ])
-        trainer.add_event_handler(Events.ITERATION_STARTED, combined_scheduler)
-        #
-        # Sets the Learning rate linearly from 0.1 to 0.5 over 30 iterations. Then
-        # starts an annealing schedule from 0.5 to 0.01 over 60 iterations.
-        # The annealing cycles are repeated indefinitely.
-        #
+            combined_scheduler = ConcatScheduler(schedulers=[scheduler_1, scheduler_2], durations=[30, ])
+            trainer.add_event_handler(Events.ITERATION_STARTED, combined_scheduler)
+            #
+            # Sets the Learning rate linearly from 0.1 to 0.5 over 30 iterations. Then
+            # starts an annealing schedule from 0.5 to 0.01 over 60 iterations.
+            # The annealing cycles are repeated indefinitely.
 
     .. versionadded:: 0.4.5
     """
@@ -789,7 +781,6 @@ def create_lr_scheduler_with_warmup(
         `lr_scheduler` provides its learning rate values as normally.
 
     Examples:
-
         .. code-block:: python
 
             torch_lr_scheduler = ExponentialLR(optimizer=optimizer, gamma=0.98)

--- a/ignite/handlers/stores.py
+++ b/ignite/handlers/stores.py
@@ -20,19 +20,20 @@ class EpochOutputStore:
         data: a list of :class:`~ignite.engine.engine.Engine` outputs,
             optionally transformed by `output_transform`.
 
-    Examples::
+    Examples:
+        .. code-block:: python
 
-        eos = EpochOutputStore()
-        trainer = create_supervised_trainer(model, optimizer, loss)
-        train_evaluator = create_supervised_evaluator(model, metrics)
-        eos.attach(train_evaluator, 'output')
+            eos = EpochOutputStore()
+            trainer = create_supervised_trainer(model, optimizer, loss)
+            train_evaluator = create_supervised_evaluator(model, metrics)
+            eos.attach(train_evaluator, 'output')
 
-        @trainer.on(Events.EPOCH_COMPLETED)
-        def log_training_results(engine):
-            train_evaluator.run(train_loader)
-            output = train_evaluator.state.output
-            # output = [(y_pred0, y0), (y_pred1, y1), ...]
-            # do something with output, e.g., plotting
+            @trainer.on(Events.EPOCH_COMPLETED)
+            def log_training_results(engine):
+                train_evaluator.run(train_loader)
+                output = train_evaluator.state.output
+                # output = [(y_pred0, y0), (y_pred1, y1), ...]
+                # do something with output, e.g., plotting
 
     .. versionadded:: 0.4.5
     .. versionchanged:: 0.4.5

--- a/ignite/handlers/terminate_on_nan.py
+++ b/ignite/handlers/terminate_on_nan.py
@@ -25,10 +25,9 @@ class TerminateOnNan:
 
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
-
-        trainer.add_event_handler(Events.ITERATION_COMPLETED, TerminateOnNan())
+            trainer.add_event_handler(Events.ITERATION_COMPLETED, TerminateOnNan())
 
     """
 

--- a/ignite/handlers/time_limit.py
+++ b/ignite/handlers/time_limit.py
@@ -17,7 +17,6 @@ class TimeLimit:
         limit_sec: Maximum time before training terminates (in seconds). Defaults to 28800.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.engine import Events

--- a/ignite/handlers/time_profilers.py
+++ b/ignite/handlers/time_profilers.py
@@ -14,24 +14,23 @@ class BasicTimeProfiler:
     events, data loading and data processing times.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers import BasicTimeProfiler
 
-        from ignite.handlers import BasicTimeProfiler
+            trainer = Engine(train_updater)
 
-        trainer = Engine(train_updater)
+            # Create an object of the profiler and attach an engine to it
+            profiler = BasicTimeProfiler()
+            profiler.attach(trainer)
 
-        # Create an object of the profiler and attach an engine to it
-        profiler = BasicTimeProfiler()
-        profiler.attach(trainer)
+            @trainer.on(Events.EPOCH_COMPLETED)
+            def log_intermediate_results():
+                profiler.print_results(profiler.get_results())
 
-        @trainer.on(Events.EPOCH_COMPLETED)
-        def log_intermediate_results():
-            profiler.print_results(profiler.get_results())
+            trainer.run(dataloader, max_epochs=3)
 
-        trainer.run(dataloader, max_epochs=3)
-
-        profiler.write_results('path_to_dir/time_profiling.csv')
+            profiler.write_results('path_to_dir/time_profiling.csv')
 
     .. versionadded:: 0.4.6
     """
@@ -281,14 +280,13 @@ class BasicTimeProfiler:
 
             profiler.write_results('path_to_dir/awesome_filename.csv')
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
-
-            -----------------------------------------------------------------
-            epoch iteration processing_stats dataflow_stats Event_STARTED ...
-            1.0     1.0        0.00003         0.252387        0.125676
-            1.0     2.0        0.00029         0.252342        0.125123
+                -----------------------------------------------------------------
+                epoch iteration processing_stats dataflow_stats Event_STARTED ...
+                1.0     1.0        0.00003         0.252387        0.125676
+                1.0     2.0        0.00029         0.252342        0.125123
 
         """
         try:
@@ -362,41 +360,40 @@ class BasicTimeProfiler:
 
             profiler.print_results(results)
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
+                 ----------------------------------------------------
+                | Time profiling stats (in seconds):                 |
+                 ----------------------------------------------------
+                total  |  min/index  |  max/index  |  mean  |  std
 
-             ----------------------------------------------------
-            | Time profiling stats (in seconds):                 |
-             ----------------------------------------------------
-            total  |  min/index  |  max/index  |  mean  |  std
+                Processing function:
+                157.46292 | 0.01452/1501 | 0.26905/0 | 0.07730 | 0.01258
 
-            Processing function:
-            157.46292 | 0.01452/1501 | 0.26905/0 | 0.07730 | 0.01258
+                Dataflow:
+                6.11384 | 0.00008/1935 | 0.28461/1551 | 0.00300 | 0.02693
 
-            Dataflow:
-            6.11384 | 0.00008/1935 | 0.28461/1551 | 0.00300 | 0.02693
+                Event handlers:
+                2.82721
 
-            Event handlers:
-            2.82721
+                - Events.STARTED: []
+                0.00000
 
-            - Events.STARTED: []
-            0.00000
+                - Events.EPOCH_STARTED: []
+                0.00006 | 0.00000/0 | 0.00000/17 | 0.00000 | 0.00000
 
-            - Events.EPOCH_STARTED: []
-            0.00006 | 0.00000/0 | 0.00000/17 | 0.00000 | 0.00000
+                - Events.ITERATION_STARTED: ['PiecewiseLinear']
+                0.03482 | 0.00001/188 | 0.00018/679 | 0.00002 | 0.00001
 
-            - Events.ITERATION_STARTED: ['PiecewiseLinear']
-            0.03482 | 0.00001/188 | 0.00018/679 | 0.00002 | 0.00001
+                - Events.ITERATION_COMPLETED: ['TerminateOnNan']
+                0.20037 | 0.00006/866 | 0.00089/1943 | 0.00010 | 0.00003
 
-            - Events.ITERATION_COMPLETED: ['TerminateOnNan']
-            0.20037 | 0.00006/866 | 0.00089/1943 | 0.00010 | 0.00003
+                - Events.EPOCH_COMPLETED: ['empty_cuda_cache', 'training.<locals>.log_elapsed_time', ]
+                2.57860 | 0.11529/0 | 0.14977/13 | 0.12893 | 0.00790
 
-            - Events.EPOCH_COMPLETED: ['empty_cuda_cache', 'training.<locals>.log_elapsed_time', ]
-            2.57860 | 0.11529/0 | 0.14977/13 | 0.12893 | 0.00790
-
-            - Events.COMPLETED: []
-            not yet triggered
+                - Events.COMPLETED: []
+                not yet triggered
 
         """
 
@@ -465,24 +462,23 @@ class HandlersTimeProfiler:
     profiled by this profiler
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers import HandlersTimeProfiler
 
-        from ignite.handlers import HandlersTimeProfiler
+            trainer = Engine(train_updater)
 
-        trainer = Engine(train_updater)
+            # Create an object of the profiler and attach an engine to it
+            profiler = HandlersTimeProfiler()
+            profiler.attach(trainer)
 
-        # Create an object of the profiler and attach an engine to it
-        profiler = HandlersTimeProfiler()
-        profiler.attach(trainer)
+            @trainer.on(Events.EPOCH_COMPLETED)
+            def log_intermediate_results():
+                profiler.print_results(profiler.get_results())
 
-        @trainer.on(Events.EPOCH_COMPLETED)
-        def log_intermediate_results():
-            profiler.print_results(profiler.get_results())
+            trainer.run(dataloader, max_epochs=3)
 
-        trainer.run(dataloader, max_epochs=3)
-
-        profiler.write_results('path_to_dir/time_profiling.csv')
+            profiler.write_results('path_to_dir/time_profiling.csv')
 
     .. versionadded:: 0.4.6
     """
@@ -652,14 +648,13 @@ class HandlersTimeProfiler:
 
             profiler.write_results('path_to_dir/awesome_filename.csv')
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
-
-            -----------------------------------------------------------------
-            # processing_stats dataflow_stats training.<locals>.log_elapsed_time (EPOCH_COMPLETED) ...
-            1     0.00003         0.252387                          0.125676
-            2     0.00029         0.252342                          0.125123
+                -----------------------------------------------------------------
+                # processing_stats dataflow_stats training.<locals>.log_elapsed_time (EPOCH_COMPLETED) ...
+                1     0.00003         0.252387                          0.125676
+                2     0.00029         0.252342                          0.125123
 
         """
         try:
@@ -703,26 +698,25 @@ class HandlersTimeProfiler:
 
             profiler.print_results(results)
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
-
-            -----------------------------------------  -----------------------  -------------- ...
-            Handler                                    Event Name                     Total(s)
-            -----------------------------------------  -----------------------  --------------
-            run.<locals>.log_training_results          EPOCH_COMPLETED                19.43245
-            run.<locals>.log_validation_results        EPOCH_COMPLETED                 2.55271
-            run.<locals>.log_time                      EPOCH_COMPLETED                 0.00049
-            run.<locals>.log_intermediate_results      EPOCH_COMPLETED                 0.00106
-            run.<locals>.log_training_loss             ITERATION_COMPLETED               0.059
-            run.<locals>.log_time                      COMPLETED                 not triggered
-            -----------------------------------------  -----------------------  --------------
-            Total                                                                     22.04571
-            -----------------------------------------  -----------------------  --------------
-            Processing took total 11.29543s [min/index: 0.00393s/1875, max/index: 0.00784s/0,
-             mean: 0.00602s, std: 0.00034s]
-            Dataflow took total 16.24365s [min/index: 0.00533s/1874, max/index: 0.01129s/937,
-             mean: 0.00866s, std: 0.00113s]
+                -----------------------------------------  -----------------------  -------------- ...
+                Handler                                    Event Name                     Total(s)
+                -----------------------------------------  -----------------------  --------------
+                run.<locals>.log_training_results          EPOCH_COMPLETED                19.43245
+                run.<locals>.log_validation_results        EPOCH_COMPLETED                 2.55271
+                run.<locals>.log_time                      EPOCH_COMPLETED                 0.00049
+                run.<locals>.log_intermediate_results      EPOCH_COMPLETED                 0.00106
+                run.<locals>.log_training_loss             ITERATION_COMPLETED               0.059
+                run.<locals>.log_time                      COMPLETED                 not triggered
+                -----------------------------------------  -----------------------  --------------
+                Total                                                                     22.04571
+                -----------------------------------------  -----------------------  --------------
+                Processing took total 11.29543s [min/index: 0.00393s/1875, max/index: 0.00784s/0,
+                 mean: 0.00602s, std: 0.00034s]
+                Dataflow took total 16.24365s [min/index: 0.00533s/1874, max/index: 0.01129s/937,
+                 mean: 0.00866s, std: 0.00113s]
 
         """
         # adopted implementation of torch.autograd.profiler.build_table

--- a/ignite/handlers/timing.py
+++ b/ignite/handlers/timing.py
@@ -24,56 +24,63 @@ class Timer:
         the examples below.
 
     Examples:
-
         Measuring total time of the epoch:
 
-        >>> from ignite.handlers import Timer
-        >>> import time
-        >>> work = lambda : time.sleep(0.1)
-        >>> idle = lambda : time.sleep(0.1)
-        >>> t = Timer(average=False)
-        >>> for _ in range(10):
-        ...    work()
-        ...    idle()
-        ...
-        >>> t.value()
-        2.003073937026784
+        .. code-block:: python
+
+            from ignite.handlers import Timer
+            import time
+            work = lambda : time.sleep(0.1)
+            idle = lambda : time.sleep(0.1)
+            t = Timer(average=False)
+            for _ in range(10):
+                work()
+                idle()
+
+            t.value()
+            # 2.003073937026784
 
         Measuring average time of the epoch:
 
-        >>> t = Timer(average=True)
-        >>> for _ in range(10):
-        ...    work()
-        ...    idle()
-        ...    t.step()
-        ...
-        >>> t.value()
-        0.2003182829997968
+        .. code-block:: python
+
+            t = Timer(average=True)
+            for _ in range(10):
+                work()
+                idle()
+                t.step()
+
+            t.value()
+            # 0.2003182829997968
 
         Measuring average time it takes to execute a single ``work()`` call:
 
-        >>> t = Timer(average=True)
-        >>> for _ in range(10):
-        ...    t.resume()
-        ...    work()
-        ...    t.pause()
-        ...    idle()
-        ...    t.step()
-        ...
-        >>> t.value()
-        0.10016545779653825
+        .. code-block:: python
+
+            t = Timer(average=True)
+            for _ in range(10):
+                t.resume()
+                work()
+                t.pause()
+                idle()
+                t.step()
+
+            t.value()
+            # 0.10016545779653825
 
         Using the Timer to measure average time it takes to process a single batch of examples:
 
-        >>> from ignite.engine import Engine, Events
-        >>> from ignite.handlers import Timer
-        >>> trainer = Engine(training_update_function)
-        >>> timer = Timer(average=True)
-        >>> timer.attach(trainer,
-        ...              start=Events.STARTED,
-        ...              resume=Events.ITERATION_STARTED,
-        ...              pause=Events.ITERATION_COMPLETED,
-        ...              step=Events.ITERATION_COMPLETED)
+        .. code-block:: python
+
+            from ignite.engine import Engine, Events
+            from ignite.handlers import Timer
+            trainer = Engine(training_update_function)
+            timer = Timer(average=True)
+            timer.attach(trainer,
+                         start=Events.STARTED,
+                         resume=Events.ITERATION_STARTED,
+                         pause=Events.ITERATION_COMPLETED,
+                         step=Events.ITERATION_COMPLETED)
     """
 
     def __init__(self, average: bool = False):

--- a/ignite/metrics/accumulation.py
+++ b/ignite/metrics/accumulation.py
@@ -99,18 +99,6 @@ class Average(VariableAccumulation):
         For input `x` being an ND `torch.Tensor` with N > 1, the first dimension is seen as the number of samples and
         is summed up and added to the accumulator: `accumulator += x.sum(dim=0)`
 
-    Examples:
-
-    .. code-block:: python
-
-        evaluator = ...
-
-        custom_var_mean = Average(output_transform=lambda output: output['custom_var'])
-        custom_var_mean.attach(evaluator, 'mean_custom_var')
-
-        state = evaluator.run(dataset)
-        # state.metrics['mean_custom_var'] -> average of output['custom_var']
-
     Args:
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
@@ -119,6 +107,17 @@ class Average(VariableAccumulation):
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
+
+    Examples:
+        .. code-block:: python
+
+            evaluator = ...
+
+            custom_var_mean = Average(output_transform=lambda output: output['custom_var'])
+            custom_var_mean.attach(evaluator, 'mean_custom_var')
+
+            state = evaluator.run(dataset)
+            # state.metrics['mean_custom_var'] -> average of output['custom_var']
     """
 
     def __init__(
@@ -147,6 +146,15 @@ class GeometricAverage(VariableAccumulation):
     - ``update`` must receive output of the form `x`.
     - `x` can be a positive number or a positive `torch.Tensor`, such that ``torch.log(x)`` is not `nan`.
 
+    Args:
+        output_transform: a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        device: specifies which device updates are accumulated on. Setting the metric's
+            device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
+            default, CPU.
+
     Note:
 
         Number of samples is updated following the rule:
@@ -157,15 +165,6 @@ class GeometricAverage(VariableAccumulation):
 
         For input `x` being an ND `torch.Tensor` with N > 1, the first dimension is seen as the number of samples and
         is aggregated and added to the accumulator: `accumulator *= prod(x, dim=0)`
-
-    Args:
-        output_transform: a callable that is used to transform the
-            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
-            form expected by the metric. This can be useful if, for example, you have a multi-output model and
-            you want to compute the metric with respect to one of the outputs.
-        device: specifies which device updates are accumulated on. Setting the metric's
-            device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
-            default, CPU.
 
     """
 

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -105,18 +105,7 @@ class Accuracy(_BaseClassification):
     - `y` and `y_pred` must be in the following shape of (batch_size, num_categories, ...) and
       num_categories must be greater than 1 for multilabel cases.
 
-    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
-    predictions can be done as below:
-
-    .. code-block:: python
-
-        def thresholded_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.round(y_pred)
-            return y_pred, y
-
-        binary_accuracy = Accuracy(thresholded_output_transform)
-
+    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values.
 
     Args:
         output_transform: a callable that is used to transform the
@@ -128,6 +117,17 @@ class Accuracy(_BaseClassification):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
+    Examples:
+        Thresholding of predictions can be done as below:
+
+        .. code-block:: python
+
+            def thresholded_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.round(y_pred)
+                return y_pred, y
+
+            binary_accuracy = Accuracy(thresholded_output_transform)
     """
 
     def __init__(

--- a/ignite/metrics/classification_report.py
+++ b/ignite/metrics/classification_report.py
@@ -36,36 +36,36 @@ def ClassificationReport(
         device: optional device specification for internal storage.
         labels: Optional list of label indices to include in the report
 
-    .. code-block:: python
+    Examples:
+        .. code-block:: python
 
+            def process_function(engine, batch):
+                # ...
+                return y_pred, y
 
-        def process_function(engine, batch):
-            # ...
-            return y_pred, y
-
-        engine = Engine(process_function)
-        metric = ClassificationReport()
-        metric.attach(engine, "cr")
-        engine.run...
-        res = engine.state.metrics["cr"]
-        # result should be like
-        {
-          "0": {
-            "precision": 0.4891304347826087,
-            "recall": 0.5056179775280899,
-            "f1-score": 0.497237569060773
-          },
-          "1": {
-            "precision": 0.5157232704402516,
-            "recall": 0.4992389649923896,
-            "f1-score": 0.507347254447022
-          },
-          "macro avg": {
-            "precision": 0.5024268526114302,
-            "recall": 0.5024284712602398,
-            "f1-score": 0.5022924117538975
-          }
-        }
+            engine = Engine(process_function)
+            metric = ClassificationReport()
+            metric.attach(engine, "cr")
+            engine.run...
+            res = engine.state.metrics["cr"]
+            # result should be like
+            {
+              "0": {
+                "precision": 0.4891304347826087,
+                "recall": 0.5056179775280899,
+                "f1-score": 0.497237569060773
+              },
+              "1": {
+                "precision": 0.5157232704402516,
+                "recall": 0.4992389649923896,
+                "f1-score": 0.507347254447022
+              },
+              "macro avg": {
+                "precision": 0.5024268526114302,
+                "recall": 0.5024284712602398,
+                "f1-score": 0.5022924117538975
+              }
+            }
     """
 
     # setup all the underlying metrics

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -36,10 +36,16 @@ class ConfusionMatrix(Metric):
             default, CPU.
 
     Note:
+        The confusion matrix is formatted such that columns are predictions and rows are targets.
+        For example, if you were to plot the matrix, you could correctly assign to the horizontal axis
+        the label "predicted values" and to the vertical axis the label "actual values".
+
+    Note:
         In case of the targets `y` in `(batch_size, ...)` format, target indices between 0 and `num_classes` only
         contribute to the confusion matrix and others are neglected. For example, if `num_classes=20` and target index
         equal 255 is encountered, then it is filtered out.
 
+    Examples:
         If you are doing binary classification with a single output unit, you may have to transform your network output,
         so that you have one value for each class. E.g. you can transform your network output into a one-hot vector
         with:
@@ -60,12 +66,6 @@ class ConfusionMatrix(Metric):
             evaluator = create_supervised_evaluator(
                 model, metrics=metrics, output_transform=lambda x, y, y_pred: (y_pred, y)
             )
-
-    Note:
-        The confusion matrix is formatted such that columns are predictions and rows are targets.
-        For example, if you were to plot the matrix, you could correctly assign to the horizontal axis
-        the label "predicted values" and to the vertical axis the label "actual values".
-
     """
 
     def __init__(
@@ -174,16 +174,15 @@ def IoU(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> MetricsLambd
         MetricsLambda
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            train_evaluator = ...
 
-        train_evaluator = ...
+            cm = ConfusionMatrix(num_classes=num_classes)
+            IoU(cm, ignore_index=0).attach(train_evaluator, 'IoU')
 
-        cm = ConfusionMatrix(num_classes=num_classes)
-        IoU(cm, ignore_index=0).attach(train_evaluator, 'IoU')
-
-        state = train_evaluator.run(train_dataset)
-        # state.metrics['IoU'] -> tensor of shape (num_classes - 1, )
+            state = train_evaluator.run(train_dataset)
+            # state.metrics['IoU'] -> tensor of shape (num_classes - 1, )
 
     """
     if not isinstance(cm, ConfusionMatrix):
@@ -225,18 +224,15 @@ def mIoU(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> MetricsLamb
         MetricsLambda
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            train_evaluator = ...
 
-        train_evaluator = ...
+            cm = ConfusionMatrix(num_classes=num_classes)
+            mIoU(cm, ignore_index=0).attach(train_evaluator, 'mean IoU')
 
-        cm = ConfusionMatrix(num_classes=num_classes)
-        mIoU(cm, ignore_index=0).attach(train_evaluator, 'mean IoU')
-
-        state = train_evaluator.run(train_dataset)
-        # state.metrics['mean IoU'] -> scalar
-
-
+            state = train_evaluator.run(train_dataset)
+            # state.metrics['mean IoU'] -> scalar
     """
     iou = IoU(cm=cm, ignore_index=ignore_index).mean()  # type: MetricsLambda
     return iou
@@ -345,16 +341,14 @@ def JaccardIndex(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> Met
         MetricsLambda
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            train_evaluator = ...
 
-        train_evaluator = ...
+            cm = ConfusionMatrix(num_classes=num_classes)
+            JaccardIndex(cm, ignore_index=0).attach(train_evaluator, 'JaccardIndex')
 
-        cm = ConfusionMatrix(num_classes=num_classes)
-        JaccardIndex(cm, ignore_index=0).attach(train_evaluator, 'JaccardIndex')
-
-        state = train_evaluator.run(train_dataset)
-        # state.metrics['JaccardIndex'] -> tensor of shape (num_classes - 1, )
-
+            state = train_evaluator.run(train_dataset)
+            # state.metrics['JaccardIndex'] -> tensor of shape (num_classes - 1, )
     """
     return IoU(cm, ignore_index)

--- a/ignite/metrics/frequency.py
+++ b/ignite/metrics/frequency.py
@@ -12,7 +12,6 @@ class Frequency(Metric):
     """Provides metrics for the number of examples processed per second.
 
     Examples:
-
         .. code-block:: python
 
             # Compute number of tokens processed

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -94,8 +94,7 @@ class FID(_BaseInceptionMetric):
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
 
-    Example:
-
+    Examples:
         .. code-block:: python
 
             import torch

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -25,9 +25,6 @@ class InceptionScore(_BaseInceptionMetric):
 
     __ https://arxiv.org/pdf/1801.01973.pdf
 
-    .. note::
-        The default Inception model requires the `torchvision` module to be installed.
-
     Args:
         num_features: number of features predicted by the model or number of classes of the model. Default
             value is 1000.
@@ -47,8 +44,10 @@ class InceptionScore(_BaseInceptionMetric):
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
 
-    Example:
+    .. note::
+        The default Inception model requires the `torchvision` module to be installed.
 
+    Examples:
         .. code-block:: python
 
             from ignite.metric.gan import InceptionScore

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -34,10 +34,9 @@ class Loss(Metric):
         required_output_keys: dictionary defines required keys to be found in ``engine.state.output`` if the
             latter is a dictionary. Default, ``("y_pred", "y", "criterion_kwargs")``. This is useful when the
             criterion function requires additional arguments, which can be passed using ``criterion_kwargs``.
-            See notes below for an example.
+            See an example below.
 
-    Note:
-
+    Examples:
         Let's implement a Loss metric that requires ``x``, ``y_pred``, ``y`` and ``criterion_kwargs`` as input
         for ``criterion`` function. In the example below we show how to setup standard metric like Accuracy
         and the Loss metric using an ``evaluator`` created with

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -143,10 +143,9 @@ class Metric(metaclass=ABCMeta):
     Attributes:
         required_output_keys: dictionary defines required keys to be found in ``engine.state.output`` if the
             latter is a dictionary. Default, ``("y_pred", "y")``. This is useful with custom metrics that can require
-            other arguments than predictions ``y_pred`` and targets ``y``. See notes below for an example.
+            other arguments than predictions ``y_pred`` and targets ``y``. See an example below.
 
-    Note:
-
+    Examples:
         Let's implement a custom metric that requires ``y_pred``, ``y`` and ``x`` as input for ``update`` function.
         In the example below we show how to setup standard metric like Accuracy and the custom metric using by an
         ``evaluator`` created with :meth:`~ignite.engine.create_supervised_evaluator` method.
@@ -280,14 +279,14 @@ class Metric(metaclass=ABCMeta):
         """Helper method to update metric's computation. It is automatically attached to the
         `engine` with :meth:`~ignite.metrics.metric.Metric.attach`.
 
+        Args:
+            engine: the engine to which the metric must be attached
+
         Note:
             ``engine.state.output`` is used to compute metric values.
             The majority of implemented metrics accepts the following formats for ``engine.state.output``:
             ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``. ``y_pred`` and ``y`` can be torch tensors or
             list of tensors/numbers if applicable.
-
-        Args:
-            engine: the engine to which the metric must be attached
 
         .. versionchanged:: 0.4.5
             ``y_pred`` and ``y`` can be torch tensors or list of tensors/numbers
@@ -378,27 +377,26 @@ class Metric(metaclass=ABCMeta):
                 :attr:`ignite.metrics.metric.EpochWise.usage_name` (default) or
                 :attr:`ignite.metrics.metric.BatchWise.usage_name`.
 
-        Example:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                metric.attach(engine, "mymetric")
 
-            metric = ...
-            metric.attach(engine, "mymetric")
+                assert "mymetric" in engine.run(data).metrics
 
-            assert "mymetric" in engine.run(data).metrics
+                assert metric.is_attached(engine)
 
-            assert metric.is_attached(engine)
+            Example with usage:
 
-        Example with usage:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                metric.attach(engine, "mymetric", usage=BatchWise.usage_name)
 
-            metric = ...
-            metric.attach(engine, "mymetric", usage=BatchWise.usage_name)
+                assert "mymetric" in engine.run(data).metrics
 
-            assert "mymetric" in engine.run(data).metrics
-
-            assert metric.is_attached(engine, usage=BatchWise.usage_name)
+                assert metric.is_attached(engine, usage=BatchWise.usage_name)
         """
         usage = self._check_usage(usage)
         if not engine.has_event_handler(self.started, usage.STARTED):
@@ -419,29 +417,28 @@ class Metric(metaclass=ABCMeta):
             usage: the usage of the metric. Valid string values should be
                 'epoch_wise' (default) or 'batch_wise'.
 
-        Example:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                engine = ...
+                metric.detach(engine)
 
-            metric = ...
-            engine = ...
-            metric.detach(engine)
+                assert "mymetric" not in engine.run(data).metrics
 
-            assert "mymetric" not in engine.run(data).metrics
+                assert not metric.is_attached(engine)
 
-            assert not metric.is_attached(engine)
+            Example with usage:
 
-        Example with usage:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                engine = ...
+                metric.detach(engine, usage="batch_wise")
 
-            metric = ...
-            engine = ...
-            metric.detach(engine, usage="batch_wise")
+                assert "mymetric" not in engine.run(data).metrics
 
-            assert "mymetric" not in engine.run(data).metrics
-
-            assert not metric.is_attached(engine, usage="batch_wise")
+                assert not metric.is_attached(engine, usage="batch_wise")
         """
         usage = self._check_usage(usage)
         if engine.has_event_handler(self.completed, usage.COMPLETED):

--- a/ignite/metrics/metrics_lambda.py
+++ b/ignite/metrics/metrics_lambda.py
@@ -27,43 +27,41 @@ class MetricsLambda(Metric):
         kwargs: Sequence of other metrics or something
             else that will be fed to ``f`` as keyword arguments.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            precision = Precision(average=False)
+            recall = Recall(average=False)
 
-        precision = Precision(average=False)
-        recall = Recall(average=False)
+            def Fbeta(r, p, beta):
+                return torch.mean((1 + beta ** 2) * p * r / (beta ** 2 * p + r + 1e-20)).item()
 
-        def Fbeta(r, p, beta):
-            return torch.mean((1 + beta ** 2) * p * r / (beta ** 2 * p + r + 1e-20)).item()
+            F1 = MetricsLambda(Fbeta, recall, precision, 1)
+            F2 = MetricsLambda(Fbeta, recall, precision, 2)
+            F3 = MetricsLambda(Fbeta, recall, precision, 3)
+            F4 = MetricsLambda(Fbeta, recall, precision, 4)
 
-        F1 = MetricsLambda(Fbeta, recall, precision, 1)
-        F2 = MetricsLambda(Fbeta, recall, precision, 2)
-        F3 = MetricsLambda(Fbeta, recall, precision, 3)
-        F4 = MetricsLambda(Fbeta, recall, precision, 4)
+        When check if the metric is attached, if one of its dependency
+        metrics is detached, the metric is considered detached too.
 
-    When check if the metric is attached, if one of its dependency
-    metrics is detached, the metric is considered detached too.
+        .. code-block:: python
 
-    .. code-block:: python
+            engine = ...
+            precision = Precision(average=False)
 
-        engine = ...
-        precision = Precision(average=False)
+            aP = precision.mean()
 
-        aP = precision.mean()
+            aP.attach(engine, "aP")
 
-        aP.attach(engine, "aP")
+            assert aP.is_attached(engine)
+            # partially attached
+            assert not precision.is_attached(engine)
 
-        assert aP.is_attached(engine)
-        # partially attached
-        assert not precision.is_attached(engine)
+            precision.detach(engine)
 
-        precision.detach(engine)
-
-        assert not aP.is_attached(engine)
-        # fully attached
-        assert not precision.is_attached(engine)
-
+            assert not aP.is_attached(engine)
+            # fully attached
+            assert not precision.is_attached(engine)
     """
 
     def __init__(self, f: Callable, *args: Any, **kwargs: Any) -> None:

--- a/ignite/metrics/nlp/bleu.py
+++ b/ignite/metrics/nlp/bleu.py
@@ -102,20 +102,19 @@ class Bleu(Metric):
             for more details refer https://www.nltk.org/_modules/nltk/translate/bleu_score.html
             Default: "macro"
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics.nlp import Bleu
 
-        from ignite.metrics.nlp import Bleu
+            m = Bleu(ngram=4, smooth="smooth1")
 
-        m = Bleu(ngram=4, smooth="smooth1")
+            y_pred = "the the the the the the the"
+            y = ["the cat is on the mat", "there is a cat on the mat"]
 
-        y_pred = "the the the the the the the"
-        y = ["the cat is on the mat", "there is a cat on the mat"]
+            m.update(([y_pred.split()], [[_y.split() for _y in y]]))
 
-        m.update(([y_pred.split()], [[_y.split() for _y in y]]))
-
-        print(m.compute())
+            print(m.compute())
 
     .. versionadded:: 0.4.5
     .. versionchanged:: 0.5.0

--- a/ignite/metrics/nlp/rouge.py
+++ b/ignite/metrics/nlp/rouge.py
@@ -209,24 +209,23 @@ class RougeN(_BaseRouge):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics import RougeN
 
-        from ignite.metrics import RougeN
+            m = RougeN(ngram=2, multiref="best")
 
-        m = RougeN(ngram=2, multiref="best")
+            candidate = "the cat is not there".split()
+            references = [
+                "the cat is on the mat".split(),
+                "there is a cat on the mat".split()
+            ]
 
-        candidate = "the cat is not there".split()
-        references = [
-            "the cat is on the mat".split(),
-            "there is a cat on the mat".split()
-        ]
+            m.update((candidate, references))
 
-        m.update((candidate, references))
-
-        m.compute()
-        >>> {'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
+            m.compute()
+            # {'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
 
     .. versionadded:: 0.4.5
     """
@@ -276,24 +275,23 @@ class RougeL(_BaseRouge):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics import RougeL
 
-        from ignite.metrics import RougeL
+            m = RougeL(multiref="best")
 
-        m = RougeL(multiref="best")
+            candidate = "the cat is not there".split()
+            references = [
+               "the cat is on the mat".split(),
+                "there is a cat on the mat".split()
+            ]
 
-        candidate = "the cat is not there".split()
-        references = [
-           "the cat is on the mat".split(),
-            "there is a cat on the mat".split()
-        ]
+            m.update((candidate, references))
 
-        m.update((candidate, references))
-
-       m.compute()
-       >>> {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5}
+           m.compute()
+           # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5}
 
     .. versionadded:: 0.4.5
     """
@@ -338,24 +336,23 @@ class Rouge(Metric):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics import Rouge
 
-        from ignite.metrics import Rouge
+            m = Rouge(variants=["L", 2], multiref="best")
 
-        m = Rouge(variants=["L", 2], multiref="best")
+            candidate = "the cat is not there".split()
+            references = [
+                "the cat is on the mat".split(),
+                "there is a cat on the mat".split()
+            ]
 
-        candidate = "the cat is not there".split()
-        references = [
-            "the cat is on the mat".split(),
-            "there is a cat on the mat".split()
-        ]
+            m.update((candidate, references))
 
-        m.update((candidate, references))
-
-        m.compute()
-        >>> {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
+            m.compute()
+            # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
 
     .. versionadded:: 0.4.5
     """

--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -73,35 +73,6 @@ class Precision(_BasePrecisionRecall):
     - `y_pred` must be in the following shape (batch_size, num_categories, ...) or (batch_size, ...).
     - `y` must be in the following shape (batch_size, ...).
 
-    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
-    predictions can be done as below:
-
-    .. code-block:: python
-
-        def thresholded_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.round(y_pred)
-            return y_pred, y
-
-        precision = Precision(output_transform=thresholded_output_transform)
-
-    In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
-    example, average parameter should be False. This can be done as shown below:
-
-    .. code-block:: python
-
-        precision = Precision(average=False)
-        recall = Recall(average=False)
-        F1 = precision * recall * 2 / (precision + recall + 1e-20)
-        F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
-
-    .. warning::
-
-        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
-        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
-        than available RAM.
-
-
     Args:
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
@@ -114,6 +85,36 @@ class Precision(_BasePrecisionRecall):
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
+
+    Examples:
+        In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
+        predictions can be done as below:
+
+        .. code-block:: python
+
+            def thresholded_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.round(y_pred)
+                return y_pred, y
+
+            precision = Precision(output_transform=thresholded_output_transform)
+
+        In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
+        example, average parameter should be False. This can be done as shown below:
+
+        .. code-block:: python
+
+            precision = Precision(average=False)
+            recall = Recall(average=False)
+            F1 = precision * recall * 2 / (precision + recall + 1e-20)
+            F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
+
+    .. warning::
+
+        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
+        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
+        than available RAM.
+
 
     """
 

--- a/ignite/metrics/psnr.py
+++ b/ignite/metrics/psnr.py
@@ -29,40 +29,39 @@ class PSNR(Metric):
             Setting the metric’s device to be the same as your update arguments ensures
             the update method is non-blocking. By default, CPU.
 
-    Example:
+    Examples:
+        To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
+        The output of the engine's ``process_function`` needs to be in format of
+        ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
 
-    To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
-    The output of the engine's ``process_function`` needs to be in format of
-    ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
+        .. code-block:: python
 
-    .. code-block:: python
-
-        def process_function(engine, batch):
+            def process_function(engine, batch):
+                # ...
+                return y_pred, y
+            engine = Engine(process_function)
+            psnr = PSNR(data_range=1.0)
+            psnr.attach(engine, "psnr")
             # ...
-            return y_pred, y
-        engine = Engine(process_function)
-        psnr = PSNR(data_range=1.0)
-        psnr.attach(engine, "psnr")
-        # ...
-        state = engine.run(data)
-        print(f"PSNR: {state.metrics['psnr']}")
+            state = engine.run(data)
+            print(f"PSNR: {state.metrics['psnr']}")
 
-    This metric by default accepts Grayscale or RGB images. But if you have YCbCr or YUV images, only
-    Y channel is needed for computing PSNR. And, this can be done with ``output_transform``. For instance,
+        This metric by default accepts Grayscale or RGB images. But if you have YCbCr or YUV images, only
+        Y channel is needed for computing PSNR. And, this can be done with ``output_transform``. For instance,
 
-    .. code-block:: python
+        .. code-block:: python
 
-        def get_y_channel(output):
-            y_pred, y = output
-            # y_pred and y are (B, 3, H, W) and YCbCr or YUV images
-            # let's select y channel
-            return y_pred[:, 0, ...], y[:, 0, ...]
+            def get_y_channel(output):
+                y_pred, y = output
+                # y_pred and y are (B, 3, H, W) and YCbCr or YUV images
+                # let's select y channel
+                return y_pred[:, 0, ...], y[:, 0, ...]
 
-        psnr = PSNR(data_range=219, output_transform=get_y_channel)
-        psnr.attach(engine, "psnr")
-        # ...
-        state = engine.run(data)
-        print(f"PSNR: {state.metrics['psrn']}")
+            psnr = PSNR(data_range=219, output_transform=get_y_channel)
+            psnr.attach(engine, "psnr")
+            # ...
+            state = engine.run(data)
+            print(f"PSNR: {state.metrics['psrn']}")
 
     .. versionadded:: 0.4.3
     """

--- a/ignite/metrics/recall.py
+++ b/ignite/metrics/recall.py
@@ -20,35 +20,6 @@ class Recall(_BasePrecisionRecall):
     - `y_pred` must be in the following shape (batch_size, num_categories, ...) or (batch_size, ...).
     - `y` must be in the following shape (batch_size, ...).
 
-    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
-    predictions can be done as below:
-
-    .. code-block:: python
-
-        def thresholded_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.round(y_pred)
-            return y_pred, y
-
-        recall = Recall(output_transform=thresholded_output_transform)
-
-    In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
-    example, average parameter should be False. This can be done as shown below:
-
-    .. code-block:: python
-
-        precision = Precision(average=False)
-        recall = Recall(average=False)
-        F1 = precision * recall * 2 / (precision + recall + 1e-20)
-        F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
-
-    .. warning::
-
-        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
-        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
-        than available RAM.
-
-
     Args:
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
@@ -62,6 +33,34 @@ class Recall(_BasePrecisionRecall):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
+    Examples:
+        In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
+        predictions can be done as below:
+
+        .. code-block:: python
+
+            def thresholded_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.round(y_pred)
+                return y_pred, y
+
+            recall = Recall(output_transform=thresholded_output_transform)
+
+        In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
+        example, average parameter should be False. This can be done as shown below:
+
+        .. code-block:: python
+
+            precision = Precision(average=False)
+            recall = Recall(average=False)
+            F1 = precision * recall * 2 / (precision + recall + 1e-20)
+            F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
+
+    .. warning::
+
+        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
+        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
+        than available RAM.
     """
 
     def __init__(

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -25,22 +25,20 @@ class RunningAverage(Metric):
             use the ``src``'s device. Otherwise, defaults to CPU. Only applicable when the computed value
             from the metric is a tensor.
 
-
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            alpha = 0.98
+            acc_metric = RunningAverage(Accuracy(output_transform=lambda x: [x[1], x[2]]), alpha=alpha)
+            acc_metric.attach(trainer, 'running_avg_accuracy')
 
-        alpha = 0.98
-        acc_metric = RunningAverage(Accuracy(output_transform=lambda x: [x[1], x[2]]), alpha=alpha)
-        acc_metric.attach(trainer, 'running_avg_accuracy')
+            avg_output = RunningAverage(output_transform=lambda x: x[0], alpha=alpha)
+            avg_output.attach(trainer, 'running_avg_loss')
 
-        avg_output = RunningAverage(output_transform=lambda x: x[0], alpha=alpha)
-        avg_output.attach(trainer, 'running_avg_loss')
-
-        @trainer.on(Events.ITERATION_COMPLETED)
-        def log_running_avg_metrics(engine):
-            print("running avg accuracy:", engine.state.metrics['running_avg_accuracy'])
-            print("running avg loss:", engine.state.metrics['running_avg_loss'])
+            @trainer.on(Events.ITERATION_COMPLETED)
+            def log_running_avg_metrics(engine):
+                print("running avg accuracy:", engine.state.metrics['running_avg_accuracy'])
+                print("running avg loss:", engine.state.metrics['running_avg_loss'])
 
     """
 

--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -28,23 +28,22 @@ class SSIM(Metric):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
+        The output of the engine's ``process_function`` needs to be in the format of
+        ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
 
-    To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
-    The output of the engine's ``process_function`` needs to be in the format of
-    ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
+        ``y_pred`` and ``y`` can be un-normalized or normalized image tensors. Depending on that, the user might need
+        to adjust ``data_range``. ``y_pred`` and ``y`` should have the same shape.
 
-    ``y_pred`` and ``y`` can be un-normalized or normalized image tensors. Depending on that, the user might need
-    to adjust ``data_range``. ``y_pred`` and ``y`` should have the same shape.
+        .. code-block:: python
 
-    .. code-block:: python
-
-        def process_function(engine, batch):
-            # ...
-            return y_pred, y
-        engine = Engine(process_function)
-        metric = SSIM(data_range=1.0)
-        metric.attach(engine, "ssim")
+            def process_function(engine, batch):
+                # ...
+                return y_pred, y
+            engine = Engine(process_function)
+            metric = SSIM(data_range=1.0)
+            metric.attach(engine, "ssim")
 
     .. versionadded:: 0.4.2
     """

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -108,48 +108,49 @@ def setup_logger(
     Returns:
         logging.Logger
 
-    For example, to improve logs readability when training with a trainer and evaluator:
+    Examples:
+        Improve logs readability when training with a trainer and evaluator:
 
-    .. code-block:: python
+        .. code-block:: python
 
-        from ignite.utils import setup_logger
+            from ignite.utils import setup_logger
 
-        trainer = ...
-        evaluator = ...
+            trainer = ...
+            evaluator = ...
 
-        trainer.logger = setup_logger("trainer")
-        evaluator.logger = setup_logger("evaluator")
+            trainer.logger = setup_logger("trainer")
+            evaluator.logger = setup_logger("evaluator")
 
-        trainer.run(data, max_epochs=10)
+            trainer.run(data, max_epochs=10)
 
-        # Logs will look like
-        # 2020-01-21 12:46:07,356 trainer INFO: Engine run starting with max_epochs=5.
-        # 2020-01-21 12:46:07,358 trainer INFO: Epoch[1] Complete. Time taken: 00:5:23
-        # 2020-01-21 12:46:07,358 evaluator INFO: Engine run starting with max_epochs=1.
-        # 2020-01-21 12:46:07,358 evaluator INFO: Epoch[1] Complete. Time taken: 00:01:02
-        # ...
+            # Logs will look like
+            # 2020-01-21 12:46:07,356 trainer INFO: Engine run starting with max_epochs=5.
+            # 2020-01-21 12:46:07,358 trainer INFO: Epoch[1] Complete. Time taken: 00:5:23
+            # 2020-01-21 12:46:07,358 evaluator INFO: Engine run starting with max_epochs=1.
+            # 2020-01-21 12:46:07,358 evaluator INFO: Epoch[1] Complete. Time taken: 00:01:02
+            # ...
 
-    Every existing logger can be reset if needed
+        Every existing logger can be reset if needed
 
-    .. code-block:: python
+        .. code-block:: python
 
-        logger = setup_logger(name="my-logger", format="=== %(name)s %(message)s")
-        logger.info("first message")
-        setup_logger(name="my-logger", format="+++ %(name)s %(message)s", reset=True)
-        logger.info("second message")
+            logger = setup_logger(name="my-logger", format="=== %(name)s %(message)s")
+            logger.info("first message")
+            setup_logger(name="my-logger", format="+++ %(name)s %(message)s", reset=True)
+            logger.info("second message")
 
-        # Logs will look like
-        # === my-logger first message
-        # +++ my-logger second message
+            # Logs will look like
+            # === my-logger first message
+            # +++ my-logger second message
 
-    Example to change the level of an existing internal logger
+        Change the level of an existing internal logger
 
-    .. code-block:: python
+        .. code-block:: python
 
-        setup_logger(
-            name="ignite.distributed.launcher.Parallel",
-            level=logging.WARNING
-        )
+            setup_logger(
+                name="ignite.distributed.launcher.Parallel",
+                level=logging.WARNING
+            )
 
     .. versionchanged:: 0.4.3
         Added ``stream`` parameter.


### PR DESCRIPTION
Fixes #2114 

Description:
1. Highlight docstring section headers by adding some CSS
2. Add Sphinx's "copybutton" plugin to copy code examples to the clipboard in one click

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
