### PR TITLE
fix #2114: reformat docstrings in the 'contrib' folder

### DIFF
--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -49,15 +49,10 @@ class ClearMLLogger(BaseLogger):
         clearml-init
 
     Args:
-        project_name: The name of the project in which the experiment will be created. If the project
-            does not exist, it is created. If ``project_name`` is ``None``, the repository name is used. (Optional)
-        task_name: The name of Task (experiment). If ``task_name`` is ``None``, the Python experiment
-            script's file name is used. (Optional)
-        task_type: Optional. The task type. Valid values are:
-            - ``TaskTypes.training`` (Default)
-            - ``TaskTypes.train``
-            - ``TaskTypes.testing``
-            - ``TaskTypes.inference``
+        kwargs: Keyword arguments accepted from
+            `clearml.Task
+            <https://clear.ml/docs/latest/docs/references/sdk/task#taskinit>`_.
+            All arguments are optional.
 
     Examples:
         .. code-block:: python
@@ -118,7 +113,7 @@ class ClearMLLogger(BaseLogger):
 
     """
 
-    def __init__(self, *_: Any, **kwargs: Any):
+    def __init__(self, **kwargs: Any):
         try:
             from clearml import Task
             from clearml.binding.frameworks.tensorflow_bind import WeightsGradientHistHelper

--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -60,7 +60,6 @@ class ClearMLLogger(BaseLogger):
             - ``TaskTypes.inference``
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -202,8 +201,22 @@ class ClearMLLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.clearml_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -284,23 +297,7 @@ class OutputHandler(BaseOutputHandler):
                 event_name=Events.ITERATION_COMPLETED
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.clearml_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-        Example of `global_step_transform`:
+        Example of `global_step_transform`
 
         .. code-block:: python
 
@@ -350,8 +347,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -375,12 +377,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):
@@ -407,8 +403,12 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -426,12 +426,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -460,8 +454,11 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
 class WeightsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's weights as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, 'generator'
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -479,11 +476,6 @@ class WeightsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, 'generator'
-
     """
 
     def __init__(self, model: Module, tag: Optional[str] = None):
@@ -514,8 +506,12 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -533,12 +529,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -566,8 +556,11 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
 class GradsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's gradients as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, 'generator'
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *
@@ -585,11 +578,6 @@ class GradsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, 'generator'
-
     """
 
     def __init__(self, model: Module, tag: Optional[str] = None):
@@ -629,7 +617,6 @@ class ClearMLSaver(DiskSaver):
             directory will be created.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.clearml_logger import *

--- a/ignite/contrib/handlers/mlflow_logger.py
+++ b/ignite/contrib/handlers/mlflow_logger.py
@@ -26,7 +26,6 @@ class MLflowLogger(BaseLogger):
         tracking_uri: MLflow tracking uri. See MLflow docs for more details
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.mlflow_logger import *
@@ -122,8 +121,22 @@ class MLflowLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics.
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, 'training'
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{'loss': loss1, 'another_loss': loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.mlflow_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.mlflow_logger import *
@@ -193,24 +206,6 @@ class OutputHandler(BaseOutputHandler):
                 state_attributes=["alpha", "beta"],
             )
 
-
-    Args:
-        tag: common title for all produced plots. For example, 'training'
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{'loss': loss1, 'another_loss': loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.mlflow_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -271,8 +266,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, 'generator'
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.mlflow_logger import *
@@ -294,12 +294,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, 'generator'
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):

--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -63,7 +63,6 @@ class NeptuneLogger(BaseLogger):
            Tags are displayed in the experiment’s Details and can be viewed in experiments view as a column.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -214,8 +213,22 @@ class NeptuneLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.neptune_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -301,23 +314,6 @@ class OutputHandler(BaseOutputHandler):
                 state_attributes=["alpha", "beta"],
             )
 
-
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.neptune_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -363,8 +359,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -392,12 +393,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):
@@ -423,8 +418,12 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -446,12 +445,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -479,8 +472,12 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *
@@ -502,12 +499,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -537,7 +528,6 @@ class NeptuneSaver(BaseSaveHandler):
             NeptuneLogger class.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.neptune_logger import *

--- a/ignite/contrib/handlers/polyaxon_logger.py
+++ b/ignite/contrib/handlers/polyaxon_logger.py
@@ -25,9 +25,13 @@ class PolyaxonLogger(BaseLogger):
 
         pip install polyaxon-client
 
+    Args:
+        args: Positional arguments accepted from
+            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
+        kwargs: Keyword arguments accepted from
+            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.polyaxon_logger import *
@@ -86,13 +90,6 @@ class PolyaxonLogger(BaseLogger):
             )
             # to manually end a run
             plx_logger.close()
-
-    Args:
-        args: Positional arguments accepted from
-            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
-        kwargs: Keyword arguments accepted from
-            `Experiment <https://polyaxon.com/docs/experimentation/tracking/client/>`_.
-
     """
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -132,8 +129,22 @@ class PolyaxonLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics.
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.polyaxon_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.polyaxon_logger import *
@@ -203,23 +214,6 @@ class OutputHandler(BaseOutputHandler):
                 state_attributes=["alpha", "beta"],
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.polyaxon_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -266,8 +260,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.polyaxon_logger import *
@@ -287,12 +286,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):

--- a/ignite/contrib/handlers/tensorboard_logger.py
+++ b/ignite/contrib/handlers/tensorboard_logger.py
@@ -52,7 +52,6 @@ class TensorboardLogger(BaseLogger):
             For example, `log_dir` to setup path to the directory where to log.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -176,8 +175,22 @@ class TensorboardLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output, engine's state attributes and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.tensorboard_logger.global_step_from_engine`.
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -249,23 +262,6 @@ class OutputHandler(BaseOutputHandler):
                 event_name=Events.ITERATION_COMPLETED
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.tensorboard_logger.global_step_from_engine`.
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -310,8 +306,13 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -331,12 +332,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
     """
 
     def __init__(self, optimizer: Optimizer, param_name: str = "lr", tag: Optional[str] = None):
@@ -362,8 +357,12 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -377,12 +376,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -408,8 +401,11 @@ class WeightsScalarHandler(BaseWeightsScalarHandler):
 class WeightsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's weights as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -423,11 +419,6 @@ class WeightsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, tag: Optional[str] = None):
@@ -454,8 +445,12 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -469,12 +464,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, reduction: Callable = torch.norm, tag: Optional[str] = None):
@@ -499,8 +488,11 @@ class GradsScalarHandler(BaseWeightsScalarHandler):
 class GradsHistHandler(BaseWeightsHistHandler):
     """Helper handler to log model's gradients as histograms.
 
-    Examples:
+    Args:
+        model: model to log weights
+        tag: common title for all produced plots. For example, "generator"
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.tensorboard_logger import *
@@ -514,11 +506,6 @@ class GradsHistHandler(BaseWeightsHistHandler):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsHistHandler(model)
             )
-
-    Args:
-        model: model to log weights
-        tag: common title for all produced plots. For example, "generator"
-
     """
 
     def __init__(self, model: nn.Module, tag: Optional[str] = None):

--- a/ignite/contrib/handlers/tqdm_logger.py
+++ b/ignite/contrib/handlers/tqdm_logger.py
@@ -27,7 +27,6 @@ class ProgressBar(BaseLogger):
             "Predictions [5/10]" if number of epochs is more than one otherwise it is simply "Predictions".
 
     Examples:
-
         Simple progress bar
 
         .. code-block:: python

--- a/ignite/contrib/handlers/visdom_logger.py
+++ b/ignite/contrib/handlers/visdom_logger.py
@@ -56,7 +56,6 @@ class VisdomLogger(BaseLogger):
         log less frequently or set `num_workers=1`.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -254,8 +253,23 @@ class _BaseVisDrawer:
 class OutputHandler(BaseOutputHandler, _BaseVisDrawer):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.visdom_logger.global_step_from_engine`.
+        show_legend: flag to show legend in the window
+        state_attributes: list of attributes of the ``trainer.state`` to plot.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -327,31 +341,12 @@ class OutputHandler(BaseOutputHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_COMPLETED
             )
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.visdom_logger.global_step_from_engine`.
-        show_legend: flag to show legend in the window
-        state_attributes: list of attributes of the ``trainer.state`` to plot.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
 
             def global_step_transform(engine, event_name):
                 return engine.state.get_event_attrib_value(event_name)
-
     """
 
     def __init__(
@@ -392,8 +387,14 @@ class OutputHandler(BaseOutputHandler, _BaseVisDrawer):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler, _BaseVisDrawer):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
+        show_legend: flag to show legend in the window
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -413,13 +414,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
-        show_legend: flag to show legend in the window
     """
 
     def __init__(
@@ -450,8 +444,13 @@ class WeightsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
     Handler iterates over named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
+        show_legend: flag to show legend in the window
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -465,12 +464,6 @@ class WeightsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=WeightsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-        show_legend: flag to show legend in the window
     """
 
     def __init__(
@@ -500,8 +493,13 @@ class GradsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
     Handler iterates over the gradients of named parameters of the model, applies reduction function to each parameter
     produce a scalar and then logs the scalar.
 
-    Examples:
+    Args:
+        model: model to log weights
+        reduction: function to reduce parameters into scalar
+        tag: common title for all produced plots. For example, "generator"
+        show_legend: flag to show legend in the window
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.visdom_logger import *
@@ -515,13 +513,6 @@ class GradsScalarHandler(BaseWeightsScalarHandler, _BaseVisDrawer):
                 event_name=Events.ITERATION_COMPLETED,
                 log_handler=GradsScalarHandler(model, reduction=torch.norm)
             )
-
-    Args:
-        model: model to log weights
-        reduction: function to reduce parameters into scalar
-        tag: common title for all produced plots. For example, "generator"
-        show_legend: flag to show legend in the window
-
     """
 
     def __init__(

--- a/ignite/contrib/handlers/wandb_logger.py
+++ b/ignite/contrib/handlers/wandb_logger.py
@@ -27,7 +27,6 @@ class WandBLogger(BaseLogger):
             Please see `wandb.init <https://docs.wandb.ai/library/init>`_ for documentation of possible parameters.
 
     Examples:
-
         .. code-block:: python
 
             from ignite.contrib.handlers.wandb_logger import *
@@ -151,8 +150,23 @@ class WandBLogger(BaseLogger):
 class OutputHandler(BaseOutputHandler):
     """Helper handler to log engine's output and/or metrics
 
-    Examples:
+    Args:
+        tag: common title for all produced plots. For example, "training"
+        metric_names: list of metric names to plot or a string "all" to plot all available
+            metrics.
+        output_transform: output transform function to prepare `engine.state.output` as a number.
+            For example, `output_transform = lambda output: output`
+            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
+            with corresponding keys.
+        global_step_transform: global step transform function to output a desired global step.
+            Input of the function is `(engine, event_name)`. Output of function should be an integer.
+            Default is None, global_step based on attached engine. If provided,
+            uses function output as global_step. To setup global step from another engine, please use
+            :meth:`~ignite.contrib.handlers.wandb_logger.global_step_from_engine`.
+        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
+            the default value of wandb.log.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.wandb_logger import *
@@ -240,24 +254,6 @@ class OutputHandler(BaseOutputHandler):
             )
 
 
-    Args:
-        tag: common title for all produced plots. For example, "training"
-        metric_names: list of metric names to plot or a string "all" to plot all available
-            metrics.
-        output_transform: output transform function to prepare `engine.state.output` as a number.
-            For example, `output_transform = lambda output: output`
-            This function can also return a dictionary, e.g `{"loss": loss1, "another_loss": loss2}` to label the plot
-            with corresponding keys.
-        global_step_transform: global step transform function to output a desired global step.
-            Input of the function is `(engine, event_name)`. Output of function should be an integer.
-            Default is None, global_step based on attached engine. If provided,
-            uses function output as global_step. To setup global step from another engine, please use
-            :meth:`~ignite.contrib.handlers.wandb_logger.global_step_from_engine`.
-        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
-            the default value of wandb.log.
-
-    Note:
-
         Example of `global_step_transform`:
 
         .. code-block:: python
@@ -300,8 +296,15 @@ class OutputHandler(BaseOutputHandler):
 class OptimizerParamsHandler(BaseOptimizerParamsHandler):
     """Helper handler to log optimizer parameters
 
-    Examples:
+    Args:
+        optimizer: torch optimizer or any object with attribute ``param_groups``
+            as a sequence.
+        param_name: parameter name
+        tag: common title for all produced plots. For example, "generator"
+        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
+            the default value of wandb.log.
 
+    Examples:
         .. code-block:: python
 
             from ignite.contrib.handlers.wandb_logger import *
@@ -329,14 +332,6 @@ class OptimizerParamsHandler(BaseOptimizerParamsHandler):
                 event_name=Events.ITERATION_STARTED,
                 optimizer=optimizer
             )
-
-    Args:
-        optimizer: torch optimizer or any object with attribute ``param_groups``
-            as a sequence.
-        param_name: parameter name
-        tag: common title for all produced plots. For example, "generator"
-        sync: If set to False, process calls to log in a seperate thread. Default (None) uses whatever
-            the default value of wandb.log.
     """
 
     def __init__(

--- a/ignite/contrib/metrics/average_precision.py
+++ b/ignite/contrib/metrics/average_precision.py
@@ -29,17 +29,18 @@ class AveragePrecision(EpochMetric):
             no issues. User will be warned in case there are any issues computing the function.
         device: optional device specification for internal storage.
 
-    AveragePrecision expects y to be comprised of 0's and 1's. y_pred must either be probability estimates or
-    confidence values. To apply an activation to y_pred, use output_transform as shown below:
+    Examples:
+        AveragePrecision expects y to be comprised of 0's and 1's. y_pred must either be probability estimates or
+        confidence values. To apply an activation to y_pred, use output_transform as shown below:
 
-    .. code-block:: python
+        .. code-block:: python
 
-        def activated_output_transform(output):
-            y_pred, y = output
-            y_pred = torch.softmax(y_pred, dim=1)
-            return y_pred, y
+            def activated_output_transform(output):
+                y_pred, y = output
+                y_pred = torch.softmax(y_pred, dim=1)
+                return y_pred, y
 
-        avg_precision = AveragePrecision(activated_output_transform)
+            avg_precision = AveragePrecision(activated_output_transform)
 
     """
 

--- a/ignite/contrib/metrics/gpu_info.py
+++ b/ignite/contrib/metrics/gpu_info.py
@@ -17,7 +17,6 @@ class GpuInfo(Metric):
         In case if gpu utilization reports "N/A" on a given GPU, corresponding metric value is not set.
 
     Examples:
-
         .. code-block:: python
 
             # Default GPU measurements


### PR DESCRIPTION
Fixes #2114

Description:
part 7 of 7, reformat docstrings in the 'contrib' folder, make sure all examples have "Examples:" header, move "Args:" block to the top of method documentation

Check list:

- [ ] New tests are added (if a new feature is added)
- [X] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
