### PR TITLE
Related to #2114: reformat docstrings in the 'metrics' folder

### DIFF
--- a/ignite/metrics/accumulation.py
+++ b/ignite/metrics/accumulation.py
@@ -99,18 +99,6 @@ class Average(VariableAccumulation):
         For input `x` being an ND `torch.Tensor` with N > 1, the first dimension is seen as the number of samples and
         is summed up and added to the accumulator: `accumulator += x.sum(dim=0)`
 
-    Examples:
-
-    .. code-block:: python
-
-        evaluator = ...
-
-        custom_var_mean = Average(output_transform=lambda output: output['custom_var'])
-        custom_var_mean.attach(evaluator, 'mean_custom_var')
-
-        state = evaluator.run(dataset)
-        # state.metrics['mean_custom_var'] -> average of output['custom_var']
-
     Args:
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
@@ -119,6 +107,17 @@ class Average(VariableAccumulation):
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
+
+    Examples:
+        .. code-block:: python
+
+            evaluator = ...
+
+            custom_var_mean = Average(output_transform=lambda output: output['custom_var'])
+            custom_var_mean.attach(evaluator, 'mean_custom_var')
+
+            state = evaluator.run(dataset)
+            # state.metrics['mean_custom_var'] -> average of output['custom_var']
     """
 
     def __init__(
@@ -147,6 +146,15 @@ class GeometricAverage(VariableAccumulation):
     - ``update`` must receive output of the form `x`.
     - `x` can be a positive number or a positive `torch.Tensor`, such that ``torch.log(x)`` is not `nan`.
 
+    Args:
+        output_transform: a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        device: specifies which device updates are accumulated on. Setting the metric's
+            device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
+            default, CPU.
+
     Note:
 
         Number of samples is updated following the rule:
@@ -157,15 +165,6 @@ class GeometricAverage(VariableAccumulation):
 
         For input `x` being an ND `torch.Tensor` with N > 1, the first dimension is seen as the number of samples and
         is aggregated and added to the accumulator: `accumulator *= prod(x, dim=0)`
-
-    Args:
-        output_transform: a callable that is used to transform the
-            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
-            form expected by the metric. This can be useful if, for example, you have a multi-output model and
-            you want to compute the metric with respect to one of the outputs.
-        device: specifies which device updates are accumulated on. Setting the metric's
-            device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
-            default, CPU.
 
     """
 

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -105,18 +105,7 @@ class Accuracy(_BaseClassification):
     - `y` and `y_pred` must be in the following shape of (batch_size, num_categories, ...) and
       num_categories must be greater than 1 for multilabel cases.
 
-    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
-    predictions can be done as below:
-
-    .. code-block:: python
-
-        def thresholded_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.round(y_pred)
-            return y_pred, y
-
-        binary_accuracy = Accuracy(thresholded_output_transform)
-
+    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values.
 
     Args:
         output_transform: a callable that is used to transform the
@@ -128,6 +117,17 @@ class Accuracy(_BaseClassification):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
+    Examples:
+        Thresholding of predictions can be done as below:
+
+        .. code-block:: python
+
+            def thresholded_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.round(y_pred)
+                return y_pred, y
+
+            binary_accuracy = Accuracy(thresholded_output_transform)
     """
 
     def __init__(

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -105,7 +105,17 @@ class Accuracy(_BaseClassification):
     - `y` and `y_pred` must be in the following shape of (batch_size, num_categories, ...) and
       num_categories must be greater than 1 for multilabel cases.
 
-    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values.
+    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
+    predictions can be done as below:
+
+    .. code-block:: python
+
+        def thresholded_output_transform(output):
+            y_pred, y = output
+            y_pred = torch.round(y_pred)
+            return y_pred, y
+
+        binary_accuracy = Accuracy(thresholded_output_transform)
 
     Args:
         output_transform: a callable that is used to transform the
@@ -116,18 +126,6 @@ class Accuracy(_BaseClassification):
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
-
-    Examples:
-        Thresholding of predictions can be done as below:
-
-        .. code-block:: python
-
-            def thresholded_output_transform(output):
-                y_pred, y = output
-                y_pred = torch.round(y_pred)
-                return y_pred, y
-
-            binary_accuracy = Accuracy(thresholded_output_transform)
     """
 
     def __init__(

--- a/ignite/metrics/classification_report.py
+++ b/ignite/metrics/classification_report.py
@@ -36,36 +36,36 @@ def ClassificationReport(
         device: optional device specification for internal storage.
         labels: Optional list of label indices to include in the report
 
-    .. code-block:: python
+    Examples:
+        .. code-block:: python
 
+            def process_function(engine, batch):
+                # ...
+                return y_pred, y
 
-        def process_function(engine, batch):
-            # ...
-            return y_pred, y
-
-        engine = Engine(process_function)
-        metric = ClassificationReport()
-        metric.attach(engine, "cr")
-        engine.run...
-        res = engine.state.metrics["cr"]
-        # result should be like
-        {
-          "0": {
-            "precision": 0.4891304347826087,
-            "recall": 0.5056179775280899,
-            "f1-score": 0.497237569060773
-          },
-          "1": {
-            "precision": 0.5157232704402516,
-            "recall": 0.4992389649923896,
-            "f1-score": 0.507347254447022
-          },
-          "macro avg": {
-            "precision": 0.5024268526114302,
-            "recall": 0.5024284712602398,
-            "f1-score": 0.5022924117538975
-          }
-        }
+            engine = Engine(process_function)
+            metric = ClassificationReport()
+            metric.attach(engine, "cr")
+            engine.run...
+            res = engine.state.metrics["cr"]
+            # result should be like
+            {
+              "0": {
+                "precision": 0.4891304347826087,
+                "recall": 0.5056179775280899,
+                "f1-score": 0.497237569060773
+              },
+              "1": {
+                "precision": 0.5157232704402516,
+                "recall": 0.4992389649923896,
+                "f1-score": 0.507347254447022
+              },
+              "macro avg": {
+                "precision": 0.5024268526114302,
+                "recall": 0.5024284712602398,
+                "f1-score": 0.5022924117538975
+              }
+            }
     """
 
     # setup all the underlying metrics

--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -36,10 +36,16 @@ class ConfusionMatrix(Metric):
             default, CPU.
 
     Note:
+        The confusion matrix is formatted such that columns are predictions and rows are targets.
+        For example, if you were to plot the matrix, you could correctly assign to the horizontal axis
+        the label "predicted values" and to the vertical axis the label "actual values".
+
+    Note:
         In case of the targets `y` in `(batch_size, ...)` format, target indices between 0 and `num_classes` only
         contribute to the confusion matrix and others are neglected. For example, if `num_classes=20` and target index
         equal 255 is encountered, then it is filtered out.
 
+    Examples:
         If you are doing binary classification with a single output unit, you may have to transform your network output,
         so that you have one value for each class. E.g. you can transform your network output into a one-hot vector
         with:
@@ -60,12 +66,6 @@ class ConfusionMatrix(Metric):
             evaluator = create_supervised_evaluator(
                 model, metrics=metrics, output_transform=lambda x, y, y_pred: (y_pred, y)
             )
-
-    Note:
-        The confusion matrix is formatted such that columns are predictions and rows are targets.
-        For example, if you were to plot the matrix, you could correctly assign to the horizontal axis
-        the label "predicted values" and to the vertical axis the label "actual values".
-
     """
 
     def __init__(
@@ -174,16 +174,15 @@ def IoU(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> MetricsLambd
         MetricsLambda
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            train_evaluator = ...
 
-        train_evaluator = ...
+            cm = ConfusionMatrix(num_classes=num_classes)
+            IoU(cm, ignore_index=0).attach(train_evaluator, 'IoU')
 
-        cm = ConfusionMatrix(num_classes=num_classes)
-        IoU(cm, ignore_index=0).attach(train_evaluator, 'IoU')
-
-        state = train_evaluator.run(train_dataset)
-        # state.metrics['IoU'] -> tensor of shape (num_classes - 1, )
+            state = train_evaluator.run(train_dataset)
+            # state.metrics['IoU'] -> tensor of shape (num_classes - 1, )
 
     """
     if not isinstance(cm, ConfusionMatrix):
@@ -225,18 +224,15 @@ def mIoU(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> MetricsLamb
         MetricsLambda
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            train_evaluator = ...
 
-        train_evaluator = ...
+            cm = ConfusionMatrix(num_classes=num_classes)
+            mIoU(cm, ignore_index=0).attach(train_evaluator, 'mean IoU')
 
-        cm = ConfusionMatrix(num_classes=num_classes)
-        mIoU(cm, ignore_index=0).attach(train_evaluator, 'mean IoU')
-
-        state = train_evaluator.run(train_dataset)
-        # state.metrics['mean IoU'] -> scalar
-
-
+            state = train_evaluator.run(train_dataset)
+            # state.metrics['mean IoU'] -> scalar
     """
     iou = IoU(cm=cm, ignore_index=ignore_index).mean()  # type: MetricsLambda
     return iou
@@ -345,16 +341,14 @@ def JaccardIndex(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> Met
         MetricsLambda
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            train_evaluator = ...
 
-        train_evaluator = ...
+            cm = ConfusionMatrix(num_classes=num_classes)
+            JaccardIndex(cm, ignore_index=0).attach(train_evaluator, 'JaccardIndex')
 
-        cm = ConfusionMatrix(num_classes=num_classes)
-        JaccardIndex(cm, ignore_index=0).attach(train_evaluator, 'JaccardIndex')
-
-        state = train_evaluator.run(train_dataset)
-        # state.metrics['JaccardIndex'] -> tensor of shape (num_classes - 1, )
-
+            state = train_evaluator.run(train_dataset)
+            # state.metrics['JaccardIndex'] -> tensor of shape (num_classes - 1, )
     """
     return IoU(cm, ignore_index)

--- a/ignite/metrics/frequency.py
+++ b/ignite/metrics/frequency.py
@@ -12,7 +12,6 @@ class Frequency(Metric):
     """Provides metrics for the number of examples processed per second.
 
     Examples:
-
         .. code-block:: python
 
             # Compute number of tokens processed

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -94,8 +94,7 @@ class FID(_BaseInceptionMetric):
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
 
-    Example:
-
+    Examples:
         .. code-block:: python
 
             import torch

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -25,9 +25,6 @@ class InceptionScore(_BaseInceptionMetric):
 
     __ https://arxiv.org/pdf/1801.01973.pdf
 
-    .. note::
-        The default Inception model requires the `torchvision` module to be installed.
-
     Args:
         num_features: number of features predicted by the model or number of classes of the model. Default
             value is 1000.
@@ -47,8 +44,10 @@ class InceptionScore(_BaseInceptionMetric):
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
 
-    Example:
+    .. note::
+        The default Inception model requires the `torchvision` module to be installed.
 
+    Examples:
         .. code-block:: python
 
             from ignite.metric.gan import InceptionScore

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -34,10 +34,9 @@ class Loss(Metric):
         required_output_keys: dictionary defines required keys to be found in ``engine.state.output`` if the
             latter is a dictionary. Default, ``("y_pred", "y", "criterion_kwargs")``. This is useful when the
             criterion function requires additional arguments, which can be passed using ``criterion_kwargs``.
-            See notes below for an example.
+            See an example below.
 
-    Note:
-
+    Examples:
         Let's implement a Loss metric that requires ``x``, ``y_pred``, ``y`` and ``criterion_kwargs`` as input
         for ``criterion`` function. In the example below we show how to setup standard metric like Accuracy
         and the Loss metric using an ``evaluator`` created with

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -143,10 +143,9 @@ class Metric(metaclass=ABCMeta):
     Attributes:
         required_output_keys: dictionary defines required keys to be found in ``engine.state.output`` if the
             latter is a dictionary. Default, ``("y_pred", "y")``. This is useful with custom metrics that can require
-            other arguments than predictions ``y_pred`` and targets ``y``. See notes below for an example.
+            other arguments than predictions ``y_pred`` and targets ``y``. See an example below.
 
-    Note:
-
+    Examples:
         Let's implement a custom metric that requires ``y_pred``, ``y`` and ``x`` as input for ``update`` function.
         In the example below we show how to setup standard metric like Accuracy and the custom metric using by an
         ``evaluator`` created with :meth:`~ignite.engine.create_supervised_evaluator` method.
@@ -280,14 +279,14 @@ class Metric(metaclass=ABCMeta):
         """Helper method to update metric's computation. It is automatically attached to the
         `engine` with :meth:`~ignite.metrics.metric.Metric.attach`.
 
+        Args:
+            engine: the engine to which the metric must be attached
+
         Note:
             ``engine.state.output`` is used to compute metric values.
             The majority of implemented metrics accepts the following formats for ``engine.state.output``:
             ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``. ``y_pred`` and ``y`` can be torch tensors or
             list of tensors/numbers if applicable.
-
-        Args:
-            engine: the engine to which the metric must be attached
 
         .. versionchanged:: 0.4.5
             ``y_pred`` and ``y`` can be torch tensors or list of tensors/numbers
@@ -378,27 +377,26 @@ class Metric(metaclass=ABCMeta):
                 :attr:`ignite.metrics.metric.EpochWise.usage_name` (default) or
                 :attr:`ignite.metrics.metric.BatchWise.usage_name`.
 
-        Example:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                metric.attach(engine, "mymetric")
 
-            metric = ...
-            metric.attach(engine, "mymetric")
+                assert "mymetric" in engine.run(data).metrics
 
-            assert "mymetric" in engine.run(data).metrics
+                assert metric.is_attached(engine)
 
-            assert metric.is_attached(engine)
+            Example with usage:
 
-        Example with usage:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                metric.attach(engine, "mymetric", usage=BatchWise.usage_name)
 
-            metric = ...
-            metric.attach(engine, "mymetric", usage=BatchWise.usage_name)
+                assert "mymetric" in engine.run(data).metrics
 
-            assert "mymetric" in engine.run(data).metrics
-
-            assert metric.is_attached(engine, usage=BatchWise.usage_name)
+                assert metric.is_attached(engine, usage=BatchWise.usage_name)
         """
         usage = self._check_usage(usage)
         if not engine.has_event_handler(self.started, usage.STARTED):
@@ -419,29 +417,28 @@ class Metric(metaclass=ABCMeta):
             usage: the usage of the metric. Valid string values should be
                 'epoch_wise' (default) or 'batch_wise'.
 
-        Example:
+        Examples:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                engine = ...
+                metric.detach(engine)
 
-            metric = ...
-            engine = ...
-            metric.detach(engine)
+                assert "mymetric" not in engine.run(data).metrics
 
-            assert "mymetric" not in engine.run(data).metrics
+                assert not metric.is_attached(engine)
 
-            assert not metric.is_attached(engine)
+            Example with usage:
 
-        Example with usage:
+            .. code-block:: python
 
-        .. code-block:: python
+                metric = ...
+                engine = ...
+                metric.detach(engine, usage="batch_wise")
 
-            metric = ...
-            engine = ...
-            metric.detach(engine, usage="batch_wise")
+                assert "mymetric" not in engine.run(data).metrics
 
-            assert "mymetric" not in engine.run(data).metrics
-
-            assert not metric.is_attached(engine, usage="batch_wise")
+                assert not metric.is_attached(engine, usage="batch_wise")
         """
         usage = self._check_usage(usage)
         if engine.has_event_handler(self.completed, usage.COMPLETED):

--- a/ignite/metrics/metrics_lambda.py
+++ b/ignite/metrics/metrics_lambda.py
@@ -27,43 +27,41 @@ class MetricsLambda(Metric):
         kwargs: Sequence of other metrics or something
             else that will be fed to ``f`` as keyword arguments.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            precision = Precision(average=False)
+            recall = Recall(average=False)
 
-        precision = Precision(average=False)
-        recall = Recall(average=False)
+            def Fbeta(r, p, beta):
+                return torch.mean((1 + beta ** 2) * p * r / (beta ** 2 * p + r + 1e-20)).item()
 
-        def Fbeta(r, p, beta):
-            return torch.mean((1 + beta ** 2) * p * r / (beta ** 2 * p + r + 1e-20)).item()
+            F1 = MetricsLambda(Fbeta, recall, precision, 1)
+            F2 = MetricsLambda(Fbeta, recall, precision, 2)
+            F3 = MetricsLambda(Fbeta, recall, precision, 3)
+            F4 = MetricsLambda(Fbeta, recall, precision, 4)
 
-        F1 = MetricsLambda(Fbeta, recall, precision, 1)
-        F2 = MetricsLambda(Fbeta, recall, precision, 2)
-        F3 = MetricsLambda(Fbeta, recall, precision, 3)
-        F4 = MetricsLambda(Fbeta, recall, precision, 4)
+        When check if the metric is attached, if one of its dependency
+        metrics is detached, the metric is considered detached too.
 
-    When check if the metric is attached, if one of its dependency
-    metrics is detached, the metric is considered detached too.
+        .. code-block:: python
 
-    .. code-block:: python
+            engine = ...
+            precision = Precision(average=False)
 
-        engine = ...
-        precision = Precision(average=False)
+            aP = precision.mean()
 
-        aP = precision.mean()
+            aP.attach(engine, "aP")
 
-        aP.attach(engine, "aP")
+            assert aP.is_attached(engine)
+            # partially attached
+            assert not precision.is_attached(engine)
 
-        assert aP.is_attached(engine)
-        # partially attached
-        assert not precision.is_attached(engine)
+            precision.detach(engine)
 
-        precision.detach(engine)
-
-        assert not aP.is_attached(engine)
-        # fully attached
-        assert not precision.is_attached(engine)
-
+            assert not aP.is_attached(engine)
+            # fully attached
+            assert not precision.is_attached(engine)
     """
 
     def __init__(self, f: Callable, *args: Any, **kwargs: Any) -> None:

--- a/ignite/metrics/nlp/bleu.py
+++ b/ignite/metrics/nlp/bleu.py
@@ -102,20 +102,19 @@ class Bleu(Metric):
             for more details refer https://www.nltk.org/_modules/nltk/translate/bleu_score.html
             Default: "macro"
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics.nlp import Bleu
 
-        from ignite.metrics.nlp import Bleu
+            m = Bleu(ngram=4, smooth="smooth1")
 
-        m = Bleu(ngram=4, smooth="smooth1")
+            y_pred = "the the the the the the the"
+            y = ["the cat is on the mat", "there is a cat on the mat"]
 
-        y_pred = "the the the the the the the"
-        y = ["the cat is on the mat", "there is a cat on the mat"]
+            m.update(([y_pred.split()], [[_y.split() for _y in y]]))
 
-        m.update(([y_pred.split()], [[_y.split() for _y in y]]))
-
-        print(m.compute())
+            print(m.compute())
 
     .. versionadded:: 0.4.5
     .. versionchanged:: 0.5.0

--- a/ignite/metrics/nlp/rouge.py
+++ b/ignite/metrics/nlp/rouge.py
@@ -352,7 +352,8 @@ class Rouge(Metric):
             m.update((candidate, references))
 
             m.compute()
-            # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
+            # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4,
+            # 'Rouge-2-F': 0.4}
 
     .. versionadded:: 0.4.5
     """

--- a/ignite/metrics/nlp/rouge.py
+++ b/ignite/metrics/nlp/rouge.py
@@ -209,24 +209,23 @@ class RougeN(_BaseRouge):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics import RougeN
 
-        from ignite.metrics import RougeN
+            m = RougeN(ngram=2, multiref="best")
 
-        m = RougeN(ngram=2, multiref="best")
+            candidate = "the cat is not there".split()
+            references = [
+                "the cat is on the mat".split(),
+                "there is a cat on the mat".split()
+            ]
 
-        candidate = "the cat is not there".split()
-        references = [
-            "the cat is on the mat".split(),
-            "there is a cat on the mat".split()
-        ]
+            m.update((candidate, references))
 
-        m.update((candidate, references))
-
-        m.compute()
-        >>> {'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
+            m.compute()
+            # {'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
 
     .. versionadded:: 0.4.5
     """
@@ -276,24 +275,23 @@ class RougeL(_BaseRouge):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics import RougeL
 
-        from ignite.metrics import RougeL
+            m = RougeL(multiref="best")
 
-        m = RougeL(multiref="best")
+            candidate = "the cat is not there".split()
+            references = [
+               "the cat is on the mat".split(),
+                "there is a cat on the mat".split()
+            ]
 
-        candidate = "the cat is not there".split()
-        references = [
-           "the cat is on the mat".split(),
-            "there is a cat on the mat".split()
-        ]
+            m.update((candidate, references))
 
-        m.update((candidate, references))
-
-       m.compute()
-       >>> {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5}
+           m.compute()
+           # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5}
 
     .. versionadded:: 0.4.5
     """
@@ -338,24 +336,23 @@ class Rouge(Metric):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            from ignite.metrics import Rouge
 
-        from ignite.metrics import Rouge
+            m = Rouge(variants=["L", 2], multiref="best")
 
-        m = Rouge(variants=["L", 2], multiref="best")
+            candidate = "the cat is not there".split()
+            references = [
+                "the cat is on the mat".split(),
+                "there is a cat on the mat".split()
+            ]
 
-        candidate = "the cat is not there".split()
-        references = [
-            "the cat is on the mat".split(),
-            "there is a cat on the mat".split()
-        ]
+            m.update((candidate, references))
 
-        m.update((candidate, references))
-
-        m.compute()
-        >>> {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
+            m.compute()
+            # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
 
     .. versionadded:: 0.4.5
     """

--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -73,35 +73,6 @@ class Precision(_BasePrecisionRecall):
     - `y_pred` must be in the following shape (batch_size, num_categories, ...) or (batch_size, ...).
     - `y` must be in the following shape (batch_size, ...).
 
-    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
-    predictions can be done as below:
-
-    .. code-block:: python
-
-        def thresholded_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.round(y_pred)
-            return y_pred, y
-
-        precision = Precision(output_transform=thresholded_output_transform)
-
-    In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
-    example, average parameter should be False. This can be done as shown below:
-
-    .. code-block:: python
-
-        precision = Precision(average=False)
-        recall = Recall(average=False)
-        F1 = precision * recall * 2 / (precision + recall + 1e-20)
-        F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
-
-    .. warning::
-
-        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
-        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
-        than available RAM.
-
-
     Args:
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
@@ -114,6 +85,36 @@ class Precision(_BasePrecisionRecall):
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
+
+    Examples:
+        In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
+        predictions can be done as below:
+
+        .. code-block:: python
+
+            def thresholded_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.round(y_pred)
+                return y_pred, y
+
+            precision = Precision(output_transform=thresholded_output_transform)
+
+        In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
+        example, average parameter should be False. This can be done as shown below:
+
+        .. code-block:: python
+
+            precision = Precision(average=False)
+            recall = Recall(average=False)
+            F1 = precision * recall * 2 / (precision + recall + 1e-20)
+            F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
+
+    .. warning::
+
+        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
+        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
+        than available RAM.
+
 
     """
 

--- a/ignite/metrics/psnr.py
+++ b/ignite/metrics/psnr.py
@@ -29,40 +29,39 @@ class PSNR(Metric):
             Setting the metric’s device to be the same as your update arguments ensures
             the update method is non-blocking. By default, CPU.
 
-    Example:
+    Examples:
+        To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
+        The output of the engine's ``process_function`` needs to be in format of
+        ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
 
-    To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
-    The output of the engine's ``process_function`` needs to be in format of
-    ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
+        .. code-block:: python
 
-    .. code-block:: python
-
-        def process_function(engine, batch):
+            def process_function(engine, batch):
+                # ...
+                return y_pred, y
+            engine = Engine(process_function)
+            psnr = PSNR(data_range=1.0)
+            psnr.attach(engine, "psnr")
             # ...
-            return y_pred, y
-        engine = Engine(process_function)
-        psnr = PSNR(data_range=1.0)
-        psnr.attach(engine, "psnr")
-        # ...
-        state = engine.run(data)
-        print(f"PSNR: {state.metrics['psnr']}")
+            state = engine.run(data)
+            print(f"PSNR: {state.metrics['psnr']}")
 
-    This metric by default accepts Grayscale or RGB images. But if you have YCbCr or YUV images, only
-    Y channel is needed for computing PSNR. And, this can be done with ``output_transform``. For instance,
+        This metric by default accepts Grayscale or RGB images. But if you have YCbCr or YUV images, only
+        Y channel is needed for computing PSNR. And, this can be done with ``output_transform``. For instance,
 
-    .. code-block:: python
+        .. code-block:: python
 
-        def get_y_channel(output):
-            y_pred, y = output
-            # y_pred and y are (B, 3, H, W) and YCbCr or YUV images
-            # let's select y channel
-            return y_pred[:, 0, ...], y[:, 0, ...]
+            def get_y_channel(output):
+                y_pred, y = output
+                # y_pred and y are (B, 3, H, W) and YCbCr or YUV images
+                # let's select y channel
+                return y_pred[:, 0, ...], y[:, 0, ...]
 
-        psnr = PSNR(data_range=219, output_transform=get_y_channel)
-        psnr.attach(engine, "psnr")
-        # ...
-        state = engine.run(data)
-        print(f"PSNR: {state.metrics['psrn']}")
+            psnr = PSNR(data_range=219, output_transform=get_y_channel)
+            psnr.attach(engine, "psnr")
+            # ...
+            state = engine.run(data)
+            print(f"PSNR: {state.metrics['psrn']}")
 
     .. versionadded:: 0.4.3
     """

--- a/ignite/metrics/recall.py
+++ b/ignite/metrics/recall.py
@@ -20,35 +20,6 @@ class Recall(_BasePrecisionRecall):
     - `y_pred` must be in the following shape (batch_size, num_categories, ...) or (batch_size, ...).
     - `y` must be in the following shape (batch_size, ...).
 
-    In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
-    predictions can be done as below:
-
-    .. code-block:: python
-
-        def thresholded_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.round(y_pred)
-            return y_pred, y
-
-        recall = Recall(output_transform=thresholded_output_transform)
-
-    In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
-    example, average parameter should be False. This can be done as shown below:
-
-    .. code-block:: python
-
-        precision = Precision(average=False)
-        recall = Recall(average=False)
-        F1 = precision * recall * 2 / (precision + recall + 1e-20)
-        F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
-
-    .. warning::
-
-        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
-        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
-        than available RAM.
-
-
     Args:
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
@@ -62,6 +33,34 @@ class Recall(_BasePrecisionRecall):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
+    Examples:
+        In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
+        predictions can be done as below:
+
+        .. code-block:: python
+
+            def thresholded_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.round(y_pred)
+                return y_pred, y
+
+            recall = Recall(output_transform=thresholded_output_transform)
+
+        In multilabel cases, average parameter should be True. However, if user would like to compute F1 metric, for
+        example, average parameter should be False. This can be done as shown below:
+
+        .. code-block:: python
+
+            precision = Precision(average=False)
+            recall = Recall(average=False)
+            F1 = precision * recall * 2 / (precision + recall + 1e-20)
+            F1 = MetricsLambda(lambda t: torch.mean(t).item(), F1)
+
+    .. warning::
+
+        In multilabel cases, if average is False, current implementation stores all input data (output and target) in
+        as tensors before computing a metric. This can potentially lead to a memory error if the input data is larger
+        than available RAM.
     """
 
     def __init__(

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -25,22 +25,20 @@ class RunningAverage(Metric):
             use the ``src``'s device. Otherwise, defaults to CPU. Only applicable when the computed value
             from the metric is a tensor.
 
-
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
+            alpha = 0.98
+            acc_metric = RunningAverage(Accuracy(output_transform=lambda x: [x[1], x[2]]), alpha=alpha)
+            acc_metric.attach(trainer, 'running_avg_accuracy')
 
-        alpha = 0.98
-        acc_metric = RunningAverage(Accuracy(output_transform=lambda x: [x[1], x[2]]), alpha=alpha)
-        acc_metric.attach(trainer, 'running_avg_accuracy')
+            avg_output = RunningAverage(output_transform=lambda x: x[0], alpha=alpha)
+            avg_output.attach(trainer, 'running_avg_loss')
 
-        avg_output = RunningAverage(output_transform=lambda x: x[0], alpha=alpha)
-        avg_output.attach(trainer, 'running_avg_loss')
-
-        @trainer.on(Events.ITERATION_COMPLETED)
-        def log_running_avg_metrics(engine):
-            print("running avg accuracy:", engine.state.metrics['running_avg_accuracy'])
-            print("running avg loss:", engine.state.metrics['running_avg_loss'])
+            @trainer.on(Events.ITERATION_COMPLETED)
+            def log_running_avg_metrics(engine):
+                print("running avg accuracy:", engine.state.metrics['running_avg_accuracy'])
+                print("running avg loss:", engine.state.metrics['running_avg_loss'])
 
     """
 

--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -28,23 +28,22 @@ class SSIM(Metric):
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
 
-    Example:
+    Examples:
+        To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
+        The output of the engine's ``process_function`` needs to be in the format of
+        ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
 
-    To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
-    The output of the engine's ``process_function`` needs to be in the format of
-    ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``.
+        ``y_pred`` and ``y`` can be un-normalized or normalized image tensors. Depending on that, the user might need
+        to adjust ``data_range``. ``y_pred`` and ``y`` should have the same shape.
 
-    ``y_pred`` and ``y`` can be un-normalized or normalized image tensors. Depending on that, the user might need
-    to adjust ``data_range``. ``y_pred`` and ``y`` should have the same shape.
+        .. code-block:: python
 
-    .. code-block:: python
-
-        def process_function(engine, batch):
-            # ...
-            return y_pred, y
-        engine = Engine(process_function)
-        metric = SSIM(data_range=1.0)
-        metric.attach(engine, "ssim")
+            def process_function(engine, batch):
+                # ...
+                return y_pred, y
+            engine = Engine(process_function)
+            metric = SSIM(data_range=1.0)
+            metric.attach(engine, "ssim")
 
     .. versionadded:: 0.4.2
     """


### PR DESCRIPTION
Related to #2114

Description:
part 6 of 7, reformat docstrings in the 'metrics' folder, make sure all examples have "Examples:" header, move "Args:" block to the top of method documentation

Check list:

- [ ] New tests are added (if a new feature is added)
- [X] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
