### PR TITLE
Related to 2114: reformat docstrings in the 'handlers' folder

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -506,23 +506,23 @@ class Checkpoint(Serializable):
                 the user to load part of the pretrained model (useful for example, in Transfer Learning)
 
         Examples:
-        .. code-block:: python
+            .. code-block:: python
 
-            import torch
-            from ignite.engine import Engine, Events
-            from ignite.handlers import ModelCheckpoint, Checkpoint
-            trainer = Engine(lambda engine, batch: None)
-            handler = ModelCheckpoint('/tmp/models', 'myprefix', n_saved=None, create_dir=True)
-            model = torch.nn.Linear(3, 3)
-            optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
-            to_save = {"weights": model, "optimizer": optimizer}
-            trainer.add_event_handler(Events.EPOCH_COMPLETED(every=2), handler, to_save)
-            trainer.run(torch.randn(10, 1), 5)
+                import torch
+                from ignite.engine import Engine, Events
+                from ignite.handlers import ModelCheckpoint, Checkpoint
+                trainer = Engine(lambda engine, batch: None)
+                handler = ModelCheckpoint('/tmp/models', 'myprefix', n_saved=None, create_dir=True)
+                model = torch.nn.Linear(3, 3)
+                optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+                to_save = {"weights": model, "optimizer": optimizer}
+                trainer.add_event_handler(Events.EPOCH_COMPLETED(every=2), handler, to_save)
+                trainer.run(torch.randn(10, 1), 5)
 
-            to_load = to_save
-            checkpoint_fp = "/tmp/models/myprefix_checkpoint_40.pth"
-            checkpoint = torch.load(checkpoint_fp)
-            Checkpoint.load_objects(to_load=to_load, checkpoint=checkpoint)
+                to_load = to_save
+                checkpoint_fp = "/tmp/models/myprefix_checkpoint_40.pth"
+                checkpoint = torch.load(checkpoint_fp)
+                Checkpoint.load_objects(to_load=to_load, checkpoint=checkpoint)
 
         Note:
             If ``to_load`` contains objects of type torch `DistributedDataParallel`_ or

--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -22,19 +22,18 @@ class EarlyStopping(Serializable):
             it defines an increase after the last event. Default value is False.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.engine import Engine, Events
+            from ignite.handlers import EarlyStopping
 
-        from ignite.engine import Engine, Events
-        from ignite.handlers import EarlyStopping
+            def score_function(engine):
+                val_loss = engine.state.metrics['nll']
+                return -val_loss
 
-        def score_function(engine):
-            val_loss = engine.state.metrics['nll']
-            return -val_loss
-
-        handler = EarlyStopping(patience=10, score_function=score_function, trainer=trainer)
-        # Note: the handler is attached to an *Evaluator* (runs one epoch on validation dataset).
-        evaluator.add_event_handler(Events.COMPLETED, handler)
+            handler = EarlyStopping(patience=10, score_function=score_function, trainer=trainer)
+            # Note: the handler is attached to an *Evaluator* (runs one epoch on validation dataset).
+            evaluator.add_event_handler(Events.COMPLETED, handler)
 
     """
 

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -26,29 +26,28 @@ class FastaiLRFinder:
     rates and what can be an optimal learning rate.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers import FastaiLRFinder
 
-        from ignite.handlers import FastaiLRFinder
+            trainer = ...
+            model = ...
+            optimizer = ...
 
-        trainer = ...
-        model = ...
-        optimizer = ...
+            lr_finder = FastaiLRFinder()
+            to_save = {"model": model, "optimizer": optimizer}
 
-        lr_finder = FastaiLRFinder()
-        to_save = {"model": model, "optimizer": optimizer}
+            with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
+                trainer_with_lr_finder.run(dataloader)
 
-        with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
-            trainer_with_lr_finder.run(dataloader)
+            # Get lr_finder results
+            lr_finder.get_results()
 
-        # Get lr_finder results
-        lr_finder.get_results()
+            # Plot lr_finder results (requires matplotlib)
+            lr_finder.plot()
 
-        # Plot lr_finder results (requires matplotlib)
-        lr_finder.plot()
-
-        # get lr_finder suggestion for lr
-        lr_finder.lr_suggestion()
+            # get lr_finder suggestion for lr
+            lr_finder.lr_suggestion()
 
 
     Note:
@@ -339,12 +338,11 @@ class FastaiLRFinder:
         """
         Applying the suggested learning rate(s) on the given optimizer.
 
-        Note:
-            The given optimizer must be the same as the one we before found the suggested learning rate for.
-
         Args:
             optimizer: the optimizer to apply the suggested learning rate(s) on.
 
+        Note:
+            The given optimizer must be the same as the one we before found the suggested learning rate for.
         """
         sug_lr = self.lr_suggestion()
         if not isinstance(sug_lr, list):
@@ -377,14 +375,6 @@ class FastaiLRFinder:
     ) -> Any:
         """Attaches lr_finder to a given trainer. It also resets model and optimizer at the end of the run.
 
-        Usage:
-
-        .. code-block:: python
-
-            to_save = {"model": model, "optimizer": optimizer}
-            with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
-                trainer_with_lr_finder.run(dataloader)
-
         Args:
             trainer: lr_finder is attached to this trainer. Please, keep in mind that all attached handlers
                 will be executed.
@@ -406,6 +396,13 @@ class FastaiLRFinder:
 
         Returns:
             trainer_with_lr_finder (trainer used for finding the lr)
+
+        Examples:
+            .. code-block:: python
+
+                to_save = {"model": model, "optimizer": optimizer}
+                with lr_finder.attach(trainer, to_save=to_save) as trainer_with_lr_finder:
+                    trainer_with_lr_finder.run(dataloader)
 
         Note:
             lr_finder cannot be attached to more than one trainer at a time.

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -159,18 +159,16 @@ class ParamScheduler(metaclass=ABCMeta):
             event_index, value
 
         Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                lr_values = np.array(LinearCyclicalScheduler.simulate_values(num_events=50, param_name='lr',
+                                                                             start_value=1e-1, end_value=1e-3,
+                                                                             cycle_size=10))
 
-            lr_values = np.array(LinearCyclicalScheduler.simulate_values(num_events=50, param_name='lr',
-                                                                         start_value=1e-1, end_value=1e-3,
-                                                                         cycle_size=10))
-
-            plt.plot(lr_values[:, 0], lr_values[:, 1], label="learning rate")
-            plt.xlabel("events")
-            plt.ylabel("values")
-            plt.legend()
-
+                plt.plot(lr_values[:, 0], lr_values[:, 1], label="learning rate")
+                plt.xlabel("events")
+                plt.ylabel("values")
+                plt.legend()
         """
         keys_to_remove = ["optimizer", "save_history"]
         for key in keys_to_remove:
@@ -201,7 +199,6 @@ class ParamScheduler(metaclass=ABCMeta):
             matplotlib.lines.Line2D
 
         Examples:
-
             .. code-block:: python
 
                 import matplotlib.pylab as plt
@@ -328,17 +325,15 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         usually be the number of batches in an epoch.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import LinearCyclicalScheduler
 
-        from ignite.handlers.param_scheduler import LinearCyclicalScheduler
-
-        scheduler = LinearCyclicalScheduler(optimizer, 'lr', 1e-3, 1e-1, len(train_loader))
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
-        #
-        # Linearly increases the learning rate from 1e-3 to 1e-1 and back to 1e-3
-        # over the course of 1 epoch
-        #
+            scheduler = LinearCyclicalScheduler(optimizer, 'lr', 1e-3, 1e-1, len(train_loader))
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+            #
+            # Linearly increases the learning rate from 1e-3 to 1e-1 and back to 1e-3
+            # over the course of 1 epoch
 
     .. versionadded:: 0.4.5
     """
@@ -376,34 +371,33 @@ class CosineAnnealingScheduler(CyclicalScheduler):
         usually be the number of batches in an epoch.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import CosineAnnealingScheduler
 
-        from ignite.handlers.param_scheduler import CosineAnnealingScheduler
+            scheduler = CosineAnnealingScheduler(optimizer, 'lr', 1e-1, 1e-3, len(train_loader))
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+            #
+            # Anneals the learning rate from 1e-1 to 1e-3 over the course of 1 epoch.
+            #
 
-        scheduler = CosineAnnealingScheduler(optimizer, 'lr', 1e-1, 1e-3, len(train_loader))
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
-        #
-        # Anneals the learning rate from 1e-1 to 1e-3 over the course of 1 epoch.
-        #
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import CosineAnnealingScheduler
+            from ignite.handlers.param_scheduler import LinearCyclicalScheduler
 
-        from ignite.handlers.param_scheduler import CosineAnnealingScheduler
-        from ignite.handlers.param_scheduler import LinearCyclicalScheduler
+            optimizer = SGD(
+                [
+                    {"params": model.base.parameters(), 'lr': 0.001},
+                    {"params": model.fc.parameters(), 'lr': 0.01},
+                ]
+            )
 
-        optimizer = SGD(
-            [
-                {"params": model.base.parameters(), 'lr': 0.001},
-                {"params": model.fc.parameters(), 'lr': 0.01},
-            ]
-        )
+            scheduler1 = LinearCyclicalScheduler(optimizer, 'lr', 1e-7, 1e-5, len(train_loader), param_group_index=0)
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler1, "lr (base)")
 
-        scheduler1 = LinearCyclicalScheduler(optimizer, 'lr', 1e-7, 1e-5, len(train_loader), param_group_index=0)
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler1, "lr (base)")
-
-        scheduler2 = CosineAnnealingScheduler(optimizer, 'lr', 1e-5, 1e-3, len(train_loader), param_group_index=1)
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler2, "lr (fc)")
+            scheduler2 = CosineAnnealingScheduler(optimizer, 'lr', 1e-5, 1e-3, len(train_loader), param_group_index=1)
+            trainer.add_event_handler(Events.ITERATION_STARTED, scheduler2, "lr (fc)")
 
     .. [Smith17] Smith, Leslie N. "Cyclical learning rates for training neural networks."
                  Applications of Computer Vision (WACV), 2017 IEEE Winter Conference on. IEEE, 2017
@@ -431,23 +425,21 @@ class ConcatScheduler(ParamScheduler):
             `engine.state.param_history`, (default=False).
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers.param_scheduler import ConcatScheduler
+            from ignite.handlers.param_scheduler import LinearCyclicalScheduler
+            from ignite.handlers.param_scheduler import CosineAnnealingScheduler
 
-        from ignite.handlers.param_scheduler import ConcatScheduler
-        from ignite.handlers.param_scheduler import LinearCyclicalScheduler
-        from ignite.handlers.param_scheduler import CosineAnnealingScheduler
+            scheduler_1 = LinearCyclicalScheduler(optimizer, "lr", start_value=0.1, end_value=0.5, cycle_size=60)
+            scheduler_2 = CosineAnnealingScheduler(optimizer, "lr", start_value=0.5, end_value=0.01, cycle_size=60)
 
-        scheduler_1 = LinearCyclicalScheduler(optimizer, "lr", start_value=0.1, end_value=0.5, cycle_size=60)
-        scheduler_2 = CosineAnnealingScheduler(optimizer, "lr", start_value=0.5, end_value=0.01, cycle_size=60)
-
-        combined_scheduler = ConcatScheduler(schedulers=[scheduler_1, scheduler_2], durations=[30, ])
-        trainer.add_event_handler(Events.ITERATION_STARTED, combined_scheduler)
-        #
-        # Sets the Learning rate linearly from 0.1 to 0.5 over 30 iterations. Then
-        # starts an annealing schedule from 0.5 to 0.01 over 60 iterations.
-        # The annealing cycles are repeated indefinitely.
-        #
+            combined_scheduler = ConcatScheduler(schedulers=[scheduler_1, scheduler_2], durations=[30, ])
+            trainer.add_event_handler(Events.ITERATION_STARTED, combined_scheduler)
+            #
+            # Sets the Learning rate linearly from 0.1 to 0.5 over 30 iterations. Then
+            # starts an annealing schedule from 0.5 to 0.01 over 60 iterations.
+            # The annealing cycles are repeated indefinitely.
 
     .. versionadded:: 0.4.5
     """
@@ -789,7 +781,6 @@ def create_lr_scheduler_with_warmup(
         `lr_scheduler` provides its learning rate values as normally.
 
     Examples:
-
         .. code-block:: python
 
             torch_lr_scheduler = ExponentialLR(optimizer=optimizer, gamma=0.98)

--- a/ignite/handlers/stores.py
+++ b/ignite/handlers/stores.py
@@ -20,19 +20,20 @@ class EpochOutputStore:
         data: a list of :class:`~ignite.engine.engine.Engine` outputs,
             optionally transformed by `output_transform`.
 
-    Examples::
+    Examples:
+        .. code-block:: python
 
-        eos = EpochOutputStore()
-        trainer = create_supervised_trainer(model, optimizer, loss)
-        train_evaluator = create_supervised_evaluator(model, metrics)
-        eos.attach(train_evaluator, 'output')
+            eos = EpochOutputStore()
+            trainer = create_supervised_trainer(model, optimizer, loss)
+            train_evaluator = create_supervised_evaluator(model, metrics)
+            eos.attach(train_evaluator, 'output')
 
-        @trainer.on(Events.EPOCH_COMPLETED)
-        def log_training_results(engine):
-            train_evaluator.run(train_loader)
-            output = train_evaluator.state.output
-            # output = [(y_pred0, y0), (y_pred1, y1), ...]
-            # do something with output, e.g., plotting
+            @trainer.on(Events.EPOCH_COMPLETED)
+            def log_training_results(engine):
+                train_evaluator.run(train_loader)
+                output = train_evaluator.state.output
+                # output = [(y_pred0, y0), (y_pred1, y1), ...]
+                # do something with output, e.g., plotting
 
     .. versionadded:: 0.4.5
     .. versionchanged:: 0.4.5

--- a/ignite/handlers/terminate_on_nan.py
+++ b/ignite/handlers/terminate_on_nan.py
@@ -25,10 +25,9 @@ class TerminateOnNan:
 
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
-
-        trainer.add_event_handler(Events.ITERATION_COMPLETED, TerminateOnNan())
+            trainer.add_event_handler(Events.ITERATION_COMPLETED, TerminateOnNan())
 
     """
 

--- a/ignite/handlers/time_limit.py
+++ b/ignite/handlers/time_limit.py
@@ -17,7 +17,6 @@ class TimeLimit:
         limit_sec: Maximum time before training terminates (in seconds). Defaults to 28800.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.engine import Events

--- a/ignite/handlers/time_profilers.py
+++ b/ignite/handlers/time_profilers.py
@@ -14,24 +14,23 @@ class BasicTimeProfiler:
     events, data loading and data processing times.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers import BasicTimeProfiler
 
-        from ignite.handlers import BasicTimeProfiler
+            trainer = Engine(train_updater)
 
-        trainer = Engine(train_updater)
+            # Create an object of the profiler and attach an engine to it
+            profiler = BasicTimeProfiler()
+            profiler.attach(trainer)
 
-        # Create an object of the profiler and attach an engine to it
-        profiler = BasicTimeProfiler()
-        profiler.attach(trainer)
+            @trainer.on(Events.EPOCH_COMPLETED)
+            def log_intermediate_results():
+                profiler.print_results(profiler.get_results())
 
-        @trainer.on(Events.EPOCH_COMPLETED)
-        def log_intermediate_results():
-            profiler.print_results(profiler.get_results())
+            trainer.run(dataloader, max_epochs=3)
 
-        trainer.run(dataloader, max_epochs=3)
-
-        profiler.write_results('path_to_dir/time_profiling.csv')
+            profiler.write_results('path_to_dir/time_profiling.csv')
 
     .. versionadded:: 0.4.6
     """
@@ -281,14 +280,13 @@ class BasicTimeProfiler:
 
             profiler.write_results('path_to_dir/awesome_filename.csv')
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
-
-            -----------------------------------------------------------------
-            epoch iteration processing_stats dataflow_stats Event_STARTED ...
-            1.0     1.0        0.00003         0.252387        0.125676
-            1.0     2.0        0.00029         0.252342        0.125123
+                -----------------------------------------------------------------
+                epoch iteration processing_stats dataflow_stats Event_STARTED ...
+                1.0     1.0        0.00003         0.252387        0.125676
+                1.0     2.0        0.00029         0.252342        0.125123
 
         """
         try:
@@ -362,41 +360,40 @@ class BasicTimeProfiler:
 
             profiler.print_results(results)
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
+                 ----------------------------------------------------
+                | Time profiling stats (in seconds):                 |
+                 ----------------------------------------------------
+                total  |  min/index  |  max/index  |  mean  |  std
 
-             ----------------------------------------------------
-            | Time profiling stats (in seconds):                 |
-             ----------------------------------------------------
-            total  |  min/index  |  max/index  |  mean  |  std
+                Processing function:
+                157.46292 | 0.01452/1501 | 0.26905/0 | 0.07730 | 0.01258
 
-            Processing function:
-            157.46292 | 0.01452/1501 | 0.26905/0 | 0.07730 | 0.01258
+                Dataflow:
+                6.11384 | 0.00008/1935 | 0.28461/1551 | 0.00300 | 0.02693
 
-            Dataflow:
-            6.11384 | 0.00008/1935 | 0.28461/1551 | 0.00300 | 0.02693
+                Event handlers:
+                2.82721
 
-            Event handlers:
-            2.82721
+                - Events.STARTED: []
+                0.00000
 
-            - Events.STARTED: []
-            0.00000
+                - Events.EPOCH_STARTED: []
+                0.00006 | 0.00000/0 | 0.00000/17 | 0.00000 | 0.00000
 
-            - Events.EPOCH_STARTED: []
-            0.00006 | 0.00000/0 | 0.00000/17 | 0.00000 | 0.00000
+                - Events.ITERATION_STARTED: ['PiecewiseLinear']
+                0.03482 | 0.00001/188 | 0.00018/679 | 0.00002 | 0.00001
 
-            - Events.ITERATION_STARTED: ['PiecewiseLinear']
-            0.03482 | 0.00001/188 | 0.00018/679 | 0.00002 | 0.00001
+                - Events.ITERATION_COMPLETED: ['TerminateOnNan']
+                0.20037 | 0.00006/866 | 0.00089/1943 | 0.00010 | 0.00003
 
-            - Events.ITERATION_COMPLETED: ['TerminateOnNan']
-            0.20037 | 0.00006/866 | 0.00089/1943 | 0.00010 | 0.00003
+                - Events.EPOCH_COMPLETED: ['empty_cuda_cache', 'training.<locals>.log_elapsed_time', ]
+                2.57860 | 0.11529/0 | 0.14977/13 | 0.12893 | 0.00790
 
-            - Events.EPOCH_COMPLETED: ['empty_cuda_cache', 'training.<locals>.log_elapsed_time', ]
-            2.57860 | 0.11529/0 | 0.14977/13 | 0.12893 | 0.00790
-
-            - Events.COMPLETED: []
-            not yet triggered
+                - Events.COMPLETED: []
+                not yet triggered
 
         """
 
@@ -465,24 +462,23 @@ class HandlersTimeProfiler:
     profiled by this profiler
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.handlers import HandlersTimeProfiler
 
-        from ignite.handlers import HandlersTimeProfiler
+            trainer = Engine(train_updater)
 
-        trainer = Engine(train_updater)
+            # Create an object of the profiler and attach an engine to it
+            profiler = HandlersTimeProfiler()
+            profiler.attach(trainer)
 
-        # Create an object of the profiler and attach an engine to it
-        profiler = HandlersTimeProfiler()
-        profiler.attach(trainer)
+            @trainer.on(Events.EPOCH_COMPLETED)
+            def log_intermediate_results():
+                profiler.print_results(profiler.get_results())
 
-        @trainer.on(Events.EPOCH_COMPLETED)
-        def log_intermediate_results():
-            profiler.print_results(profiler.get_results())
+            trainer.run(dataloader, max_epochs=3)
 
-        trainer.run(dataloader, max_epochs=3)
-
-        profiler.write_results('path_to_dir/time_profiling.csv')
+            profiler.write_results('path_to_dir/time_profiling.csv')
 
     .. versionadded:: 0.4.6
     """
@@ -652,14 +648,13 @@ class HandlersTimeProfiler:
 
             profiler.write_results('path_to_dir/awesome_filename.csv')
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
-
-            -----------------------------------------------------------------
-            # processing_stats dataflow_stats training.<locals>.log_elapsed_time (EPOCH_COMPLETED) ...
-            1     0.00003         0.252387                          0.125676
-            2     0.00029         0.252342                          0.125123
+                -----------------------------------------------------------------
+                # processing_stats dataflow_stats training.<locals>.log_elapsed_time (EPOCH_COMPLETED) ...
+                1     0.00003         0.252387                          0.125676
+                2     0.00029         0.252342                          0.125123
 
         """
         try:
@@ -703,26 +698,25 @@ class HandlersTimeProfiler:
 
             profiler.print_results(results)
 
-        Example output:
+        Examples:
+            .. code-block:: text
 
-        .. code-block:: text
-
-            -----------------------------------------  -----------------------  -------------- ...
-            Handler                                    Event Name                     Total(s)
-            -----------------------------------------  -----------------------  --------------
-            run.<locals>.log_training_results          EPOCH_COMPLETED                19.43245
-            run.<locals>.log_validation_results        EPOCH_COMPLETED                 2.55271
-            run.<locals>.log_time                      EPOCH_COMPLETED                 0.00049
-            run.<locals>.log_intermediate_results      EPOCH_COMPLETED                 0.00106
-            run.<locals>.log_training_loss             ITERATION_COMPLETED               0.059
-            run.<locals>.log_time                      COMPLETED                 not triggered
-            -----------------------------------------  -----------------------  --------------
-            Total                                                                     22.04571
-            -----------------------------------------  -----------------------  --------------
-            Processing took total 11.29543s [min/index: 0.00393s/1875, max/index: 0.00784s/0,
-             mean: 0.00602s, std: 0.00034s]
-            Dataflow took total 16.24365s [min/index: 0.00533s/1874, max/index: 0.01129s/937,
-             mean: 0.00866s, std: 0.00113s]
+                -----------------------------------------  -----------------------  -------------- ...
+                Handler                                    Event Name                     Total(s)
+                -----------------------------------------  -----------------------  --------------
+                run.<locals>.log_training_results          EPOCH_COMPLETED                19.43245
+                run.<locals>.log_validation_results        EPOCH_COMPLETED                 2.55271
+                run.<locals>.log_time                      EPOCH_COMPLETED                 0.00049
+                run.<locals>.log_intermediate_results      EPOCH_COMPLETED                 0.00106
+                run.<locals>.log_training_loss             ITERATION_COMPLETED               0.059
+                run.<locals>.log_time                      COMPLETED                 not triggered
+                -----------------------------------------  -----------------------  --------------
+                Total                                                                     22.04571
+                -----------------------------------------  -----------------------  --------------
+                Processing took total 11.29543s [min/index: 0.00393s/1875, max/index: 0.00784s/0,
+                 mean: 0.00602s, std: 0.00034s]
+                Dataflow took total 16.24365s [min/index: 0.00533s/1874, max/index: 0.01129s/937,
+                 mean: 0.00866s, std: 0.00113s]
 
         """
         # adopted implementation of torch.autograd.profiler.build_table

--- a/ignite/handlers/timing.py
+++ b/ignite/handlers/timing.py
@@ -24,56 +24,63 @@ class Timer:
         the examples below.
 
     Examples:
-
         Measuring total time of the epoch:
 
-        >>> from ignite.handlers import Timer
-        >>> import time
-        >>> work = lambda : time.sleep(0.1)
-        >>> idle = lambda : time.sleep(0.1)
-        >>> t = Timer(average=False)
-        >>> for _ in range(10):
-        ...    work()
-        ...    idle()
-        ...
-        >>> t.value()
-        2.003073937026784
+        .. code-block:: python
+
+            from ignite.handlers import Timer
+            import time
+            work = lambda : time.sleep(0.1)
+            idle = lambda : time.sleep(0.1)
+            t = Timer(average=False)
+            for _ in range(10):
+                work()
+                idle()
+
+            t.value()
+            # 2.003073937026784
 
         Measuring average time of the epoch:
 
-        >>> t = Timer(average=True)
-        >>> for _ in range(10):
-        ...    work()
-        ...    idle()
-        ...    t.step()
-        ...
-        >>> t.value()
-        0.2003182829997968
+        .. code-block:: python
+
+            t = Timer(average=True)
+            for _ in range(10):
+                work()
+                idle()
+                t.step()
+
+            t.value()
+            # 0.2003182829997968
 
         Measuring average time it takes to execute a single ``work()`` call:
 
-        >>> t = Timer(average=True)
-        >>> for _ in range(10):
-        ...    t.resume()
-        ...    work()
-        ...    t.pause()
-        ...    idle()
-        ...    t.step()
-        ...
-        >>> t.value()
-        0.10016545779653825
+        .. code-block:: python
+
+            t = Timer(average=True)
+            for _ in range(10):
+                t.resume()
+                work()
+                t.pause()
+                idle()
+                t.step()
+
+            t.value()
+            # 0.10016545779653825
 
         Using the Timer to measure average time it takes to process a single batch of examples:
 
-        >>> from ignite.engine import Engine, Events
-        >>> from ignite.handlers import Timer
-        >>> trainer = Engine(training_update_function)
-        >>> timer = Timer(average=True)
-        >>> timer.attach(trainer,
-        ...              start=Events.STARTED,
-        ...              resume=Events.ITERATION_STARTED,
-        ...              pause=Events.ITERATION_COMPLETED,
-        ...              step=Events.ITERATION_COMPLETED)
+        .. code-block:: python
+
+            from ignite.engine import Engine, Events
+            from ignite.handlers import Timer
+            trainer = Engine(training_update_function)
+            timer = Timer(average=True)
+            timer.attach(trainer,
+                         start=Events.STARTED,
+                         resume=Events.ITERATION_STARTED,
+                         pause=Events.ITERATION_COMPLETED,
+                         step=Events.ITERATION_COMPLETED)
     """
 
     def __init__(self, average: bool = False):


### PR DESCRIPTION
Related to #2114

Description:
part 5 of 7, reformat docstrings in the 'handlers' folder, make sure all examples have "Examples:" header, move "Args:" block to the top of method documentation
Check list:

- [ ] New tests are added (if a new feature is added)
- [X] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
