### PR TITLE
Skipping visdom tests on macosx

### DIFF
--- a/tests/ignite/contrib/handlers/test_visdom_logger.py
+++ b/tests/ignite/contrib/handlers/test_visdom_logger.py
@@ -977,7 +977,9 @@ def test_integration_with_executor(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or sys.platform.startswith("darwin"), reason="Skip on Windows and Macosx"
+)
 def test_integration_with_executor_as_context_manager(visdom_server, visdom_server_stop):
 
     n_epochs = 5

--- a/tests/ignite/contrib/handlers/test_visdom_logger.py
+++ b/tests/ignite/contrib/handlers/test_visdom_logger.py
@@ -870,8 +870,9 @@ def test_integration_no_server():
         VisdomLogger()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
-                    reason="Skip on Windows and Macosx")
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or sys.platform.startswith("darwin"), reason="Skip on Windows and Macosx"
+)
 def test_logger_init_hostname_port(visdom_server):
     # Explicit hostname, port
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=0)
@@ -879,8 +880,9 @@ def test_logger_init_hostname_port(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
-                    reason="Skip on Windows and Macosx")
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or sys.platform.startswith("darwin"), reason="Skip on Windows and Macosx"
+)
 def test_logger_init_env_vars(visdom_server):
     # As env vars
     import os
@@ -898,8 +900,9 @@ def _parse_content(content):
     return json.loads(content)
 
 
-@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
-                    reason="Skip on Windows and Macosx")
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or sys.platform.startswith("darwin"), reason="Skip on Windows and Macosx"
+)
 def test_integration_no_executor(visdom_server):
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=0)
 
@@ -935,8 +938,9 @@ def test_integration_no_executor(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
-                    reason="Skip on Windows and Macosx")
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or sys.platform.startswith("darwin"), reason="Skip on Windows and Macosx"
+)
 def test_integration_with_executor(visdom_server):
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=1)
 

--- a/tests/ignite/contrib/handlers/test_visdom_logger.py
+++ b/tests/ignite/contrib/handlers/test_visdom_logger.py
@@ -870,7 +870,8 @@ def test_integration_no_server():
         VisdomLogger()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
+@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
+                    reason="Skip on Windows and Macosx")
 def test_logger_init_hostname_port(visdom_server):
     # Explicit hostname, port
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=0)
@@ -878,7 +879,8 @@ def test_logger_init_hostname_port(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
+@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
+                    reason="Skip on Windows and Macosx")
 def test_logger_init_env_vars(visdom_server):
     # As env vars
     import os
@@ -896,7 +898,8 @@ def _parse_content(content):
     return json.loads(content)
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
+@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
+                    reason="Skip on Windows and Macosx")
 def test_integration_no_executor(visdom_server):
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=0)
 
@@ -932,7 +935,8 @@ def test_integration_no_executor(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
+@pytest.mark.skipif(sys.platform.startswith("win") or sys.platform.startswith("darwin"),
+                    reason="Skip on Windows and Macosx")
 def test_integration_with_executor(visdom_server):
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=1)
 


### PR DESCRIPTION
Fixes #2229

Edited the ``test_visdom_logger.py`` file to skip tests on Macosx.
 - Edited the Functions  - ``test_logger_init_hostname_port``, ``test_logger_init_env_vars``, ``test_integration_no_executor``, ``test_integration_with_executor``.