### PR TITLE
[Capturing CI warnings] Imported `time_profilers` from core handlers in tests

### DIFF
--- a/tests/ignite/handlers/test_time_profilers.py
+++ b/tests/ignite/handlers/test_time_profilers.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 import pytest
 from pytest import approx
 
-from ignite.contrib.handlers.time_profilers import BasicTimeProfiler, HandlersTimeProfiler
 from ignite.engine import Engine, EventEnum, Events
+from ignite.handlers.time_profilers import BasicTimeProfiler, HandlersTimeProfiler
 
 if sys.platform.startswith("darwin"):
     pytest.skip("Skip if on MacOS", allow_module_level=True)


### PR DESCRIPTION
Captured deprecation warning in `time_profilers`.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
