### PR TITLE
set master_addr master_port default values

### DIFF
--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -354,8 +354,8 @@ if has_native_dist_support:
             nproc_per_node: int = 1,
             nnodes: int = 1,
             node_rank: int = 0,
-            master_addr: Optional[str] = None,
-            master_port: Optional[int] = None,
+            master_addr: Optional[str] = "127.0.0.1",
+            master_port: Optional[int] = 2222,
             backend: str = "nccl",
             init_method: Optional[str] = None,
             **kwargs: Any,
@@ -380,10 +380,8 @@ if has_native_dist_support:
                 spawn_kwargs["start_method"] = kwargs.get("start_method", default_start_method)
                 start_processes = mp.start_processes
 
-            if init_method in [None, "env://"]:
+            if init_method is None:
                 init_method = "env://"
-                master_addr = "127.0.0.1"
-                master_port = 2222
 
             start_processes(
                 _NativeDistModel._dist_worker_task_fn,

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -386,6 +386,10 @@ if has_native_dist_support:
                     master_port = 2222
                 if master_addr is None:
                     master_addr = "127.0.0.1"
+            elif master_addr is not None:
+                raise ValueError("master_addr should be None if init_method is provided other then 'env://'")
+            elif master_port is not None:
+                raise ValueError("master_port should be None if init_method is provided other then 'env://'")
 
             start_processes(
                 _NativeDistModel._dist_worker_task_fn,

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -354,8 +354,8 @@ if has_native_dist_support:
             nproc_per_node: int = 1,
             nnodes: int = 1,
             node_rank: int = 0,
-            master_addr: Optional[str] = "127.0.0.1",
-            master_port: Optional[int] = 2222,
+            master_addr: Optional[str] = None,
+            master_port: Optional[int] = None,
             backend: str = "nccl",
             init_method: Optional[str] = None,
             **kwargs: Any,
@@ -380,8 +380,12 @@ if has_native_dist_support:
                 spawn_kwargs["start_method"] = kwargs.get("start_method", default_start_method)
                 start_processes = mp.start_processes
 
-            if init_method is None:
+            if init_method in [None, "env://"]:
                 init_method = "env://"
+                if master_port is None:
+                    master_port = 2222
+                if master_addr is None:
+                    master_addr = "127.0.0.1"
 
             start_processes(
                 _NativeDistModel._dist_worker_task_fn,


### PR DESCRIPTION
Fixes #2312

Description: Fix static `master_addr` `master_port` values in `spawn` method by setting default values in method prototype.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
