### PR TITLE
Add PyTorch Adapt to Readme toolkit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Toolkits
 - [Project MONAI - AI Toolkit for Healthcare Imaging](https://github.com/Project-MONAI/MONAI)
 - [DeepSeismic - Deep Learning for Seismic Imaging and Interpretation](https://github.com/microsoft/seismic-deeplearning)
 - [Nussl - a flexible, object-oriented Python audio source separation library](https://github.com/nussl/nussl)
+- [PyTorch Adapt - A fully featured and modular domain adaptation library](https://github.com/KevinMusgrave/pytorch-adapt)
 
 </details>
 


### PR DESCRIPTION
This PR adds PyTorch Adapt (a new domain adaptation library) to the [Projects using Ignite](https://github.com/pytorch/ignite#projects-using-ignite) section of the Readme.

Relevant links:

- [The main place where Ignite is used in the library](https://github.com/KevinMusgrave/pytorch-adapt/blob/main/src/pytorch_adapt/frameworks/ignite/ignite.py)

- [Example usage for end users](https://github.com/KevinMusgrave/pytorch-adapt/blob/main/examples/getting_started/DANNIgniteWithViz.ipynb)
