### PR TITLE
Update pytorch.org/ignite site and reference pytorch-ignite.ai #2325

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -129,7 +129,7 @@
       <div class="main-menu">
         <ul>
           <li>
-            <a href="{{ pathto('quickstart') }}">Quickstart</a>
+            <a href="{{ theme_variables.external_urls['quickstart'] }}">Quickstart</a>
           </li>
 
           <li>
@@ -141,7 +141,7 @@
           </li>
 
           <li>
-            <a href="{{ pathto('faq') }}">FAQ</a>
+            <a href="{{ theme_variables.external_urls['faq'] }}">FAQ</a>
           </li>
 
           <li>
@@ -149,7 +149,7 @@
           </li>
 
           <li>
-            <a href="{{ theme_variables.external_urls['home'] }}/master/about.html">About us</a> 
+            <a href="{{ theme_variables.external_urls['about_us'] }}">About us</a>
           </li>
 
         </ul>

--- a/docs/source/_templates/theme_variables.jinja
+++ b/docs/source/_templates/theme_variables.jinja
@@ -7,8 +7,9 @@
   'home': 'https://pytorch.org/ignite',
 
   'concepts': 'concepts.html',
-  'quickstart': 'quickstart.html',
+  'quickstart': 'https://pytorch-ignite.ai/tutorials/beginner/01-getting-started/',
   'examples': 'examples.html',
-  'faq': 'faq.html'
+  'faq': 'https://pytorch-ignite.ai/how-to-guides/',
+  'about_us': 'https://pytorch-ignite.ai/about/community/'
 }
 -%}


### PR DESCRIPTION
Related to #2325

Description: I've updated some of the links as specified in the associated tasks and updated docs accordingly

To test it
```
1. cd docs
2. make html
3. cd build/
4. python -m http.server 8989
```

Checked the links and they referencing the updated links instead of the old html.

**I didn't change the main URL (https://pytorch.org/ignite')  to the new URL because it will break the pages not available for the new URL (for instance: examples), will change the base to the new URL once all of the URLs are available on the (pytorch-ignite.ai/) URL**

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
