### PR TITLE
Related to #2114: reformat docstrings in the 'engine' folder

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -71,16 +71,17 @@ def supervised_training_step(
     Returns:
         Callable: update function.
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step
+            from ignite.engine import Engine, supervised_training_step
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
+            model = ...
+            optimizer = ...
+            loss_fn = ...
 
-        update_fn = supervised_training_step(model, optimizer, loss_fn, 'cuda')
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step(model, optimizer, loss_fn, 'cuda')
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """
@@ -128,17 +129,18 @@ def supervised_training_step_amp(
     Returns:
         Callable: update function
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step_amp
+            from ignite.engine import Engine, supervised_training_step_amp
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
-        scaler = torch.cuda.amp.GradScaler(2**10)
+            model = ...
+            optimizer = ...
+            loss_fn = ...
+            scaler = torch.cuda.amp.GradScaler(2**10)
 
-        update_fn = supervised_training_step_amp(model, optimizer, loss_fn, 'cuda', scaler=scaler)
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step_amp(model, optimizer, loss_fn, 'cuda', scaler=scaler)
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """
@@ -195,16 +197,17 @@ def supervised_training_step_apex(
     Returns:
         Callable: update function.
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step_apex
+            from ignite.engine import Engine, supervised_training_step_apex
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
+            model = ...
+            optimizer = ...
+            loss_fn = ...
 
-        update_fn = supervised_training_step_apex(model, optimizer, loss_fn, 'cuda')
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step_apex(model, optimizer, loss_fn, 'cuda')
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """
@@ -256,16 +259,17 @@ def supervised_training_step_tpu(
     Returns:
         Callable: update function.
 
-    Example::
+    Examples:
+        .. code-block:: python
 
-        from ignite.engine import Engine, supervised_training_step_tpu
+            from ignite.engine import Engine, supervised_training_step_tpu
 
-        model = ...
-        optimizer = ...
-        loss_fn = ...
+            model = ...
+            optimizer = ...
+            loss_fn = ...
 
-        update_fn = supervised_training_step_tpu(model, optimizer, loss_fn, 'xla')
-        trainer = Engine(update_fn)
+            update_fn = supervised_training_step_tpu(model, optimizer, loss_fn, 'xla')
+            trainer = Engine(update_fn)
 
     .. versionadded:: 0.4.5
     """

--- a/ignite/engine/deterministic.py
+++ b/ignite/engine/deterministic.py
@@ -39,21 +39,21 @@ class ReproducibleBatchSampler(BatchSampler):
     """Reproducible batch sampler. This class internally iterates and stores indices of the input batch sampler.
     This helps to start providing data batches from an iteration in a deterministic way.
 
-    Example:
-
-        Setup dataloader with `ReproducibleBatchSampler` and start providing data batches from an iteration
-
-    .. code-block:: python
-
-        from ignite.engine.deterministic import update_dataloader
-
-        dataloader = update_dataloader(dataloader, ReproducibleBatchSampler(dataloader.batch_sampler))
-        # rewind dataloader to a specific iteration:
-        dataloader.batch_sampler.start_iteration = start_iteration
-
     Args:
         batch_sampler: batch sampler same as used with `torch.utils.data.DataLoader`.
         start_iteration: optional start iteration.
+
+    Examples:
+        Setup dataloader with `ReproducibleBatchSampler` and start providing data batches from an iteration
+
+        .. code-block:: python
+
+            from ignite.engine.deterministic import update_dataloader
+
+            dataloader = update_dataloader(dataloader, ReproducibleBatchSampler(dataloader.batch_sampler))
+            # rewind dataloader to a specific iteration:
+            dataloader.batch_sampler.start_iteration = start_iteration
+
     """
 
     def __init__(self, batch_sampler: BatchSampler, start_iteration: Optional[int] = None):

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -31,7 +31,6 @@ class Engine(Serializable):
         last_event_name: last event name triggered by the engine.
 
     Examples:
-
         Create a basic trainer
 
         .. code-block:: python
@@ -158,63 +157,62 @@ class Engine(Serializable):
                 or an object derived from :class:`~ignite.engine.events.EventEnum`. See example below.
             event_to_attr: A dictionary to map an event to a state attribute.
 
-        Example usage:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                from ignite.engine import Engine, Events, EventEnum
 
-            from ignite.engine import Engine, Events, EventEnum
+                class CustomEvents(EventEnum):
+                    FOO_EVENT = "foo_event"
+                    BAR_EVENT = "bar_event"
 
-            class CustomEvents(EventEnum):
-                FOO_EVENT = "foo_event"
-                BAR_EVENT = "bar_event"
+                def process_function(e, batch):
+                    # ...
+                    trainer.fire_event("bwd_event")
+                    loss.backward()
+                    # ...
+                    trainer.fire_event("opt_event")
+                    optimizer.step()
 
-            def process_function(e, batch):
-                # ...
-                trainer.fire_event("bwd_event")
-                loss.backward()
-                # ...
-                trainer.fire_event("opt_event")
-                optimizer.step()
+                trainer = Engine(process_function)
+                trainer.register_events(*CustomEvents)
+                trainer.register_events("bwd_event", "opt_event")
 
-            trainer = Engine(process_function)
-            trainer.register_events(*CustomEvents)
-            trainer.register_events("bwd_event", "opt_event")
+                @trainer.on(Events.EPOCH_COMPLETED)
+                def trigger_custom_event():
+                    if required(...):
+                        trainer.fire_event(CustomEvents.FOO_EVENT)
+                    else:
+                        trainer.fire_event(CustomEvents.BAR_EVENT)
 
-            @trainer.on(Events.EPOCH_COMPLETED)
-            def trigger_custom_event():
-                if required(...):
-                    trainer.fire_event(CustomEvents.FOO_EVENT)
-                else:
-                    trainer.fire_event(CustomEvents.BAR_EVENT)
+                @trainer.on(CustomEvents.FOO_EVENT)
+                def do_foo_op():
+                    # ...
 
-            @trainer.on(CustomEvents.FOO_EVENT)
-            def do_foo_op():
-                # ...
+                @trainer.on(CustomEvents.BAR_EVENT)
+                def do_bar_op():
+                    # ...
 
-            @trainer.on(CustomEvents.BAR_EVENT)
-            def do_bar_op():
-                # ...
+            Example with State Attribute:
 
-        Example with State Attribute:
+            .. code-block:: python
 
-        .. code-block:: python
+                from enum import Enum
+                from ignite.engine import Engine, EventEnum
 
-            from enum import Enum
-            from ignite.engine import Engine, EventEnum
+                class TBPTT_Events(EventEnum):
+                    TIME_ITERATION_STARTED = "time_iteration_started"
+                    TIME_ITERATION_COMPLETED = "time_iteration_completed"
 
-            class TBPTT_Events(EventEnum):
-                TIME_ITERATION_STARTED = "time_iteration_started"
-                TIME_ITERATION_COMPLETED = "time_iteration_completed"
+                TBPTT_event_to_attr = {
+                    TBPTT_Events.TIME_ITERATION_STARTED: 'time_iteration',
+                    TBPTT_Events.TIME_ITERATION_COMPLETED: 'time_iteration'
+                }
 
-            TBPTT_event_to_attr = {
-                TBPTT_Events.TIME_ITERATION_STARTED: 'time_iteration',
-                TBPTT_Events.TIME_ITERATION_COMPLETED: 'time_iteration'
-            }
-
-            engine = Engine(process_function)
-            engine.register_events(*TBPTT_Events, event_to_attr=TBPTT_event_to_attr)
-            engine.run(data)
-            # engine.state contains an attribute time_iteration, which can be accessed using engine.state.time_iteration
+                engine = Engine(process_function)
+                engine.register_events(*TBPTT_Events, event_to_attr=TBPTT_event_to_attr)
+                engine.run(data)
+                # engine.state contains an attribute time_iteration, which can be accessed using engine.state.time_iteration
         """
         if not (event_to_attr is None or isinstance(event_to_attr, dict)):
             raise ValueError(f"Expected event_to_attr to be dictionary. Got {type(event_to_attr)}.")
@@ -266,24 +264,23 @@ class Engine(Serializable):
             Note that other arguments can be passed to the handler in addition to the `*args` and  `**kwargs`
             passed here, for example during :attr:`~ignite.engine.events.Events.EXCEPTION_RAISED`.
 
-        Example usage:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                engine = Engine(process_function)
 
-            engine = Engine(process_function)
+                def print_epoch(engine):
+                    print(f"Epoch: {engine.state.epoch}")
 
-            def print_epoch(engine):
-                print(f"Epoch: {engine.state.epoch}")
+                engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch)
 
-            engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch)
+                events_list = Events.EPOCH_COMPLETED | Events.COMPLETED
 
-            events_list = Events.EPOCH_COMPLETED | Events.COMPLETED
+                def execute_something():
+                    # do some thing not related to engine
+                    pass
 
-            def execute_something():
-                # do some thing not related to engine
-                pass
-
-            engine.add_event_handler(events_list, execute_something)
+                engine.add_event_handler(events_list, execute_something)
 
         Note:
             Since v0.3.0, Events become more flexible and allow to pass an event filter to the Engine.
@@ -379,20 +376,19 @@ class Engine(Serializable):
             args: optional args to be passed to `handler`.
             kwargs: optional keyword args to be passed to `handler`.
 
-        Example usage:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                engine = Engine(process_function)
 
-            engine = Engine(process_function)
+                @engine.on(Events.EPOCH_COMPLETED)
+                def print_epoch():
+                    print(f"Epoch: {engine.state.epoch}")
 
-            @engine.on(Events.EPOCH_COMPLETED)
-            def print_epoch():
-                print(f"Epoch: {engine.state.epoch}")
-
-            @engine.on(Events.EPOCH_COMPLETED | Events.COMPLETED)
-            def execute_something():
-                # do some thing not related to engine
-                pass
+                @engine.on(Events.EPOCH_COMPLETED | Events.COMPLETED)
+                def execute_something():
+                    # do some thing not related to engine
+                    pass
         """
 
         def decorator(f: Callable) -> Callable:
@@ -572,7 +568,7 @@ class Engine(Serializable):
         Args:
             data: Collection of batches allowing repeated iteration (e.g., list or `DataLoader`).
 
-        Example usage:
+        Examples:
             User can switch data provider during the training:
 
             .. code-block:: python

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -212,7 +212,8 @@ class Engine(Serializable):
                 engine = Engine(process_function)
                 engine.register_events(*TBPTT_Events, event_to_attr=TBPTT_event_to_attr)
                 engine.run(data)
-                # engine.state contains an attribute time_iteration, which can be accessed using engine.state.time_iteration
+                # engine.state contains an attribute time_iteration, which can be accessed
+                # using engine.state.time_iteration
         """
         if not (event_to_attr is None or isinstance(event_to_attr, dict)):
             raise ValueError(f"Expected event_to_attr to be dictionary. Got {type(event_to_attr)}.")

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -140,7 +140,10 @@ class CallableEventWithFilter:
 
 class EventEnum(CallableEventWithFilter, Enum):  # type: ignore[misc]
     """Base class for all :class:`~ignite.engine.events.Events`. User defined custom events should also inherit
-    this class. For example, Custom events based on the loss calculation and backward pass can be created as follows:
+    this class.
+
+     Examples:
+         Custom events based on the loss calculation and backward pass can be created as follows:
 
         .. code-block:: python
 
@@ -436,20 +439,19 @@ class RemovableEventHandle:
         handler: Registered event handler, stored as weakref.
         engine: Target engine, stored as weakref.
 
-    Example usage:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            engine = Engine()
 
-        engine = Engine()
+            def print_epoch(engine):
+                print(f"Epoch: {engine.state.epoch}")
 
-        def print_epoch(engine):
-            print(f"Epoch: {engine.state.epoch}")
+            with engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch):
+                # print_epoch handler registered for a single run
+                engine.run(data)
 
-        with engine.add_event_handler(Events.EPOCH_COMPLETED, print_epoch):
-            # print_epoch handler registered for a single run
-            engine.run(data)
-
-        # print_epoch handler is now unregistered
+            # print_epoch handler is now unregistered
     """
 
     def __init__(

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -108,48 +108,49 @@ def setup_logger(
     Returns:
         logging.Logger
 
-    For example, to improve logs readability when training with a trainer and evaluator:
+    Examples:
+        Improve logs readability when training with a trainer and evaluator:
 
-    .. code-block:: python
+        .. code-block:: python
 
-        from ignite.utils import setup_logger
+            from ignite.utils import setup_logger
 
-        trainer = ...
-        evaluator = ...
+            trainer = ...
+            evaluator = ...
 
-        trainer.logger = setup_logger("trainer")
-        evaluator.logger = setup_logger("evaluator")
+            trainer.logger = setup_logger("trainer")
+            evaluator.logger = setup_logger("evaluator")
 
-        trainer.run(data, max_epochs=10)
+            trainer.run(data, max_epochs=10)
 
-        # Logs will look like
-        # 2020-01-21 12:46:07,356 trainer INFO: Engine run starting with max_epochs=5.
-        # 2020-01-21 12:46:07,358 trainer INFO: Epoch[1] Complete. Time taken: 00:5:23
-        # 2020-01-21 12:46:07,358 evaluator INFO: Engine run starting with max_epochs=1.
-        # 2020-01-21 12:46:07,358 evaluator INFO: Epoch[1] Complete. Time taken: 00:01:02
-        # ...
+            # Logs will look like
+            # 2020-01-21 12:46:07,356 trainer INFO: Engine run starting with max_epochs=5.
+            # 2020-01-21 12:46:07,358 trainer INFO: Epoch[1] Complete. Time taken: 00:5:23
+            # 2020-01-21 12:46:07,358 evaluator INFO: Engine run starting with max_epochs=1.
+            # 2020-01-21 12:46:07,358 evaluator INFO: Epoch[1] Complete. Time taken: 00:01:02
+            # ...
 
-    Every existing logger can be reset if needed
+        Every existing logger can be reset if needed
 
-    .. code-block:: python
+        .. code-block:: python
 
-        logger = setup_logger(name="my-logger", format="=== %(name)s %(message)s")
-        logger.info("first message")
-        setup_logger(name="my-logger", format="+++ %(name)s %(message)s", reset=True)
-        logger.info("second message")
+            logger = setup_logger(name="my-logger", format="=== %(name)s %(message)s")
+            logger.info("first message")
+            setup_logger(name="my-logger", format="+++ %(name)s %(message)s", reset=True)
+            logger.info("second message")
 
-        # Logs will look like
-        # === my-logger first message
-        # +++ my-logger second message
+            # Logs will look like
+            # === my-logger first message
+            # +++ my-logger second message
 
-    Example to change the level of an existing internal logger
+        Change the level of an existing internal logger
 
-    .. code-block:: python
+        .. code-block:: python
 
-        setup_logger(
-            name="ignite.distributed.launcher.Parallel",
-            level=logging.WARNING
-        )
+            setup_logger(
+                name="ignite.distributed.launcher.Parallel",
+                level=logging.WARNING
+            )
 
     .. versionchanged:: 0.4.3
         Added ``stream`` parameter.


### PR DESCRIPTION
Related to #2114 

Description:
part 4 of 7, reformat docstrings in the 'engine' folder, make sure all examples have "Examples:" header, move "Args:" block to the top of method documentation

Check list:

- [ ] New tests are added (if a new feature is added)
- [X] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
