### PR TITLE
fixed xla version extraction

### DIFF
--- a/examples/notebooks/MNIST_on_TPU.ipynb
+++ b/examples/notebooks/MNIST_on_TPU.ipynb
@@ -68,7 +68,7 @@
       },
       "source": [
         "VERSION = !curl -s https://api.github.com/repos/pytorch/xla/releases/latest | grep -Po '\"tag_name\": \"v\\K.*?(?=\")'\n",
-        "VERSION = VERSION[0].rstrip('.0') # remove trailing zero\n",
+        "VERSION = VERSION[0].rstrip('0').rstrip('.') # remove trailing zero\n",
         "!pip install cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-{VERSION}-cp37-cp37m-linux_x86_64.whl"
       ],
       "execution_count": null,


### PR DESCRIPTION
Fixes #2322 

Description: The version wasn't being correctly extracted due to `rstrip()` being incorrectly used.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
