### PR TITLE
solves  AttributeError: 'State' object has no attribute 'rng_states'

### DIFF
--- a/ignite/engine/deterministic.py
+++ b/ignite/engine/deterministic.py
@@ -185,8 +185,8 @@ class DeterministicEngine(Engine):
         self.add_event_handler(Events.DATALOADER_STOP_ITERATION | Events.TERMINATE_SINGLE_EPOCH, self._setup_seed)
 
     def state_dict(self) -> OrderedDict:
+        setattr(self.state, "rng_states", _get_rng_states())
         state_dict = super(DeterministicEngine, self).state_dict()
-        state_dict["rng_states"] = _get_rng_states()
         return state_dict
 
     def _init_run(self) -> None:

--- a/ignite/engine/deterministic.py
+++ b/ignite/engine/deterministic.py
@@ -185,8 +185,8 @@ class DeterministicEngine(Engine):
         self.add_event_handler(Events.DATALOADER_STOP_ITERATION | Events.TERMINATE_SINGLE_EPOCH, self._setup_seed)
 
     def state_dict(self) -> OrderedDict:
-        setattr(self.state, "rng_states", _get_rng_states())
         state_dict = super(DeterministicEngine, self).state_dict()
+        state_dict["rng_states"] = _get_rng_states()
         return state_dict
 
     def _init_run(self) -> None:

--- a/ignite/engine/deterministic.py
+++ b/ignite/engine/deterministic.py
@@ -179,6 +179,8 @@ class DeterministicEngine(Engine):
     def __init__(self, process_function: Callable[[Engine, Any], Any]):
         super(DeterministicEngine, self).__init__(process_function)
         self.state_dict_user_keys.append("rng_states")
+        if not hasattr(self.state, "rng_states"):
+            setattr(self.state, "rng_states", None)
         self.add_event_handler(Events.STARTED, self._init_run)
         self.add_event_handler(Events.DATALOADER_STOP_ITERATION | Events.TERMINATE_SINGLE_EPOCH, self._setup_seed)
 
@@ -189,9 +191,6 @@ class DeterministicEngine(Engine):
 
     def _init_run(self) -> None:
         self.state.seed = int(torch.randint(0, int(1e9), (1,)).item())
-        if not hasattr(self.state, "rng_states"):
-            setattr(self.state, "rng_states", None)
-
         if torch.cuda.is_available():
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -904,4 +904,3 @@ def test_state_dict():
     assert "max_epochs" in sd and sd["max_epochs"] is None
     assert "epoch_length" in sd and sd["epoch_length"] is None
     assert "rng_states" in sd and sd["rng_states"] is not None
-    

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -1,7 +1,7 @@
 import os
-from collections.abc import Mapping
 import random
 import sys
+from collections.abc import Mapping
 from unittest.mock import patch
 
 import numpy as np

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -904,17 +904,4 @@ def test_state_dict():
     assert "max_epochs" in sd and sd["max_epochs"] is None
     assert "epoch_length" in sd and sd["epoch_length"] is None
     assert "rng_states" in sd and sd["rng_states"] is not None
-
-    def _test(state):
-        engine.state = state
-        sd = engine.state_dict()
-        assert isinstance(sd, Mapping) and len(sd) == len(engine._state_dict_all_req_keys) + 1 + len(
-            engine.state_dict_user_keys
-        )
-        assert sd["iteration"] == engine.state.iteration
-        assert sd["epoch_length"] == engine.state.epoch_length
-        assert sd["max_epochs"] == engine.state.max_epochs
-        assert sd["rng_states"] == engine.state.rng_states
-
-    _test(State(iteration=500, epoch_length=1000, max_epochs=100, rng_states=None))
-    _test(State(epoch=5, epoch_length=1000, max_epochs=100, rng_states=None))
+    

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -12,7 +12,7 @@ from torch.optim import SGD
 from torch.utils.data import BatchSampler, DataLoader, RandomSampler
 
 import ignite.distributed as idist
-from ignite.engine import Events, State
+from ignite.engine import Events
 from ignite.engine.deterministic import (
     DeterministicEngine,
     ReproducibleBatchSampler,

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -903,7 +903,7 @@ def test_state_dict():
     assert "iteration" in sd and sd["iteration"] == 0
     assert "max_epochs" in sd and sd["max_epochs"] is None
     assert "epoch_length" in sd and sd["epoch_length"] is None
-    assert "rng_states" in sd and sd["rng_states"] is None
+    assert "rng_states" in sd and sd["rng_states"] is not None
 
     def _test(state):
         engine.state = state


### PR DESCRIPTION
Fixes #2197

Description:
```
e2 = DeterministicEngine(lambda e, b: None)
print(e2.state_dict())
```
**returns:**
AttributeError: 'State' object has no attribute 'rng_states'

Check list:

- [x] solves the AttributeError: 'State' object has no attribute 'rng_states'
- [ ] add test for the state_dict method