### PR TITLE
Fix #2343

### DIFF
--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -148,6 +148,7 @@ class ClearMLLogger(BaseLogger):
 
             self._task = _Stub()
         else:
+            # Try to retrieve current task before trying to create a new one
             self._task = Task.current_task()
             if self._task is None: 
                 self._task = Task.init(

--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -52,7 +52,7 @@ class ClearMLLogger(BaseLogger):
         kwargs: Keyword arguments accepted from
             `clearml.Task
             <https://clear.ml/docs/latest/docs/references/sdk/task#taskinit>`_.
-            All arguments are optional. If a ClearML Task has already been created, 
+            All arguments are optional. If a ClearML Task has already been created,
             kwargs will be ignored and the current ClearML Task will be used.
 
     Examples:
@@ -150,7 +150,7 @@ class ClearMLLogger(BaseLogger):
         else:
             # Try to retrieve current the ClearML Task before trying to create a new one
             self._task = Task.current_task()
-            if self._task is None: 
+            if self._task is None:
                 self._task = Task.init(
                     project_name=kwargs.get("project_name"),
                     task_name=kwargs.get("task_name"),

--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -52,7 +52,8 @@ class ClearMLLogger(BaseLogger):
         kwargs: Keyword arguments accepted from
             `clearml.Task
             <https://clear.ml/docs/latest/docs/references/sdk/task#taskinit>`_.
-            All arguments are optional.
+            All arguments are optional. If a ClearML has already been created, 
+            kwargs will be ignored and the current task will be used.
 
     Examples:
         .. code-block:: python

--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -147,12 +147,14 @@ class ClearMLLogger(BaseLogger):
 
             self._task = _Stub()
         else:
-            self._task = Task.init(
-                project_name=kwargs.get("project_name"),
-                task_name=kwargs.get("task_name"),
-                task_type=kwargs.get("task_type", Task.TaskTypes.training),
-                **experiment_kwargs,
-            )
+            self._task = Task.current_task()
+            if self._task is None: 
+                self._task = Task.init(
+                    project_name=kwargs.get("project_name"),
+                    task_name=kwargs.get("task_name"),
+                    task_type=kwargs.get("task_type", Task.TaskTypes.training),
+                    **experiment_kwargs,
+                )
 
         self.clearml_logger = self._task.get_logger()
 

--- a/ignite/contrib/handlers/clearml_logger.py
+++ b/ignite/contrib/handlers/clearml_logger.py
@@ -52,8 +52,8 @@ class ClearMLLogger(BaseLogger):
         kwargs: Keyword arguments accepted from
             `clearml.Task
             <https://clear.ml/docs/latest/docs/references/sdk/task#taskinit>`_.
-            All arguments are optional. If a ClearML has already been created, 
-            kwargs will be ignored and the current task will be used.
+            All arguments are optional. If a ClearML Task has already been created, 
+            kwargs will be ignored and the current ClearML Task will be used.
 
     Examples:
         .. code-block:: python
@@ -148,7 +148,7 @@ class ClearMLLogger(BaseLogger):
 
             self._task = _Stub()
         else:
-            # Try to retrieve current task before trying to create a new one
+            # Try to retrieve current the ClearML Task before trying to create a new one
             self._task = Task.current_task()
             if self._task is None: 
                 self._task = Task.init(


### PR DESCRIPTION
Fixes #2343 

Description: ClearMLLogger tries to retrieve current task before trying to create a new one.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [X] Documentation is updated (if required)
