### PR TITLE
removing 1.8.1 and 1.9.1 support for python 3.9

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -26,6 +26,10 @@ jobs:
             python-version: 3.9 
           - pytorch-version: 1.6.0
             python-version: 3.9 
+          - pytorch-version: 1.7.1
+            python-version: 3.9
+          - pytorch-version: 1.8.1
+            python-version: 3.9
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#2383

Description: removing python 3.9 PyTorch 1.8.1 and 1.7.1 support for PyTorch version tests
