### PR TITLE
Related to #2207: Friendly Errors (#2207)

### DIFF
--- a/examples/contrib/cifar10/main.py
+++ b/examples/contrib/cifar10/main.py
@@ -187,6 +187,11 @@ def run(
         **spawn_kwargs: Other kwargs to spawn run in child processes: master_addr, master_port, node_rank, nnodes
 
     """
+    # check to see if the num_epochs is greater than num_warmup_epochs issue user friendly Error
+    if num_warmup_epochs>num_epochs:
+        raise ValueError(f"""The minimum number of warmup epochs is {num_warmup_epochs}, either increase the num_epochs 
+        or decrease the num_warmup_epochs""")
+
     # catch all local parameters
     config = locals()
     config.update(config["spawn_kwargs"])

--- a/examples/contrib/cifar10_qat/main.py
+++ b/examples/contrib/cifar10_qat/main.py
@@ -174,6 +174,11 @@ def run(
         **spawn_kwargs: Other kwargs to spawn run in child processes: master_addr, master_port, node_rank, nnodes
 
     """
+    # check to see if the num_epochs is greater than num_warmup_epochs issue user friendly Error
+    if num_warmup_epochs>num_epochs:
+        raise ValueError(f"""The minimum number of warmup epochs is {num_warmup_epochs}, either increase the num_epochs 
+        or decrease the num_warmup_epochs""")
+
     # catch all local parameters
     config = locals()
     config.update(config["spawn_kwargs"])

--- a/examples/contrib/transformers/main.py
+++ b/examples/contrib/transformers/main.py
@@ -192,6 +192,11 @@ def run(
         with_amp (bool): if True, enables native automatic mixed precision. Default, False.
         **spawn_kwargs: Other kwargs to spawn run in child processes: master_addr, master_port, node_rank, nnodes
     """
+    # check to see if the num_epochs is greater than num_warmup_epochs issue user friendly Error
+    if num_warmup_epochs>num_epochs:
+        raise ValueError(f"""The minimum number of warmup epochs is {num_warmup_epochs}, either increase the num_epochs 
+        or decrease the num_warmup_epochs""")
+
     # catch all local parameters
     config = locals()
     config.update(config["spawn_kwargs"])


### PR DESCRIPTION
Fixes #2207

Description:  
- Edited to raise friendly errors if ``num_epochs`` is less than ``num_warmup_epochs``
- Edited main.py in directories ``cifar10``, ``cifar10_qat`` and ``transformers``.
