### PR TITLE
Relates to #2114. bugfix for docstring examples with huge bottom padding

### DIFF
--- a/docs/source/_templates/_static/css/ignite_theme.css
+++ b/docs/source/_templates/_static/css/ignite_theme.css
@@ -216,7 +216,7 @@ article.pytorch-article p.rubric {
   margin: 15px 0 10px 0;
 }
 
-.highlight {
+.highlight pre {
   border: 1px solid rgba(0,0,0,0.15);
   border-radius: 4px;
 }


### PR DESCRIPTION
Relates to #2114

Description:
docstrings examples CSS styles should be applied to the `<pre>` tag rather than .highlight, otherwise another `<pre>` style is added and a big bottom padding becomes highlighted too.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
