### PR TITLE
[skip ci] Add doctest for GAN metrics

### DIFF
--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -95,7 +95,7 @@ class FID(_BaseInceptionMetric):
             non-blocking. By default, CPU.
 
     Examples:
-    
+
         .. code-block:: python
 
             metric = FID()

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -95,15 +95,28 @@ class FID(_BaseInceptionMetric):
             non-blocking. By default, CPU.
 
     Examples:
+    
         .. code-block:: python
 
-            import torch
-            from ignite.metric.gan import FID
+            metric = FID()
+            metric.attach(default_evaluator, "fid")
+            y_true = torch.rand(10, 3, 299, 299)
+            y_pred = torch.rand(10, 3, 299, 299)
+            state = default_evaluator.run([[y_pred, y_true]])
+            print(state.metrics["fid"])
 
-            y_pred, y = torch.rand(10, 3, 299, 299), torch.rand(10, 3, 299, 299)
-            m = FID()
-            m.update((y_pred, y))
-            print(m.compute())
+        .. testcode::
+
+            metric = FID(num_features=1, feature_extractor=default_model)
+            metric.attach(default_evaluator, "fid")
+            y_true = torch.ones(10, 4)
+            y_pred = torch.ones(10, 4)
+            state = default_evaluator.run([[y_pred, y_true]])
+            print(state.metrics["fid"])
+
+        .. testoutput::
+
+            0.0
 
     .. versionadded:: 0.4.6
     """

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -48,16 +48,26 @@ class InceptionScore(_BaseInceptionMetric):
         The default Inception model requires the `torchvision` module to be installed.
 
     Examples:
+
         .. code-block:: python
 
-            from ignite.metric.gan import InceptionScore
-            import torch
+            metric = InceptionScore()
+            metric.attach(default_evaluator, "is")
+            y = torch.rand(10, 3, 299, 299)
+            state = default_evaluator.run([y])
+            print(state.metrics["is"])
 
-            images = torch.rand(10, 3, 299, 299)
+        .. testcode::
 
-            m = InceptionScore()
-            m.update(images)
-            print(m.compute())
+            metric = InceptionScore(num_features=1, feature_extractor=default_model)
+            metric.attach(default_evaluator, "is")
+            y = torch.zeros(10, 4)
+            state = default_evaluator.run([y])
+            print(state.metrics["is"])
+
+        .. testoutput::
+
+            1.0
 
     .. versionadded:: 0.4.6
     """


### PR DESCRIPTION
Addresses #2265

Description: Add doctest for GAN metrics (`FID `and `InceptionScore`)

@ydcjeff 

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
