### PR TITLE
Add concurrency to cancel in-progress workflows for testing

### DIFF
--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -13,6 +13,11 @@ on:
       - "tests/run_cpu_tests.sh"
       - ".github/workflows/hvd-tests.yml"
 
+concurrency:
+  # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>
+  group: hvd-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   horovod-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -14,6 +14,7 @@ on:
       - ".github/workflows/hvd-tests.yml"
 
 concurrency:
+  # check auto-cancel
   # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>
   group: hvd-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -14,7 +14,6 @@ on:
       - ".github/workflows/hvd-tests.yml"
 
 concurrency:
-  # check auto-cancel
   # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>
   group: hvd-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -13,6 +13,11 @@ on:
       - "tests/run_tpu_tests.sh"
       - ".github/workflows/tpu-tests.yml"
 
+concurrency:
+  # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>
+  group: tpu-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   tpu-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,11 @@ on:
       - "requirements-dev.txt"
       - ".github/workflows/unit-tests.yml"
 
+concurrency:
+  # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>
+  group: unit-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fixes #{issue number}

Description:

This PR utilizes concurrency groups to cancel in-progress workflows for GH Actions for the following ci workflows:

- [x] unit-tests
- [x] tpu-tests
- [x] hvd-tests 

**Note:** for protected branches (like master) this works differently: every new commit doesn't cancel previous one.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
