### PR TITLE
Doctest for nlp metrics (`BLEU`, `Rouge`, `RougeN`, `RougeL`)

### DIFF
--- a/ignite/metrics/nlp/bleu.py
+++ b/ignite/metrics/nlp/bleu.py
@@ -103,7 +103,8 @@ class Bleu(Metric):
             Default: "macro"
 
     Examples:
-        .. code-block:: python
+
+        .. testcode::
 
             from ignite.metrics.nlp import Bleu
 
@@ -115,6 +116,10 @@ class Bleu(Metric):
             m.update(([y_pred.split()], [[_y.split() for _y in y]]))
 
             print(m.compute())
+
+        .. testoutput::
+
+            tensor(0.0393, dtype=torch.float64)
 
     .. versionadded:: 0.4.5
     .. versionchanged:: 0.5.0

--- a/ignite/metrics/nlp/rouge.py
+++ b/ignite/metrics/nlp/rouge.py
@@ -211,7 +211,8 @@ class RougeN(_BaseRouge):
             default, CPU.
 
     Examples:
-        .. code-block:: python
+
+        .. testcode::
 
             from ignite.metrics import RougeN
 
@@ -225,8 +226,11 @@ class RougeN(_BaseRouge):
 
             m.update(([candidate], [references]))
 
-            m.compute()
-            # {'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
+            print(m.compute())
+
+        .. testoutput::
+
+            {'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
 
     .. versionadded:: 0.4.5
     """
@@ -277,7 +281,8 @@ class RougeL(_BaseRouge):
             default, CPU.
 
     Examples:
-        .. code-block:: python
+
+        .. testcode::
 
             from ignite.metrics import RougeL
 
@@ -291,8 +296,11 @@ class RougeL(_BaseRouge):
 
             m.update(([candidate], [references]))
 
-           m.compute()
-           # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5}
+            print(m.compute())
+
+        .. testoutput::
+
+           {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5}
 
     .. versionadded:: 0.4.5
     """
@@ -338,7 +346,8 @@ class Rouge(Metric):
             default, CPU.
 
     Examples:
-        .. code-block:: python
+
+        .. testcode::
 
             from ignite.metrics import Rouge
 
@@ -352,9 +361,11 @@ class Rouge(Metric):
 
             m.update(([candidate], [references]))
 
-            m.compute()
-            # {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4,
-            # 'Rouge-2-F': 0.4}
+            print(m.compute())
+
+        .. testoutput::
+
+            {'Rouge-L-P': 0.6, 'Rouge-L-R': 0.5, 'Rouge-L-F': 0.5, 'Rouge-2-P': 0.5, 'Rouge-2-R': 0.4, 'Rouge-2-F': 0.4}
 
     .. versionadded:: 0.4.5
     .. versionchanged:: 0.5.0


### PR DESCRIPTION
Addresses #2265

Description: Added doctests for `BLEU`, `Rouge`, `RougeN`, `RougeL`

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
