### PR TITLE
TPU CI : mkl version

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -49,6 +49,7 @@ jobs:
           restore-keys: |
             ${{ steps.get-date.outputs.date }}-pytorch-${{ runner.os }}-${{ matrix.xla-version }}-
 
+      # mkl version fixed due to https://github.com/pytorch/ignite/issues/2350
       - name: Install Torch XLA and others
         run: |
 

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
           ## Install openblas, mkl, gsutil
           sudo apt-get install -y libopenblas-dev libomp5-10 libomp5
-          pip install mkl requests gsutil
+          pip install mkl==2021.4.0 requests gsutil
 
           ## Install torch & xla
           curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py


### PR DESCRIPTION
Fixes #2350

Description: set mkl version to mkl==2021.4.0 for fixing TPU CI

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
