### PR TITLE
Paramscheduler emahandler

### DIFF
--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -50,8 +50,6 @@ class StateParamScheduler(BaseParamScheduler):
                     f"This may be a conflict between multiple handlers. "
                     f"Please choose another name."
                 )
-            else:
-                setattr(engine.state, self.param_name, None)
         else:
             if not self.create_new:
                 warnings.warn(

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -46,7 +46,7 @@ class StateParamScheduler(BaseParamScheduler):
         if hasattr(engine.state, self.param_name):
             if self.create_new:
                 raise ValueError(
-                    f"Attribute: `{self.param_name}` already exists in the engine.state. "
+                    f"Attribute '{self.param_name}' already exists in the engine.state. "
                     f"This may be a conflict between multiple handlers. "
                     f"Please choose another name."
                 )

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -15,6 +15,9 @@ class StateParamScheduler(BaseParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
+        create_new: in case `param_name` already exists in `engine.state`, whether to authorize `StateParamScheduler`
+            create a new parameter based on `StateParamScheduler` class name.
+            By default, this option is `False` meaning that `StateParamScheduler` will override `param_name` values.
 
     Note:
         Parameter scheduler works independently of the internal state of the attached engine.

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -1,5 +1,4 @@
 import numbers
-import re
 import warnings
 from bisect import bisect_right
 from typing import Any, List, Sequence, Tuple, Union

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -53,8 +53,8 @@ class StateParamScheduler(BaseParamScheduler):
         else:
             if not self.create_new:
                 warnings.warn(
-                    f"Attribute: `{self.param_name}` is not defined in the engine.state. "
-                    f"{type(self).__name__} will create it. Remove this warning by setting `create_new=True`."
+                    f"Attribute '{self.param_name}' is not defined in the engine.state. "
+                    f"{type(self).__name__} will create it. Remove this warning by setting create_new=True."
                 )
             setattr(engine.state, self.param_name, None)
 

--- a/tests/ignite/handlers/test_state_param_scheduler.py
+++ b/tests/ignite/handlers/test_state_param_scheduler.py
@@ -276,32 +276,6 @@ def test_simulate_values(scheduler_cls, scheduler_kwargs):
     _test(scheduler_cls, scheduler_kwargs)
 
 
-@pytest.mark.skip
-@pytest.mark.parametrize("scheduler_cls,scheduler_kwargs", [config3, config4, config5, config6])
-def test_state_param_asserts(scheduler_cls, scheduler_kwargs):
-    import re
-
-    def _test(scheduler_cls, scheduler_kwargs):
-        scheduler = scheduler_cls(**scheduler_kwargs)
-        with pytest.raises(
-            ValueError,
-            match=r"Attribute: '"
-            + re.escape(scheduler_kwargs["param_name"])
-            + "' is already defined in the Engine.state.This may be a conflict between multiple StateParameterScheduler"
-            + " handlers.Please choose another name.",
-        ):
-
-            trainer = Engine(lambda engine, batch: None)
-            event = Events.EPOCH_COMPLETED
-            max_epochs = 2
-            data = [0] * 10
-            scheduler.attach(trainer, event)
-            trainer.run(data, max_epochs=max_epochs)
-            scheduler.attach(trainer, event)
-
-    _test(scheduler_cls, scheduler_kwargs)
-
-
 def test_torch_save_load():
 
     lambda_state_parameter_scheduler = LambdaStateScheduler(

--- a/tests/ignite/handlers/test_state_param_scheduler.py
+++ b/tests/ignite/handlers/test_state_param_scheduler.py
@@ -414,7 +414,7 @@ def test_param_scheduler_with_ema_handler_attach_exception():
 
     with pytest.raises(
         ValueError,
-        match=r"Attribute: `ema_decay` already exists in the engine.state. "
+        match=r"Attribute 'ema_decay' already exists in the engine.state. "
         r"This may be a conflict between multiple handlers. "
         r"Please choose another name.",
     ):
@@ -440,7 +440,7 @@ def test_param_scheduler_attach_warning():
 
     with pytest.warns(
         UserWarning,
-        match=r"Attribute: `ema_decay` is not defined in the engine.state. "
-        r"PiecewiseLinearStateScheduler will create it. Remove this warning by setting `create_new=True`.",
+        match=r"Attribute 'ema_decay' is not defined in the engine.state. "
+        r"PiecewiseLinearStateScheduler will create it. Remove this warning by setting create_new=True.",
     ):
         ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)

--- a/tests/ignite/handlers/test_state_param_scheduler.py
+++ b/tests/ignite/handlers/test_state_param_scheduler.py
@@ -276,6 +276,7 @@ def test_simulate_values(scheduler_cls, scheduler_kwargs):
     _test(scheduler_cls, scheduler_kwargs)
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("scheduler_cls,scheduler_kwargs", [config3, config4, config5, config6])
 def test_state_param_asserts(scheduler_cls, scheduler_kwargs):
     import re
@@ -414,3 +415,51 @@ def test_docstring_examples():
     param_scheduler.attach(engine, Events.EPOCH_COMPLETED)
 
     engine.run([0] * 8, max_epochs=10)
+
+
+@pytest.mark.parametrize("create_new", [True, False])
+def test_param_scheduler_with_ema_handler(create_new):
+    import torch.nn as nn
+
+    from ignite.handlers import EMAHandler
+
+    model = nn.Linear(2, 1)
+    trainer = Engine(lambda e, b: model(b))
+    data = torch.rand(100, 2)
+
+    param_name = "ema_decay"
+    save_history = True
+    ema_handler = EMAHandler(model)
+    ema_handler.attach(trainer, name=param_name, event=Events.ITERATION_COMPLETED)
+
+    ema_decay_scheduler = PiecewiseLinearStateScheduler(
+        param_name=param_name,
+        milestones_values=[(0, 0.0), (10 * len(data), 0.999)],
+        save_history=save_history,
+        create_new=create_new,
+    )
+
+    if create_new:
+        with pytest.warns(
+            UserWarning,
+            match=r"Attribute: 'ema_decay' is already defined in the Engine.state. "
+            r"PiecewiseLinearStateScheduler will create a new parameter ema_decay_PiecewiseLinearStateScheduler_0 in"
+            r" Engine.state.",
+        ):
+            ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
+    else:
+        with pytest.warns(
+            UserWarning,
+            match=r"Attribute: 'ema_decay' is already defined in the Engine.state. "
+            r"PiecewiseLinearStateScheduler will override its values.",
+        ):
+            ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
+
+    trainer.run(data, max_epochs=20)
+    if create_new:
+        assert "ema_decay_PiecewiseLinearStateScheduler_0" in vars(trainer.state).keys()
+        assert "ema_decay_PiecewiseLinearStateScheduler_0" in trainer.state.param_history
+        assert "ema_decay" in vars(trainer.state).keys()
+    else:
+        assert "ema_decay" in vars(trainer.state).keys()
+        assert "ema_decay" in trainer.state.param_history

--- a/tests/ignite/handlers/test_state_param_scheduler.py
+++ b/tests/ignite/handlers/test_state_param_scheduler.py
@@ -412,14 +412,13 @@ def test_param_scheduler_with_ema_handler_attach_exception():
         create_new=create_new,
     )
 
-    if create_new:
-        with pytest.raises(
-            ValueError,
-            match=r"Attribute: `ema_decay` already exists in the engine.state. "
-            r"This may be a conflict between multiple handlers. "
-            r"Please choose another name.",
-        ):
-            ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
+    with pytest.raises(
+        ValueError,
+        match=r"Attribute: `ema_decay` already exists in the engine.state. "
+        r"This may be a conflict between multiple handlers. "
+        r"Please choose another name.",
+    ):
+        ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
 
 
 def test_param_scheduler_attach_warning():
@@ -430,7 +429,7 @@ def test_param_scheduler_attach_warning():
     trainer = Engine(lambda e, b: model(b))
     param_name = "ema_decay"
     save_history = True
-    create_new = True
+    create_new = False
 
     ema_decay_scheduler = PiecewiseLinearStateScheduler(
         param_name=param_name,
@@ -439,10 +438,9 @@ def test_param_scheduler_attach_warning():
         create_new=create_new,
     )
 
-    if not create_new:
-        with pytest.warns(
-            UserWarning,
-            match=r"Attribute: `ema_decay` is not defined in the engine.state. "
-            r"PiecewiseLinearStateScheduler will create it. Remove this warning by setting `create_new=True`.",
-        ):
-            ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
+    with pytest.warns(
+        UserWarning,
+        match=r"Attribute: `ema_decay` is not defined in the engine.state. "
+        r"PiecewiseLinearStateScheduler will create it. Remove this warning by setting `create_new=True`.",
+    ):
+        ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)


### PR DESCRIPTION
Fixes #2295

Description:
Add `create_new` parameter to ``attach`` method . This flag is used to create ``param_name`` on ``engine.state`` and is taking into account whether ``param_name`` attribute already exists or not on ``engine.state``. Overrides existing attribute by default.

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
