### PR TITLE
fix #2114: make doc subsections header bold

### DIFF
--- a/docs/source/_templates/_static/css/ignite_theme.css
+++ b/docs/source/_templates/_static/css/ignite_theme.css
@@ -211,12 +211,12 @@ so make sure not to go above that value */
 /* docsearch end */
 
 article.pytorch-article p.rubric {
-    font-weight: bold;
-    font-size: 19px;
-    margin: 15px 0 10px 0;
+  font-weight: bold;
+  font-size: 1.25rem;
+  margin: 15px 0 10px 0;
 }
 
-pre {
-    border: 1px solid rgba(0,0,0,0.15);
-    border-radius: 4px;
+.highlight {
+  border: 1px solid rgba(0,0,0,0.15);
+  border-radius: 4px;
 }

--- a/docs/source/_templates/_static/css/ignite_theme.css
+++ b/docs/source/_templates/_static/css/ignite_theme.css
@@ -209,3 +209,14 @@ so make sure not to go above that value */
   }
 }
 /* docsearch end */
+
+article.pytorch-article p.rubric {
+    font-weight: bold;
+    font-size: 19px;
+    margin: 15px 0 10px 0;
+}
+
+pre {
+    border: 1px solid rgba(0,0,0,0.15);
+    border-radius: 4px;
+}


### PR DESCRIPTION
Fixes #2114

Description:
part 1 of 7, adding CSS style for docstring section headers

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
