### PR TITLE
Ema momentum

### DIFF
--- a/ignite/handlers/ema_handler.py
+++ b/ignite/handlers/ema_handler.py
@@ -5,8 +5,24 @@ from typing import Optional, Union
 import torch.nn as nn
 
 from ignite.engine import CallableEventWithFilter, Engine, Events, EventsList
+from ignite.handlers.state_param_scheduler import LambdaStateScheduler
 
 __all__ = ["EMAHandler"]
+
+
+class EMAWarmUp:
+    def __init__(self, momentum_warmup: float, warmup_iters: int, momentum: float) -> None:
+        self.momentum_warmup = momentum_warmup
+        self.warmup_iters = warmup_iters
+        self.momentum = momentum
+
+    def __call__(self, event_index: int) -> float:
+        denominator = max(1, self.warmup_iters - 1)
+        curr_momentum = self.momentum_warmup + (self.momentum - self.momentum_warmup) * (event_index - 1) / denominator
+        if self.momentum >= self.momentum_warmup:
+            return min(self.momentum, curr_momentum)
+        else:
+            return max(self.momentum, curr_momentum)
 
 
 class EMAHandler:
@@ -23,8 +39,8 @@ class EMAHandler:
           model: the online model for which an EMA model will be computed. If ``model`` is ``DataParallel`` or
               ``DistributedDataParallel``, the EMA smoothing will be applied to ``model.module`` .
           momentum: the update momentum after warmup phase, should be float in range :math:`\left(0, 1 \right)`.
-          momentum_warmup: the initial update momentum during warmup phase. This argument is not used.
-          warmup_iters: iterations of warmup. This argument is not used.
+          momentum_warmup: the initial update momentum during warmup phase.
+          warmup_iters: iterations of warmup.
 
     Attributes:
           ema_model: the exponential moving averaged model.
@@ -36,11 +52,6 @@ class EMAHandler:
           The EMA model is already in ``eval`` mode. If model in the arguments is an ``nn.Module`` or
           ``DistributedDataParallel``, the EMA model is an ``nn.Module`` and it is on the same device as the online
           model. If the model is an ``nn.DataParallel``, then the EMA model is an ``nn.DataParallel``.
-
-    .. warning::
-        The arguments `momentum_warmup` and `warmup_iters` will be deprecated in the future. In the current version,
-        these two argument have no effect on the momentum. I.e., the momentum will be constant during the training.
-        If users need to change the momentum, please use a ``StateParamScheduler``.
 
 
     Note:
@@ -89,6 +100,17 @@ class EMAHandler:
 
               trainer.run(...)
 
+          The following example shows how to perform warm-up to the EMA momentum:
+          .. code-block::python
+              device = torch.device("cuda:0")
+              model = nn.Linear(2, 1).to(device)
+              # linearly change the EMA momentum from 0.2 to 0.002 in the first 100 iterations,
+              # then keep a constant EMA momentum of 0.002 afterwards
+              ema_handler = EMAHandler(model, momentum=0.002, momentum_warmup=0.2, warmup_iters=100)
+              engine = Engine(step_fn)
+              ema_handler.attach(engine, name="ema_momentum")
+              engine.run(...)
+
           The following example shows how to attach two handlers to the same trainer:
 
           .. code-block:: python
@@ -127,25 +149,18 @@ class EMAHandler:
     ) -> None:
         if not 0 < momentum < 1:
             raise ValueError(f"Invalid momentum: {momentum}")
-        if momentum_warmup is not None:
-            warnings.warn(
-                "Argument 'momentum_warmup' will be deprecated in the future. In the current version,"
-                "it has no effect on the ema momentum. Please use the ParamStateScheduler to schedule"
-                "the ema momentum."
-            )
-        if warmup_iters is not None:
-            warnings.warn(
-                "Argument 'warmup_iters' will be deprecated in the future. In the current version, "
-                "it has no effect on the ema momentum. Please use the ParamStateScheduler to schedule"
-                "the ema momentum."
-            )
+        self.momentum = momentum
+        if momentum_warmup is not None and warmup_iters is not None:
+            self.momentum_scheduler = None
+            self._momentum_lambda_obj = EMAWarmUp(momentum_warmup, warmup_iters, momentum)
+        else:
+            self._momentum_lambda_obj = None  # type: ignore[assignment]
+
         if not isinstance(model, nn.Module):
             raise ValueError(
                 f"model should be an instance of nn.Module or its subclasses, but got"
                 f"model: {model.__class__.__name__}"
             )
-        # TODO: in the next version, rename momentum to init_momentum, which is more rigorous
-        self.momentum = momentum
 
         if isinstance(model, nn.parallel.DistributedDataParallel):
             model = model.module
@@ -195,10 +210,19 @@ class EMAHandler:
         if hasattr(engine.state, name):
             if warn_if_exists:
                 warnings.warn(
-                    f"Attribute '{name}' already exists in Engine.state. Turn off this warning by setting"
+                    f"Attribute '{name}' already exists in Engine.state. It might because 1. the engine has loaded its "
+                    f"state dict or 2. {name} is already created by other handlers. Turn off this warning by setting"
                     f"warn_if_exists to False.",
                     category=UserWarning,
                 )
         else:
             setattr(engine.state, name, self.momentum)
+
+        if self._momentum_lambda_obj is not None:
+            self.momentum_scheduler = LambdaStateScheduler(
+                self._momentum_lambda_obj, param_name="ema_momentum"
+            )  # type: ignore[assignment]
+
+            # first update the momentum and then update the EMA model
+            self.momentum_scheduler.attach(engine, event)  # type: ignore[attr-defined]
         engine.add_event_handler(event, self._update_ema_model, name)

--- a/ignite/handlers/ema_handler.py
+++ b/ignite/handlers/ema_handler.py
@@ -101,7 +101,9 @@ class EMAHandler:
               trainer.run(...)
 
           The following example shows how to perform warm-up to the EMA momentum:
-          .. code-block::python
+
+          .. code-block:: python
+
               device = torch.device("cuda:0")
               model = nn.Linear(2, 1).to(device)
               # linearly change the EMA momentum from 0.2 to 0.002 in the first 100 iterations,

--- a/ignite/handlers/ema_handler.py
+++ b/ignite/handlers/ema_handler.py
@@ -1,5 +1,6 @@
+import warnings
 from copy import deepcopy
-from typing import Optional, Union
+from typing import Union
 
 import torch.nn as nn
 
@@ -15,26 +16,22 @@ class EMAHandler:
     .. math:: \theta_{\text{EMA}, t+1} = (1 - \lambda) \cdot \theta_{\text{EMA}, t} + \lambda \cdot \theta_{t}
 
     where :math:`\theta_{\text{EMA}, t}` and :math:`\theta_{t}` are the EMA weights and online model weights at
-    :math:`t`-th iteration, respectively; :math:`\lambda` is the update momentum. The handler allows for linearly
-    warming up the momentum in the beginning when training process is not stable. Current momentum can be retrieved
-    from ``Engine.state.ema_momentum``.
+    :math:`t`-th iteration, respectively; :math:`\lambda` is the update momentum. Current momentum can be retrieved
+    from the engine's state with an attribute name like ``Engine.state.ema_momentum``, and the attribute name need to
+    be the same as the one used in the ``attach`` method.
 
     Args:
           model: the online model for which an EMA model will be computed. If ``model`` is ``DataParallel`` or
               ``DistributedDataParallel``, the EMA smoothing will be applied to ``model.module`` .
-          momentum: the update momentum after warmup phase, should be float in range :math:`\left(0, 1 \right)`.
-          momentum_warmup: the initial update momentum during warmup phase, the value should be smaller than
-              ``momentum``. Momentum will linearly increase from this value to ``momentum`` in ``warmup_iters``
-              iterations. If ``None``, no warmup will be performed.
-          warmup_iters: iterations of warmup. If ``None``, no warmup will be performed.
+          init_momentum: the initial momentum, should be float in range :math:`\left(0, 1 \right)`. If no
+              ``StateParamScheduler`` is used, the momentum will always be ``init_momentum`` during the whole
+              training process. Otherwise, the momentum will be scheduled by the ``StateParamScheduler``.
 
     Attributes:
           ema_model: the exponential moving averaged model.
           model: the online model that is tracked by EMAHandler. It is ``model.module`` if ``model`` in
               the initialization method is an instance of ``DistributedDataParallel``.
-          momentum: the update momentum after warmup phase.
-          momentum_warmup: the initial update momentum.
-          warmup_iters: number of warmup iterations.
+          init_momentum: the initial momentum.
 
     Note:
           The EMA model is already in ``eval`` mode. If model in the arguments is an ``nn.Module`` or
@@ -56,8 +53,7 @@ class EMAHandler:
               device = torch.device("cuda:0")
               model = nn.Linear(2, 1).to(device)
               # update the ema every 5 iterations
-              ema_handler = EMAHandler(
-                  model, momentum=0.0002, momentum_warmup=0.0001, warmup_iters=10000)
+              ema_handler = EMAHandler(model, init_momentum=0.0002)
               # get the ema model, which is an instance of nn.Module
               ema_model = ema_handler.ema_model
               trainer = Engine(train_step_fn)
@@ -118,32 +114,15 @@ class EMAHandler:
 
     """
 
-    def __init__(
-        self,
-        model: nn.Module,
-        momentum: float = 0.0002,
-        momentum_warmup: Optional[float] = None,
-        warmup_iters: Optional[int] = None,
-    ) -> None:
-        if momentum_warmup is not None and not 0 < momentum_warmup < 1:
-            raise ValueError(f"Invalid momentum_warmup: {momentum_warmup}")
-        if not 0 < momentum < 1:
-            raise ValueError(f"Invalid momentum: {momentum}")
-        if momentum_warmup is not None and not momentum_warmup <= momentum:
-            raise ValueError(
-                f"momentum_warmup should be less than or equal to momentum, but got "
-                f"momentum_warmup: {momentum_warmup} and momentum: {momentum}"
-            )
-        if warmup_iters is not None and not (isinstance(warmup_iters, int) and warmup_iters > 0):
-            raise ValueError(f"Invalid warmup_iters: {warmup_iters}")
+    def __init__(self, model: nn.Module, init_momentum: float = 0.0002,) -> None:
+        if not 0 < init_momentum < 1:
+            raise ValueError(f"Invalid momentum: {init_momentum}")
         if not isinstance(model, nn.Module):
             raise ValueError(
                 f"model should be an instance of nn.Module or its subclasses, but got"
                 f"model: {model.__class__.__name__}"
             )
-        self.momentum_warmup = momentum_warmup
-        self.momentum = momentum
-        self.warmup_iters = warmup_iters
+        self.init_momentum = init_momentum
 
         if isinstance(model, nn.parallel.DistributedDataParallel):
             model = model.module
@@ -154,22 +133,6 @@ class EMAHandler:
             param.detach_()
         self.ema_model.eval()
 
-    def _get_momentum(self, curr_iter: int) -> float:
-        """Get current momentum, `curr_iter` should be 1-based. When `curr_iter = 1`, `momentum =
-        self.momentum_warmup`; when `curr_iter >= self.warmup_iters`, `momentum = self.momentum`"""
-
-        # TODO: use ignite's parameter scheduling, see also GitHub issue #2090
-        if curr_iter < 1:
-            raise ValueError(f"curr_iter should be at least 1, but got {curr_iter}.")
-
-        # no warmup
-        if self.momentum_warmup is None or self.warmup_iters is None:
-            return self.momentum
-
-        denominator = max(1, self.warmup_iters - 1)
-        momentum = self.momentum_warmup + (self.momentum - self.momentum_warmup) * (curr_iter - 1) / denominator
-        return min(self.momentum, momentum)
-
     def _update_ema_model(self, engine: Engine, name: str) -> None:
         """Update weights of ema model"""
         momentum = getattr(engine.state, name)
@@ -179,36 +142,40 @@ class EMAHandler:
         for ema_b, model_b in zip(self.ema_model.buffers(), self.model.buffers()):
             ema_b.data = model_b.data
 
-    def _update_ema_momentum(self, engine: Engine, name: str) -> None:
-        """Update momentum in engine.state"""
-        curr_iter = engine.state.iteration
-        momentum = self._get_momentum(curr_iter)
-        setattr(engine.state, name, momentum)
-
     def attach(
         self,
         engine: Engine,
         name: str = "ema_momentum",
+        warn_if_exists: bool = True,
         event: Union[str, Events, CallableEventWithFilter, EventsList] = Events.ITERATION_COMPLETED,
     ) -> None:
         """Attach the handler to engine. After the handler is attached, the ``Engine.state`` will add an new attribute
-        with name ``name``. Then, current momentum can be retrieved by from ``Engine.state`` when the engine runs.
+        with name ``name`` if the attribute does not exist. Then, the current momentum can be retrieved from
+        ``Engine.state`` when the engine runs.
+
+
+        Note:
+            There are two cases where a momentum with name ``name`` already exists: 1. the engine has loaded its
+            state dict after resuming. In this case, there is no need to initialize the momentum again, and users
+            can set ``warn_if_exists`` to False to suppress the warning message; 2. another handler has created
+            a state attribute with the same name. In this case, users should choose another name for the ema momentum.
+
 
         Args:
             engine: trainer to which the handler will be attached.
             name: attribute name for retrieving EMA momentum from ``Engine.state``. It should be a unique name since a
                 trainer can have multiple EMA handlers.
+            warn_if_exists: if True, a warning will be thrown if the momentum with name ``name`` already exists.
             event: event when the EMA momentum and EMA model are updated.
 
         """
         if hasattr(engine.state, name):
-            raise ValueError(
-                f"Attribute: '{name}' is already in Engine.state. Thus it might be "
-                f"overridden by other EMA handlers. Please select another name."
-            )
-
-        setattr(engine.state, name, 0.0)
-
-        # first update momentum, then update ema model
-        engine.add_event_handler(event, self._update_ema_momentum, name)
+            if warn_if_exists:
+                warnings.warn(
+                    f"Attribute '{name}' already exists in Engine.state. Turn off this warning by setting"
+                    f"warn_if_exists to False.",
+                    category=UserWarning,
+                )
+        else:
+            setattr(engine.state, name, self.init_momentum)
         engine.add_event_handler(event, self._update_ema_model, name)

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -1,4 +1,5 @@
 import numbers
+import warnings
 from bisect import bisect_right
 from typing import Any, List, Sequence, Tuple, Union
 
@@ -11,8 +12,9 @@ class StateParamScheduler(BaseParamScheduler):
 
     Args:
         param_name: name of parameter to update.
-        save_history: whether to log the parameter values to
-            `engine.state.param_history`, (default=False).
+        save_history: whether to log the parameter values to ``engine.state.param_history``, (default=False).
+        create_new: whether to create ``param_name`` on ``engine.state`` taking into account whether ``param_name``
+            attribute already exists or not. Overrides existing attribute by default, (default=False).
 
     Note:
         Parameter scheduler works independently of the internal state of the attached engine.
@@ -23,10 +25,9 @@ class StateParamScheduler(BaseParamScheduler):
 
     """
 
-    def __init__(
-        self, param_name: str, save_history: bool = False,
-    ):
+    def __init__(self, param_name: str, save_history: bool = False, create_new: bool = False):
         super(StateParamScheduler, self).__init__(param_name, save_history)
+        self.create_new = create_new
 
     def attach(
         self,
@@ -43,11 +44,19 @@ class StateParamScheduler(BaseParamScheduler):
 
         """
         if hasattr(engine.state, self.param_name):
-            raise ValueError(
-                f"Attribute: '{self.param_name}' is already defined in the Engine.state."
-                f"This may be a conflict between multiple StateParameterScheduler handlers."
-                f"Please choose another name."
-            )
+            if self.create_new:
+                raise ValueError(
+                    f"Attribute '{self.param_name}' already exists in the engine.state. "
+                    f"This may be a conflict between multiple handlers. "
+                    f"Please choose another name."
+                )
+        else:
+            if not self.create_new:
+                warnings.warn(
+                    f"Attribute '{self.param_name}' is not defined in the engine.state. "
+                    f"{type(self).__name__} will create it. Remove this warning by setting create_new=True."
+                )
+            setattr(engine.state, self.param_name, None)
 
         if self.save_history:
             if not hasattr(engine.state, "param_history") or engine.state.param_history is None:  # type: ignore
@@ -147,8 +156,8 @@ class LambdaStateScheduler(StateParamScheduler):
 
     """
 
-    def __init__(self, lambda_obj: Any, param_name: str, save_history: bool = False):
-        super(LambdaStateScheduler, self).__init__(param_name, save_history)
+    def __init__(self, lambda_obj: Any, param_name: str, save_history: bool = False, create_new: bool = False):
+        super(LambdaStateScheduler, self).__init__(param_name, save_history, create_new)
 
         if not callable(lambda_obj):
             raise ValueError("Expected lambda_obj to be callable.")
@@ -199,9 +208,13 @@ class PiecewiseLinearStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self, milestones_values: List[Tuple[int, float]], param_name: str, save_history: bool = False,
+        self,
+        milestones_values: List[Tuple[int, float]],
+        param_name: str,
+        save_history: bool = False,
+        create_new: bool = False,
     ):
-        super(PiecewiseLinearStateScheduler, self).__init__(param_name, save_history)
+        super(PiecewiseLinearStateScheduler, self).__init__(param_name, save_history, create_new)
 
         if not isinstance(milestones_values, Sequence):
             raise TypeError(
@@ -289,9 +302,9 @@ class ExpStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self, initial_value: float, gamma: float, param_name: str, save_history: bool = False,
+        self, initial_value: float, gamma: float, param_name: str, save_history: bool = False, create_new: bool = False,
     ):
-        super(ExpStateScheduler, self).__init__(param_name, save_history)
+        super(ExpStateScheduler, self).__init__(param_name, save_history, create_new)
         self.initial_value = initial_value
         self.gamma = gamma
         self._state_attrs += ["initial_value", "gamma"]
@@ -337,9 +350,15 @@ class StepStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self, initial_value: float, gamma: float, step_size: int, param_name: str, save_history: bool = False,
+        self,
+        initial_value: float,
+        gamma: float,
+        step_size: int,
+        param_name: str,
+        save_history: bool = False,
+        create_new: bool = False,
     ):
-        super(StepStateScheduler, self).__init__(param_name, save_history)
+        super(StepStateScheduler, self).__init__(param_name, save_history, create_new)
         self.initial_value = initial_value
         self.gamma = gamma
         self.step_size = step_size
@@ -386,9 +405,15 @@ class MultiStepStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self, initial_value: float, gamma: float, milestones: List[int], param_name: str, save_history: bool = False,
+        self,
+        initial_value: float,
+        gamma: float,
+        milestones: List[int],
+        param_name: str,
+        save_history: bool = False,
+        create_new: bool = False,
     ):
-        super(MultiStepStateScheduler, self).__init__(param_name, save_history)
+        super(MultiStepStateScheduler, self).__init__(param_name, save_history, create_new)
         self.initial_value = initial_value
         self.gamma = gamma
         self.milestones = milestones

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -4,7 +4,7 @@ from bisect import bisect_right
 from typing import Any, List, Sequence, Tuple, Union
 
 from ignite.engine import CallableEventWithFilter, Engine, Events, EventsList
-from ignite.handlers import BaseParamScheduler
+from ignite.handlers.param_scheduler import BaseParamScheduler
 
 
 class StateParamScheduler(BaseParamScheduler):

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -1,5 +1,4 @@
 import numbers
-import warnings
 from bisect import bisect_right
 from typing import Any, List, Sequence, Tuple, Union
 
@@ -12,9 +11,8 @@ class StateParamScheduler(BaseParamScheduler):
 
     Args:
         param_name: name of parameter to update.
-        save_history: whether to log the parameter values to ``engine.state.param_history``, (default=False).
-        create_new: whether to create ``param_name`` on ``engine.state`` taking into account whether ``param_name``
-            attribute already exists or not. Overrides existing attribute by default, (default=False).
+        save_history: whether to log the parameter values to
+            `engine.state.param_history`, (default=False).
 
     Note:
         Parameter scheduler works independently of the internal state of the attached engine.
@@ -25,9 +23,10 @@ class StateParamScheduler(BaseParamScheduler):
 
     """
 
-    def __init__(self, param_name: str, save_history: bool = False, create_new: bool = False):
+    def __init__(
+        self, param_name: str, save_history: bool = False,
+    ):
         super(StateParamScheduler, self).__init__(param_name, save_history)
-        self.create_new = create_new
 
     def attach(
         self,
@@ -44,19 +43,11 @@ class StateParamScheduler(BaseParamScheduler):
 
         """
         if hasattr(engine.state, self.param_name):
-            if self.create_new:
-                raise ValueError(
-                    f"Attribute '{self.param_name}' already exists in the engine.state. "
-                    f"This may be a conflict between multiple handlers. "
-                    f"Please choose another name."
-                )
-        else:
-            if not self.create_new:
-                warnings.warn(
-                    f"Attribute '{self.param_name}' is not defined in the engine.state. "
-                    f"{type(self).__name__} will create it. Remove this warning by setting create_new=True."
-                )
-            setattr(engine.state, self.param_name, None)
+            raise ValueError(
+                f"Attribute: '{self.param_name}' is already defined in the Engine.state."
+                f"This may be a conflict between multiple StateParameterScheduler handlers."
+                f"Please choose another name."
+            )
 
         if self.save_history:
             if not hasattr(engine.state, "param_history") or engine.state.param_history is None:  # type: ignore
@@ -156,8 +147,8 @@ class LambdaStateScheduler(StateParamScheduler):
 
     """
 
-    def __init__(self, lambda_obj: Any, param_name: str, save_history: bool = False, create_new: bool = False):
-        super(LambdaStateScheduler, self).__init__(param_name, save_history, create_new)
+    def __init__(self, lambda_obj: Any, param_name: str, save_history: bool = False):
+        super(LambdaStateScheduler, self).__init__(param_name, save_history)
 
         if not callable(lambda_obj):
             raise ValueError("Expected lambda_obj to be callable.")
@@ -208,13 +199,9 @@ class PiecewiseLinearStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self,
-        milestones_values: List[Tuple[int, float]],
-        param_name: str,
-        save_history: bool = False,
-        create_new: bool = False,
+        self, milestones_values: List[Tuple[int, float]], param_name: str, save_history: bool = False,
     ):
-        super(PiecewiseLinearStateScheduler, self).__init__(param_name, save_history, create_new)
+        super(PiecewiseLinearStateScheduler, self).__init__(param_name, save_history)
 
         if not isinstance(milestones_values, Sequence):
             raise TypeError(
@@ -302,9 +289,9 @@ class ExpStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self, initial_value: float, gamma: float, param_name: str, save_history: bool = False, create_new: bool = False,
+        self, initial_value: float, gamma: float, param_name: str, save_history: bool = False,
     ):
-        super(ExpStateScheduler, self).__init__(param_name, save_history, create_new)
+        super(ExpStateScheduler, self).__init__(param_name, save_history)
         self.initial_value = initial_value
         self.gamma = gamma
         self._state_attrs += ["initial_value", "gamma"]
@@ -350,15 +337,9 @@ class StepStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self,
-        initial_value: float,
-        gamma: float,
-        step_size: int,
-        param_name: str,
-        save_history: bool = False,
-        create_new: bool = False,
+        self, initial_value: float, gamma: float, step_size: int, param_name: str, save_history: bool = False,
     ):
-        super(StepStateScheduler, self).__init__(param_name, save_history, create_new)
+        super(StepStateScheduler, self).__init__(param_name, save_history)
         self.initial_value = initial_value
         self.gamma = gamma
         self.step_size = step_size
@@ -405,15 +386,9 @@ class MultiStepStateScheduler(StateParamScheduler):
     """
 
     def __init__(
-        self,
-        initial_value: float,
-        gamma: float,
-        milestones: List[int],
-        param_name: str,
-        save_history: bool = False,
-        create_new: bool = False,
+        self, initial_value: float, gamma: float, milestones: List[int], param_name: str, save_history: bool = False,
     ):
-        super(MultiStepStateScheduler, self).__init__(param_name, save_history, create_new)
+        super(MultiStepStateScheduler, self).__init__(param_name, save_history)
         self.initial_value = initial_value
         self.gamma = gamma
         self.milestones = milestones

--- a/tests/ignite/handlers/test_ema_handler.py
+++ b/tests/ignite/handlers/test_ema_handler.py
@@ -41,10 +41,18 @@ def _get_dummy_step_fn(model: Union[nn.Module, DataParallel, DistributedDataPara
     return step_fn
 
 
-@pytest.mark.parametrize("init_momentum", [-1, 2])
-def test_ema_invalid_momentum(get_dummy_model, init_momentum):
+@pytest.mark.parametrize("momentum", [-1, 2])
+def test_ema_invalid_momentum(get_dummy_model, momentum):
     with pytest.raises(ValueError, match="Invalid momentum"):
-        EMAHandler(get_dummy_model(), init_momentum=init_momentum)
+        EMAHandler(get_dummy_model(), momentum=momentum)
+
+
+def test_ema_deprecated_(get_dummy_model):
+    with pytest.warns(UserWarning, match="Argument 'momentum_warmup' will be deprecated in the future"):
+        EMAHandler(get_dummy_model(), momentum_warmup=0.0001)
+
+    with pytest.warns(UserWarning, match="Argument 'warmup_iters' will be deprecated in the future."):
+        EMAHandler(get_dummy_model(), warmup_iters=10)
 
 
 def test_ema_invalid_model():
@@ -84,7 +92,8 @@ def test_ema_load_state_dict(get_dummy_model):
     assert ema_model.weight.data.allclose(model_1.weight.data)
 
 
-def test_ema_engine_momentum(get_dummy_model):
+def test_ema_get_const_momentum(get_dummy_model):
+    """Test if momentum retrieved from the engine is constant and equal to the handler's momentum"""
     model = get_dummy_model()
     step_fn = _get_dummy_step_fn(model)
     engine = Engine(step_fn)
@@ -92,10 +101,9 @@ def test_ema_engine_momentum(get_dummy_model):
     def assert_const_momentum(engine: Engine, const_momentum):
         assert engine.state.ema_momentum == const_momentum
 
-    ema_handler = EMAHandler(model, init_momentum=0.002)
+    ema_handler = EMAHandler(model, momentum=0.002)
     ema_handler.attach(engine)
-    # attach the assertion handler after ema_handler, so the momentum is first updated and then tested
-    engine.add_event_handler(Events.ITERATION_COMPLETED, assert_const_momentum, ema_handler.init_momentum)
+    engine.add_event_handler(Events.ITERATION_COMPLETED, assert_const_momentum, ema_handler.momentum)
     engine.run(range(2))
 
 
@@ -131,11 +139,10 @@ def test_ema_buffer():
 def test_ema_two_handlers(get_dummy_model):
     """Test when two EMA handlers are attached to a trainer"""
     model_1 = get_dummy_model()
-    # momentum will be constantly 0.5
-    ema_handler_1 = EMAHandler(model_1, init_momentum=0.5)
+    ema_handler_1 = EMAHandler(model_1, momentum=0.5)
 
     model_2 = get_dummy_model()
-    ema_handler_2 = EMAHandler(model_2, init_momentum=0.5)
+    ema_handler_2 = EMAHandler(model_2, momentum=0.5)
 
     def _step_fn(engine: Engine, batch: Any):
         model_1.weight.data.add_(1)
@@ -182,8 +189,7 @@ def _test_ema_final_weight(model, device=None, ddp=False, interval=1):
     step_fn = _get_dummy_step_fn(model)
     engine = Engine(step_fn)
 
-    # momentum will be constantly 0.5
-    ema_handler = EMAHandler(model, init_momentum=0.5)
+    ema_handler = EMAHandler(model, momentum=0.5)
     ema_handler.attach(engine, "model", event=Events.ITERATION_COMPLETED(every=interval))
 
     # engine will run 4 iterations

--- a/tests/ignite/handlers/test_ema_handler.py
+++ b/tests/ignite/handlers/test_ema_handler.py
@@ -81,7 +81,7 @@ def test_ema_warmup_func(get_dummy_model):
     engine_1.add_event_handler(
         Events.ITERATION_COMPLETED, check_ema_momentum, momentum_warmup_1, momentum, warmup_iters
     )
-    engine_1.run(range(2))
+    engine_1.run(range(10))
 
     # momentum_warmup > momentum
     model_2 = get_dummy_model()
@@ -91,7 +91,7 @@ def test_ema_warmup_func(get_dummy_model):
     engine_2.add_event_handler(
         Events.ITERATION_COMPLETED, check_ema_momentum, momentum_warmup_2, momentum, warmup_iters
     )
-    engine_2.run(range(2))
+    engine_2.run(range(10))
 
 
 def test_ema_invalid_model():
@@ -143,7 +143,7 @@ def test_ema_get_const_momentum(get_dummy_model):
     ema_handler = EMAHandler(model, momentum=0.002)
     ema_handler.attach(engine)
     engine.add_event_handler(Events.ITERATION_COMPLETED, assert_const_momentum, ema_handler.momentum)
-    engine.run(range(2))
+    engine.run(range(10))
 
 
 def test_ema_buffer():

--- a/tests/ignite/handlers/test_state_param_scheduler.py
+++ b/tests/ignite/handlers/test_state_param_scheduler.py
@@ -1,9 +1,7 @@
-import re
 from unittest.mock import patch
 
 import pytest
 import torch
-import torch.nn as nn
 
 from ignite.engine import Engine, Events
 from ignite.handlers.state_param_scheduler import (
@@ -283,6 +281,31 @@ def test_simulate_values(scheduler_cls, scheduler_kwargs):
     _test(scheduler_cls, scheduler_kwargs)
 
 
+@pytest.mark.parametrize("scheduler_cls,scheduler_kwargs", [config3, config4, config5, config6])
+def test_state_param_asserts(scheduler_cls, scheduler_kwargs):
+    import re
+
+    def _test(scheduler_cls, scheduler_kwargs):
+        scheduler = scheduler_cls(**scheduler_kwargs)
+        with pytest.raises(
+            ValueError,
+            match=r"Attribute: '"
+            + re.escape(scheduler_kwargs["param_name"])
+            + "' is already defined in the Engine.state.This may be a conflict between multiple StateParameterScheduler"
+            + " handlers.Please choose another name.",
+        ):
+
+            trainer = Engine(lambda engine, batch: None)
+            event = Events.EPOCH_COMPLETED
+            max_epochs = 2
+            data = [0] * 10
+            scheduler.attach(trainer, event)
+            trainer.run(data, max_epochs=max_epochs)
+            scheduler.attach(trainer, event)
+
+    _test(scheduler_cls, scheduler_kwargs)
+
+
 def test_torch_save_load():
 
     lambda_state_parameter_scheduler = LambdaStateScheduler(
@@ -418,69 +441,3 @@ def test_docstring_examples():
     param_scheduler.attach(engine, Events.EPOCH_COMPLETED)
 
     engine.run([0] * 8, max_epochs=10)
-
-
-def test_param_scheduler_attach_exception():
-    trainer = Engine(lambda e, b: None)
-    param_name = "state_param"
-
-    setattr(trainer.state, param_name, None)
-
-    save_history = True
-    create_new = True
-
-    param_scheduler = PiecewiseLinearStateScheduler(
-        param_name=param_name,
-        milestones_values=[(0, 0.0), (10, 0.999)],
-        save_history=save_history,
-        create_new=create_new,
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r"Attribute '" + re.escape(param_name) + "' already exists in the engine.state. "
-        r"This may be a conflict between multiple handlers. "
-        r"Please choose another name.",
-    ):
-        param_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
-
-
-def test_param_scheduler_attach_warning():
-    trainer = Engine(lambda e, b: None)
-    param_name = "state_param"
-    save_history = True
-    create_new = False
-
-    param_scheduler = PiecewiseLinearStateScheduler(
-        param_name=param_name,
-        milestones_values=[(0, 0.0), (10, 0.999)],
-        save_history=save_history,
-        create_new=create_new,
-    )
-
-    with pytest.warns(
-        UserWarning,
-        match=r"Attribute '" + re.escape(param_name) + "' is not defined in the engine.state. "
-        r"PiecewiseLinearStateScheduler will create it. Remove this warning by setting create_new=True.",
-    ):
-        param_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
-
-
-def test_param_scheduler_with_ema_handler():
-
-    from ignite.handlers import EMAHandler
-
-    model = nn.Linear(2, 1)
-    trainer = Engine(lambda e, b: model(b))
-    data = torch.rand(100, 2)
-
-    param_name = "ema_decay"
-
-    ema_handler = EMAHandler(model)
-    ema_handler.attach(trainer, name=param_name, event=Events.ITERATION_COMPLETED)
-
-    ema_decay_scheduler = PiecewiseLinearStateScheduler(
-        param_name=param_name, milestones_values=[(0, 0.0), (10, 0.999),], save_history=True
-    )
-    ema_decay_scheduler.attach(trainer, Events.ITERATION_COMPLETED)
-    trainer.run(data, max_epochs=20)


### PR DESCRIPTION
Fixes #2294 

Description: Deprecate the momentum scheduling function in the EMAHandler. 

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
