### PR TITLE
Fix 2114: Sphinx copy-button plugin

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==3.4.3
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib-katex
+sphinx-copybutton==0.4.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx_copybutton",
 ]
 
 # katex options
@@ -123,7 +124,7 @@ html_favicon = "_templates/_static/img/ignite_logomark.svg"
 html_static_path = ["_static", "_templates/_static"]
 
 html_context = {
-    "css_files": [
+    "extra_css_files": [
         # 'https://fonts.googleapis.com/css?family=Lato',
         # '_static/css/pytorch_theme.css'
         "_static/css/ignite_theme.css",


### PR DESCRIPTION
Fixes #2114

Description:
part 2 of 7: Added Sphinx plugin "copy-button" that allows copy code examples to clipboard

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
