### PR TITLE
Fixes `_compute_nproc_per_node` in case of bad dist configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ run_pytorch_container: &run_pytorch_container
         docker run --gpus=all --rm -itd --shm-size 16G -v ${wd}:/ignite -w /ignite --name pthd << pipeline.parameters.pytorch_stable_image >>
         docker exec -it pthd nvidia-smi
         docker exec -it pthd ls
-        docker exec -it pthd /bin/bash -c "$update_pth_cmd"
 
 run_pytorch_devel_container: &run_pytorch_devel_container
   - run:
@@ -97,7 +96,6 @@ run_pytorch_devel_container: &run_pytorch_devel_container
         docker run --gpus=all --rm -itd --shm-size 16G -v ${wd}:/ignite -w /ignite --name pthd << pipeline.parameters.pytorch_stable_image_devel >>
         docker exec -it pthd nvidia-smi
         docker exec -it pthd ls
-        docker exec -it pthd /bin/bash -c "$update_pth_cmd"
 
 install_dependencies: &install_dependencies
   - run:


### PR DESCRIPTION
Description:
- Now uses new gloo group to compute nproc per node
  - Context: using NCCL and if user badly setups cuda per proc, idist will hang on _compute_nproc_per_node
  - Here is an example: https://app.circleci.com/pipelines/github/pytorch/ignite/2264/workflows/2e3073fd-0859-41c7-91e8-eef0f8eabee2/jobs/7060?invite=true#step-107-872
  - However, I couldn't repro the issue on my setup

cc @sdesrozis 