### PR TITLE
Removed python 3.6 support 

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         pytorch-version: [1.9.1, 1.8.1, 1.7.1, 1.6.0, 1.5.1, 1.4.0, 1.3.1]
         exclude:
           - pytorch-version: 1.3.1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         pytorch-channel: [pytorch, pytorch-nightly]
         include:
           # includes a single build on windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -81,7 +81,7 @@ def _test_ssim(y_pred, y, data_range, kernel_size, sigma, gaussian, use_sample_c
         skimg_y,
         win_size=kernel_size,
         sigma=sigma,
-        channel_axis=3,
+        channel_axis=-1,
         gaussian_weights=gaussian,
         data_range=data_range,
         use_sample_covariance=use_sample_covariance,
@@ -142,7 +142,7 @@ def _test_distrib_integration(device, tol=1e-4):
             np_true,
             win_size=11,
             sigma=1.5,
-            channel_axis=3,
+            channel_axis=-1,
             gaussian_weights=True,
             data_range=1.0,
             use_sample_covariance=False,
@@ -161,7 +161,7 @@ def _test_distrib_integration(device, tol=1e-4):
 
         np_pred = y_pred.permute(0, 2, 3, 1).cpu().numpy()
         np_true = np_pred * 0.65
-        true_res = ski_ssim(np_pred, np_true, win_size=7, channel_axis=3, gaussian_weights=False, data_range=1.0)
+        true_res = ski_ssim(np_pred, np_true, win_size=7, channel_axis=-1, gaussian_weights=False, data_range=1.0)
 
         assert pytest.approx(res, abs=tol) == true_res
 

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -81,7 +81,7 @@ def _test_ssim(y_pred, y, data_range, kernel_size, sigma, gaussian, use_sample_c
         skimg_y,
         win_size=kernel_size,
         sigma=sigma,
-        multichannel=True,
+        channel_axis=3,
         gaussian_weights=gaussian,
         data_range=data_range,
         use_sample_covariance=use_sample_covariance,
@@ -142,7 +142,7 @@ def _test_distrib_integration(device, tol=1e-4):
             np_true,
             win_size=11,
             sigma=1.5,
-            multichannel=True,
+            channel_axis=3,
             gaussian_weights=True,
             data_range=1.0,
             use_sample_covariance=False,
@@ -161,7 +161,7 @@ def _test_distrib_integration(device, tol=1e-4):
 
         np_pred = y_pred.permute(0, 2, 3, 1).cpu().numpy()
         np_true = np_pred * 0.65
-        true_res = ski_ssim(np_pred, np_true, win_size=7, multichannel=True, gaussian_weights=False, data_range=1.0)
+        true_res = ski_ssim(np_pred, np_true, win_size=7, channel_axis=3, gaussian_weights=False, data_range=1.0)
 
         assert pytest.approx(res, abs=tol) == true_res
 

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -74,14 +74,14 @@ def _test_ssim(y_pred, y, data_range, kernel_size, sigma, gaussian, use_sample_c
     ssim.update((y_pred, y))
     ignite_ssim = ssim.compute()
 
-    skimg_pred = y_pred.permute(0, 2, 3, 1).cpu().numpy()
+    skimg_pred = y_pred.cpu().numpy()
     skimg_y = skimg_pred * 0.8
     skimg_ssim = ski_ssim(
         skimg_pred,
         skimg_y,
         win_size=kernel_size,
         sigma=sigma,
-        channel_axis=-1,
+        channel_axis=1,
         gaussian_weights=gaussian,
         data_range=data_range,
         use_sample_covariance=use_sample_covariance,
@@ -135,14 +135,14 @@ def _test_distrib_integration(device, tol=1e-4):
         assert "ssim" in engine.state.metrics
         res = engine.state.metrics["ssim"]
 
-        np_pred = y_pred.permute(0, 2, 3, 1).cpu().numpy()
+        np_pred = y_pred.cpu().numpy()
         np_true = np_pred * 0.65
         true_res = ski_ssim(
             np_pred,
             np_true,
             win_size=11,
             sigma=1.5,
-            channel_axis=-1,
+            channel_axis=1,
             gaussian_weights=True,
             data_range=1.0,
             use_sample_covariance=False,
@@ -159,9 +159,9 @@ def _test_distrib_integration(device, tol=1e-4):
         assert "ssim" in engine.state.metrics
         res = engine.state.metrics["ssim"]
 
-        np_pred = y_pred.permute(0, 2, 3, 1).cpu().numpy()
+        np_pred = y_pred.cpu().numpy()
         np_true = np_pred * 0.65
-        true_res = ski_ssim(np_pred, np_true, win_size=7, channel_axis=-1, gaussian_weights=False, data_range=1.0)
+        true_res = ski_ssim(np_pred, np_true, win_size=7, channel_axis=1, gaussian_weights=False, data_range=1.0)
 
         assert pytest.approx(res, abs=tol) == true_res
 


### PR DESCRIPTION
Fixes #2363

Description: Let's remove python 3.6 from our CI from due to EOL, 2021-12-23 (https://www.python.org/downloads/)

hey @vfdev-5 ,
 to remove python-version 3.6 and py36 support from
IG I can remove that the following way from these paths ,right? 

1. **.github/workflows/unit-tests.yml**

2. **.github/workflows/pytorch-version-tests.yml**

 `python-version: [3.6, 3.7, 3.8, 3.9]`    ->   `python-version: [3.7, 3.8, 3.9] `

3. **pyproject.toml**
 `target-version = ['py36', 'py37', 'py38']`  -> `target-version = [ 'py37', 'py38']` 

Check list:

- [ ] removing support for python 3.6 from CI