### PR TITLE
[skipci] [Doctest] added contrib regression (``FractionalBias``, ``FractionalAbsoluteError``, ``CanberraMetric``, ``GeometricMeanAbsoluteError``)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -339,6 +339,7 @@ from ignite.engine import *
 from ignite.handlers import *
 from ignite.metrics import *
 from ignite.utils import *
+from ignite.contrib.metrics.regression import *
 
 manual_seed(666)
 

--- a/ignite/contrib/metrics/regression/canberra_metric.py
+++ b/ignite/contrib/metrics/regression/canberra_metric.py
@@ -36,23 +36,19 @@ class CanberraMetric(_BaseRegression):
 
     .. _`Botchkarev 2018`:
         https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf
-    
+
     .. testcode::
 
-            def process_function(engine, batch):
-                y_pred, y = batch
-                return y_pred, y
-            engine = Engine(process_function)
             metric = CanberraMetric()
-            metric.attach(engine, 'canberra')
-            preds = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
-            target = preds * 1.5
-            state = engine.run([[preds, target]])
+            metric.attach(default_evaluator, 'canberra')
+            y_pred = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
+            y_true = y_pred * 1.5
+            state = default_evaluator.run([[y_pred, y_true]])
             print(state.metrics['canberra'])
-            
+
     .. testoutput::
 
-            0.8000
+            0.8000...
     .. versionchanged:: 0.4.3
 
         - Fixed implementation: ``abs`` in denominator.

--- a/ignite/contrib/metrics/regression/canberra_metric.py
+++ b/ignite/contrib/metrics/regression/canberra_metric.py
@@ -36,7 +36,23 @@ class CanberraMetric(_BaseRegression):
 
     .. _`Botchkarev 2018`:
         https://arxiv.org/ftp/arxiv/papers/1809/1809.03006.pdf
+    
+    .. testcode::
 
+            def process_function(engine, batch):
+                y_pred, y = batch
+                return y_pred, y
+            engine = Engine(process_function)
+            metric = CanberraMetric()
+            metric.attach(engine, 'canberra')
+            preds = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
+            target = preds * 1.5
+            state = engine.run([[preds, target]])
+            print(state.metrics['canberra'])
+            
+    .. testoutput::
+
+            0.8000
     .. versionchanged:: 0.4.3
 
         - Fixed implementation: ``abs`` in denominator.

--- a/ignite/contrib/metrics/regression/fractional_absolute_error.py
+++ b/ignite/contrib/metrics/regression/fractional_absolute_error.py
@@ -33,23 +33,19 @@ class FractionalAbsoluteError(_BaseRegression):
         device: specifies which device updates are accumulated on. Setting the
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
-    
+
     .. testcode::
 
-            def process_function(engine, batch):
-                y_pred, y = batch
-                return y_pred, y
-            engine = Engine(process_function)
             metric = FractionalAbsoluteError()
-            metric.attach(engine, 'fractional_abs_error')
-            preds = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
-            target = preds * 0.8
-            state = engine.run([[preds, target]])
+            metric.attach(default_evaluator, 'fractional_abs_error')
+            y_pred = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
+            y_true = y_pred * 0.8
+            state = default_evaluator.run([[y_pred, y_true]])
             print(state.metrics['fractional_abs_error'])
-            
+
     .. testoutput::
 
-            0.2222
+            0.2222...
     .. versionchanged:: 0.4.5
         - Works with DDP.
     """

--- a/ignite/contrib/metrics/regression/fractional_absolute_error.py
+++ b/ignite/contrib/metrics/regression/fractional_absolute_error.py
@@ -33,7 +33,23 @@ class FractionalAbsoluteError(_BaseRegression):
         device: specifies which device updates are accumulated on. Setting the
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
+    
+    .. testcode::
 
+            def process_function(engine, batch):
+                y_pred, y = batch
+                return y_pred, y
+            engine = Engine(process_function)
+            metric = FractionalAbsoluteError()
+            metric.attach(engine, 'fractional_abs_error')
+            preds = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
+            target = preds * 0.8
+            state = engine.run([[preds, target]])
+            print(state.metrics['fractional_abs_error'])
+            
+    .. testoutput::
+
+            0.2222
     .. versionchanged:: 0.4.5
         - Works with DDP.
     """

--- a/ignite/contrib/metrics/regression/fractional_bias.py
+++ b/ignite/contrib/metrics/regression/fractional_bias.py
@@ -33,23 +33,20 @@ class FractionalBias(_BaseRegression):
         device: specifies which device updates are accumulated on. Setting the
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
-	
-	.. testcode::
 
-            def process_function(engine, batch):
-                y_pred, y = batch
-                return y_pred, y
-            engine = Engine(process_function)
+    .. testcode::
+
             metric = FractionalBias()
-            metric.attach(engine, 'fractional_bias')
-            preds = torch.Tensor([[3.8], [9.9], [5.4], [2.1]])
-            target = preds * 1.5
-            state = engine.run([[preds, target]])
+            metric.attach(default_evaluator, 'fractional_bias')
+            y_pred = torch.Tensor([[3.8], [9.9], [5.4], [2.1]])
+            y_true = y_pred * 1.5
+            state = default_evaluator.run([[y_pred, y_true]])
             print(state.metrics['fractional_bias'])
 
     .. testoutput::
 
-            4.0000
+            0.4000...
+
     .. versionchanged:: 0.4.5
         - Works with DDP.
     """

--- a/ignite/contrib/metrics/regression/fractional_bias.py
+++ b/ignite/contrib/metrics/regression/fractional_bias.py
@@ -33,7 +33,23 @@ class FractionalBias(_BaseRegression):
         device: specifies which device updates are accumulated on. Setting the
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
+	
+	.. testcode::
 
+            def process_function(engine, batch):
+                y_pred, y = batch
+                return y_pred, y
+            engine = Engine(process_function)
+            metric = FractionalBias()
+            metric.attach(engine, 'fractional_bias')
+            preds = torch.Tensor([[3.8], [9.9], [5.4], [2.1]])
+            target = preds * 1.5
+            state = engine.run([[preds, target]])
+            print(state.metrics['fractional_bias'])
+
+    .. testoutput::
+
+            4.0000
     .. versionchanged:: 0.4.5
         - Works with DDP.
     """

--- a/ignite/contrib/metrics/regression/geometric_mean_absolute_error.py
+++ b/ignite/contrib/metrics/regression/geometric_mean_absolute_error.py
@@ -33,7 +33,22 @@ class GeometricMeanAbsoluteError(_BaseRegression):
         device: specifies which device updates are accumulated on. Setting the
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
+    .. testcode::
 
+            def process_function(engine, batch):
+                y_pred, y = batch
+                return y_pred, y
+            engine = Engine(process_function)
+            metric = GeometricMeanAbsoluteError()
+            metric.attach(engine, 'gmae')
+            preds = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
+            target = preds * 1.5
+            state = engine.run([[preds, target]])
+            print(state.metrics['gmae'])
+            
+    .. testoutput::
+
+            2.2723
     .. versionchanged:: 0.4.5
         - Works with DDP.
     """

--- a/ignite/contrib/metrics/regression/geometric_mean_absolute_error.py
+++ b/ignite/contrib/metrics/regression/geometric_mean_absolute_error.py
@@ -33,22 +33,19 @@ class GeometricMeanAbsoluteError(_BaseRegression):
         device: specifies which device updates are accumulated on. Setting the
             metric's device to be the same as your ``update`` arguments ensures the ``update`` method is
             non-blocking. By default, CPU.
+
     .. testcode::
 
-            def process_function(engine, batch):
-                y_pred, y = batch
-                return y_pred, y
-            engine = Engine(process_function)
             metric = GeometricMeanAbsoluteError()
-            metric.attach(engine, 'gmae')
-            preds = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
-            target = preds * 1.5
-            state = engine.run([[preds, target]])
+            metric.attach(default_evaluator, 'gmae')
+            y_pred = torch.Tensor([[3.8], [9.9], [-5.4], [2.1]])
+            y_true = y_pred * 1.5
+            state = default_evaluator.run([[y_pred, y_true]])
             print(state.metrics['gmae'])
-            
+
     .. testoutput::
 
-            2.2723
+            2.2723...
     .. versionchanged:: 0.4.5
         - Works with DDP.
     """


### PR DESCRIPTION
Addresses #2265 

Description:
Added Doctests for ``FractionalBias``, ``FractionalAbsoluteError``, ``CanberraMetric``, ``GeometricMeanAbsoluteError``

Check list:

- [ ] New tests are added (if a new feature is added)
- [X] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
