### PR TITLE
[skip ci] Add doctest for MultiLabelConfusionMatrix metric

### DIFF
--- a/ignite/metrics/multilabel_confusion_matrix.py
+++ b/ignite/metrics/multilabel_confusion_matrix.py
@@ -38,6 +38,40 @@ class MultiLabelConfusionMatrix(Metric):
             default, CPU.
         normalized: whether to normalize confusion matrix by its sum or not.
 
+    Example:
+
+        .. testcode::
+
+            metric = MultiLabelConfusionMatrix(num_classes=3)
+            metric.attach(default_evaluator, "mlcm")
+            y_true = torch.Tensor([
+                [0, 0, 1],
+                [0, 0, 0],
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 1],
+            ]).long()
+            y_pred = torch.Tensor([
+                [1, 1, 0],
+                [1, 0, 1],
+                [1, 0, 0],
+                [1, 0, 1],
+                [1, 1, 0],
+            ]).long()
+            state = default_evaluator.run([[y_pred, y_true]])
+            print(state.metrics["mlcm"])
+
+        .. testoutput::
+
+            tensor([[[0, 4],
+                    [0, 1]],
+
+                    [[3, 1],
+                    [0, 1]],
+
+                    [[1, 2],
+                    [2, 0]]])
+
     .. versionadded:: 0.4.5
 
     """

--- a/ignite/metrics/multilabel_confusion_matrix.py
+++ b/ignite/metrics/multilabel_confusion_matrix.py
@@ -64,13 +64,13 @@ class MultiLabelConfusionMatrix(Metric):
         .. testoutput::
 
             tensor([[[0, 4],
-                    [0, 1]],
+                     [0, 1]],
 
                     [[3, 1],
-                    [0, 1]],
+                     [0, 1]],
 
                     [[1, 2],
-                    [2, 0]]])
+                     [2, 0]]])
 
     .. versionadded:: 0.4.5
 


### PR DESCRIPTION
Addresses #2265

Description: Add doctest for `MultiLabelConfusionMatrix` metric

@ydcjeff

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
