### PR TITLE
adding create_new to args StateParamScheduler

### DIFF
--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -123,9 +123,9 @@ class LambdaStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
-        create_new: whether to create ``param_name`` on 
-            ``engine.state`` taking into account whether 
-            ``param_name`` attribute already exists or not. 
+        create_new: whether to create ``param_name`` on
+            ``engine.state`` taking into account whether
+            ``param_name`` attribute already exists or not.
             Overrides existing attribute by default, (default=False).
 
     Examples:
@@ -204,9 +204,9 @@ class PiecewiseLinearStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
-        create_new: whether to create ``param_name`` on 
-            ``engine.state`` taking into account whether 
-            ``param_name`` attribute already exists or not. 
+        create_new: whether to create ``param_name`` on
+            ``engine.state`` taking into account whether
+            ``param_name`` attribute already exists or not.
             Overrides existing attribute by default, (default=False).
 
     Examples:
@@ -328,9 +328,9 @@ class ExpStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
-        create_new: whether to create ``param_name`` on 
-            ``engine.state`` taking into account whether 
-            ``param_name`` attribute already exists or not. 
+        create_new: whether to create ``param_name`` on
+            ``engine.state`` taking into account whether
+            ``param_name`` attribute already exists or not.
             Overrides existing attribute by default, (default=False).
 
     Examples:
@@ -395,9 +395,9 @@ class StepStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
-        create_new: whether to create ``param_name`` on 
-            ``engine.state`` taking into account whether 
-            ``param_name`` attribute already exists or not. 
+        create_new: whether to create ``param_name`` on
+            ``engine.state`` taking into account whether
+            ``param_name`` attribute already exists or not.
             Overrides existing attribute by default, (default=False).
 
     Examples:
@@ -473,9 +473,9 @@ class MultiStepStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
-        create_new: whether to create ``param_name`` on 
-            ``engine.state`` taking into account whether 
-            ``param_name`` attribute already exists or not. 
+        create_new: whether to create ``param_name`` on
+            ``engine.state`` taking into account whether
+            ``param_name`` attribute already exists or not.
             Overrides existing attribute by default, (default=False).
 
     Examples:

--- a/ignite/handlers/state_param_scheduler.py
+++ b/ignite/handlers/state_param_scheduler.py
@@ -123,6 +123,10 @@ class LambdaStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
+        create_new: whether to create ``param_name`` on 
+            ``engine.state`` taking into account whether 
+            ``param_name`` attribute already exists or not. 
+            Overrides existing attribute by default, (default=False).
 
     Examples:
 
@@ -200,6 +204,10 @@ class PiecewiseLinearStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
+        create_new: whether to create ``param_name`` on 
+            ``engine.state`` taking into account whether 
+            ``param_name`` attribute already exists or not. 
+            Overrides existing attribute by default, (default=False).
 
     Examples:
 
@@ -320,6 +328,10 @@ class ExpStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
+        create_new: whether to create ``param_name`` on 
+            ``engine.state`` taking into account whether 
+            ``param_name`` attribute already exists or not. 
+            Overrides existing attribute by default, (default=False).
 
     Examples:
 
@@ -383,6 +395,10 @@ class StepStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
+        create_new: whether to create ``param_name`` on 
+            ``engine.state`` taking into account whether 
+            ``param_name`` attribute already exists or not. 
+            Overrides existing attribute by default, (default=False).
 
     Examples:
 
@@ -457,6 +473,10 @@ class MultiStepStateScheduler(StateParamScheduler):
         param_name: name of parameter to update.
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
+        create_new: whether to create ``param_name`` on 
+            ``engine.state`` taking into account whether 
+            ``param_name`` attribute already exists or not. 
+            Overrides existing attribute by default, (default=False).
 
     Examples:
 


### PR DESCRIPTION
Description:

adds description of `create_new` argument under `args:`