### PR TITLE
fix broken sklearn link in docstring

### DIFF
--- a/ignite/contrib/metrics/regression/canberra_metric.py
+++ b/ignite/contrib/metrics/regression/canberra_metric.py
@@ -20,7 +20,7 @@ class CanberraMetric(_BaseRegression):
     - `y` and `y_pred` must be of same shape `(N, )` or `(N, 1)`.
 
     .. _scikit-learn distance metrics:
-        https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.DistanceMetric.html
+        https://scikit-learn.org/stable/modules/generated/sklearn.metrics.DistanceMetric.html
 
     Parameters are inherited from ``Metric.__init__``.
 

--- a/ignite/contrib/metrics/regression/manhattan_distance.py
+++ b/ignite/contrib/metrics/regression/manhattan_distance.py
@@ -19,7 +19,7 @@ class ManhattanDistance(_BaseRegression):
     - ``update`` must receive output of the form ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``.
     - `y` and `y_pred` must be of same shape `(N, )` or `(N, 1)`.
 
-    __ https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.DistanceMetric.html
+    __ https://scikit-learn.org/stable/modules/generated/sklearn.metrics.DistanceMetric.html
 
     Parameters are inherited from ``Metric.__init__``.
 


### PR DESCRIPTION
Description:

replace https://scikit-learn.org/stable/modules/generated/sklearn.neighbours.xxx by https://scikit-learn.org/stable/modules/generated/sklearn.metrics.xxx

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
