### PR TITLE
Switch formatting from black+isort to µfmt (black+µsort)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ coverage.xml
 /docs/src/
 /docs/build/
 /docs/source/generated/
+
+# Virtualenv
+.venv/
+.python-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,18 +14,13 @@ repos:
       - id: prettier
         exclude_types: ["python", "jupyter", "shell", "gitignore"]
 
-  - repo: https://github.com/python/black
-    rev: 21.12b0
+  - repo: https://github.com/omnilib/ufmt
+    rev: v1.3.1
     hooks:
-      - id: black
-        language_version: python3.8
-        args: ["--config", "pyproject.toml"]
-
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
-    hooks:
-      - id: isort
-        args: ["--settings", "setup.cfg"]
+      - id: ufmt
+        additional_dependencies:
+          - black == 21.12b0
+          - usort == 1.0.1
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,33 +110,34 @@ If you modify the code, you will most probably also need to code some tests to e
 - naming convention for files `test_*.py`, e.g. `test_precision.py`
 - naming of testing functions `def test_*`, e.g. `def test_precision_on_random_data()`
   - if test function should run on GPU, please **make sure to add `cuda`** in the test name, e.g. `def test_something_on_cuda()`.
-  Additionally, we may want to decorate it with `@pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU")`.
-  For more examples, please see https://github.com/pytorch/ignite/blob/master/tests/ignite/engine/test_create_supervised.py
+    Additionally, we may want to decorate it with `@pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU")`.
+    For more examples, please see https://github.com/pytorch/ignite/blob/master/tests/ignite/engine/test_create_supervised.py
   - if test function checks distributed configuration, we have to mark the test as `@pytest.mark.distributed` and additional
-  conditions depending on the intended checks. For example, please see
-  https://github.com/pytorch/ignite/blob/master/tests/ignite/metrics/test_accuracy.py
-
+    conditions depending on the intended checks. For example, please see
+    https://github.com/pytorch/ignite/blob/master/tests/ignite/metrics/test_accuracy.py
 
 New code should be compatible with Python 3.X versions. Once you finish implementing a feature or bugfix and tests,
 please run lint checking and tests:
 
 #### Formatting Code
 
-To ensure the codebase complies with a style guide, we use [flake8](https://flake8.pycqa.org/en/latest/),
-[black](https://black.readthedocs.io/en/stable/) and [isort](https://pycqa.github.io/isort/) tools to
-format and check codebase for compliance with PEP8.
+To ensure the codebase complies with a style guide, we use [flake8](https://flake8.pycqa.org/en/latest/)
+and [ufmt](https://ufmt.omnilib.dev/) ([black](https://black.readthedocs.io/en/stable/) and
+[usort](https://usort.readthedocs.io/en/stable/)) to format and check codebase for compliance with PEP8.
 
 ##### Formatting without pre-commit
 
 If you choose not to use pre-commit, you can take advantage of IDE extensions configured to black format or invoke
 black manually to format files and commit them.
 
-To install `flake8`, `black==21.12b0`, `isort==5.7.0` and `mypy`, please run
+To install `flake8`, `ufmt` and `mypy`, please run
+
 ```bash
 bash ./tests/run_code_style.sh install
 ```
 
 To format files and commit changes:
+
 ```bash
 # This should autoformat the files
 bash ./tests/run_code_style.sh fmt
@@ -147,10 +148,10 @@ git commit -m "Added awesome feature"
 
 ##### Formatting with pre-commit
 
-To automate the process, we have configured the repo with [pre-commit hooks](https://pre-commit.com/) to use black to autoformat the staged files to ensure every commit complies with a style guide. This requires some setup, which is described below:
+To automate the process, we have configured the repo with [pre-commit hooks](https://pre-commit.com/) to use µfmt to autoformat the staged files to ensure every commit complies with a style guide. This requires some setup, which is described below:
 
 1. Install pre-commit in your python environment.
-2. Run pre-commit install that configures a virtual environment to invoke black, isort and flake8 on commits.
+2. Run pre-commit install that configures a virtual environment to invoke ufmt and flake8 on commits.
 
 ```bash
 pip install pre-commit
@@ -158,16 +159,16 @@ pre-commit install
 ```
 
 3. When files are committed:
-   - If the stages files are not compliant with black, black will autoformat the staged files. If this were to happen, files should be staged and committed again. See example code below.
+   - If the stages files are not compliant with black or µsort, µfmt will autoformat the staged files. If this were to happen, files should be staged and committed again. See example code below.
    - If the staged files are not compliant with flake8, errors will be raised. These errors should be fixed and the files should be committed again. See example code below.
 
 ```bash
 git add .
 git commit -m "Added awesome feature"
 # DONT'T WORRY IF ERRORS ARE RAISED.
-# YOUR CODE IS NOT COMPLIANT WITH flake8, isort or black
+# YOUR CODE IS NOT COMPLIANT WITH flake8, µsort or black
 # Fix any flake8 errors by following their suggestions
-# isort and black will automatically format the files so they might look different, but you'll need to stage the files
+# µfmt will automatically format the files so they might look different, but you'll need to stage the files
 # again for committing
 # After fixing any flake8 errors
 git add .

--- a/examples/contrib/cifar10/main.py
+++ b/examples/contrib/cifar10/main.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import utils
-from torch.cuda.amp import GradScaler, autocast
+from torch.cuda.amp import autocast, GradScaler
 
 import ignite
 import ignite.distributed as idist

--- a/examples/contrib/cifar100_amp_benchmark/benchmark_fp32.py
+++ b/examples/contrib/cifar100_amp_benchmark/benchmark_fp32.py
@@ -6,7 +6,7 @@ from torchvision.models import wide_resnet50_2
 from utils import get_train_eval_loaders
 
 from ignite.contrib.handlers import ProgressBar
-from ignite.engine import Engine, Events, convert_tensor, create_supervised_evaluator
+from ignite.engine import convert_tensor, create_supervised_evaluator, Engine, Events
 from ignite.handlers import Timer
 from ignite.metrics import Accuracy, Loss
 

--- a/examples/contrib/cifar100_amp_benchmark/benchmark_nvidia_apex.py
+++ b/examples/contrib/cifar100_amp_benchmark/benchmark_nvidia_apex.py
@@ -7,7 +7,7 @@ from torchvision.models import wide_resnet50_2
 from utils import get_train_eval_loaders
 
 from ignite.contrib.handlers import ProgressBar
-from ignite.engine import Engine, Events, convert_tensor, create_supervised_evaluator
+from ignite.engine import convert_tensor, create_supervised_evaluator, Engine, Events
 from ignite.handlers import Timer
 from ignite.metrics import Accuracy, Loss
 

--- a/examples/contrib/cifar100_amp_benchmark/benchmark_torch_cuda_amp.py
+++ b/examples/contrib/cifar100_amp_benchmark/benchmark_torch_cuda_amp.py
@@ -1,13 +1,13 @@
 import fire
 import torch
-from torch.cuda.amp import GradScaler, autocast
+from torch.cuda.amp import autocast, GradScaler
 from torch.nn import CrossEntropyLoss
 from torch.optim import SGD
 from torchvision.models import wide_resnet50_2
 from utils import get_train_eval_loaders
 
 from ignite.contrib.handlers import ProgressBar
-from ignite.engine import Engine, Events, convert_tensor, create_supervised_evaluator
+from ignite.engine import convert_tensor, create_supervised_evaluator, Engine, Events
 from ignite.handlers import Timer
 from ignite.metrics import Accuracy, Loss
 

--- a/examples/contrib/cifar10_qat/main.py
+++ b/examples/contrib/cifar10_qat/main.py
@@ -6,13 +6,13 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import utils
-from torch.cuda.amp import GradScaler, autocast
+from torch.cuda.amp import autocast, GradScaler
 
 import ignite
 import ignite.distributed as idist
 from ignite.contrib.engines import common
 from ignite.contrib.handlers import PiecewiseLinear
-from ignite.engine import Engine, Events, create_supervised_evaluator
+from ignite.engine import create_supervised_evaluator, Engine, Events
 from ignite.handlers import Checkpoint, DiskSaver, global_step_from_engine
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import manual_seed, setup_logger

--- a/examples/contrib/mnist/mnist_with_clearml_logger.py
+++ b/examples/contrib/mnist/mnist_with_clearml_logger.py
@@ -24,13 +24,13 @@ from torchvision.transforms import Compose, Normalize, ToTensor
 from ignite.contrib.handlers.clearml_logger import (
     ClearMLLogger,
     ClearMLSaver,
+    global_step_from_engine,
     GradsHistHandler,
     GradsScalarHandler,
     WeightsHistHandler,
     WeightsScalarHandler,
-    global_step_from_engine,
 )
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.handlers import Checkpoint
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import setup_logger

--- a/examples/contrib/mnist/mnist_with_neptune_logger.py
+++ b/examples/contrib/mnist/mnist_with_neptune_logger.py
@@ -28,13 +28,13 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from ignite.contrib.handlers.neptune_logger import (
+    global_step_from_engine,
     GradsScalarHandler,
     NeptuneLogger,
     NeptuneSaver,
     WeightsScalarHandler,
-    global_step_from_engine,
 )
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.handlers import Checkpoint
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import setup_logger

--- a/examples/contrib/mnist/mnist_with_tensorboard_logger.py
+++ b/examples/contrib/mnist/mnist_with_tensorboard_logger.py
@@ -29,14 +29,14 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from ignite.contrib.handlers.tensorboard_logger import (
+    global_step_from_engine,
     GradsHistHandler,
     GradsScalarHandler,
     TensorboardLogger,
     WeightsHistHandler,
     WeightsScalarHandler,
-    global_step_from_engine,
 )
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.handlers import ModelCheckpoint
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import setup_logger

--- a/examples/contrib/mnist/mnist_with_tqdm_logger.py
+++ b/examples/contrib/mnist/mnist_with_tqdm_logger.py
@@ -9,7 +9,7 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from ignite.contrib.handlers import ProgressBar
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.metrics import Accuracy, Loss, RunningAverage
 
 

--- a/examples/contrib/mnist/mnist_with_visdom_logger.py
+++ b/examples/contrib/mnist/mnist_with_visdom_logger.py
@@ -28,12 +28,12 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from ignite.contrib.handlers.visdom_logger import (
+    global_step_from_engine,
     GradsScalarHandler,
     VisdomLogger,
     WeightsScalarHandler,
-    global_step_from_engine,
 )
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.handlers import ModelCheckpoint
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import setup_logger

--- a/examples/contrib/mnist/mnist_with_wandb_logger.py
+++ b/examples/contrib/mnist/mnist_with_wandb_logger.py
@@ -25,8 +25,8 @@ from torch.utils.data import DataLoader
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
-from ignite.contrib.handlers.wandb_logger import WandBLogger, global_step_from_engine
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.contrib.handlers.wandb_logger import global_step_from_engine, WandBLogger
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.handlers import ModelCheckpoint
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import setup_logger

--- a/examples/contrib/transformers/main.py
+++ b/examples/contrib/transformers/main.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import utils
-from torch.cuda.amp import GradScaler, autocast
+from torch.cuda.amp import autocast, GradScaler
 
 import ignite
 import ignite.distributed as idist

--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -9,7 +9,7 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 from tqdm import tqdm
 
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import setup_logger
 

--- a/examples/mnist/mnist_save_resume_engine.py
+++ b/examples/mnist/mnist_save_resume_engine.py
@@ -11,7 +11,7 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 from tqdm import tqdm
 
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.handlers import Checkpoint, DiskSaver
 from ignite.metrics import Accuracy, Loss
 from ignite.utils import manual_seed

--- a/examples/mnist/mnist_with_tensorboard.py
+++ b/examples/mnist/mnist_with_tensorboard.py
@@ -25,7 +25,7 @@ from torch.utils.data import DataLoader
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.metrics import Accuracy, Loss
 
 try:

--- a/examples/mnist/mnist_with_tensorboard_on_tpu.py
+++ b/examples/mnist/mnist_with_tensorboard_on_tpu.py
@@ -25,7 +25,7 @@ from torch.utils.tensorboard import SummaryWriter
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.metrics import Accuracy, Loss, RunningAverage
 
 try:

--- a/examples/mnist/mnist_with_visdom.py
+++ b/examples/mnist/mnist_with_visdom.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, Normalize, ToTensor
 
-from ignite.engine import Events, create_supervised_evaluator, create_supervised_trainer
+from ignite.engine import create_supervised_evaluator, create_supervised_trainer, Events
 from ignite.metrics import Accuracy, Loss
 
 try:

--- a/examples/references/classification/imagenet/code/scripts/training.py
+++ b/examples/references/classification/imagenet/code/scripts/training.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import torch
 from apex import amp
-from py_config_runner.config_utils import TRAINVAL_CONFIG, assert_config, get_params
+from py_config_runner.config_utils import assert_config, get_params, TRAINVAL_CONFIG
 from py_config_runner.utils import set_seed
 from utils import exp_tracking
 from utils.handlers import predictions_gt_images_handler
@@ -13,7 +13,7 @@ from utils.handlers import predictions_gt_images_handler
 import ignite
 import ignite.distributed as idist
 from ignite.contrib.engines import common
-from ignite.engine import Engine, Events, _prepare_batch, create_supervised_evaluator
+from ignite.engine import _prepare_batch, create_supervised_evaluator, Engine, Events
 from ignite.metrics import Accuracy, TopKCategoricalAccuracy
 from ignite.utils import setup_logger
 

--- a/examples/references/segmentation/pascal_voc2012/main.py
+++ b/examples/references/segmentation/pascal_voc2012/main.py
@@ -6,14 +6,14 @@ import fire
 import torch
 
 try:
-    from torch.cuda.amp import GradScaler, autocast
+    from torch.cuda.amp import autocast, GradScaler
 except ImportError:
     raise RuntimeError("Please, use recent PyTorch version, e.g. >=1.6.0")
 
 import dataflow as data
 import utils
 import vis
-from py_config_runner import ConfigObject, InferenceConfigSchema, TrainvalConfigSchema, get_params
+from py_config_runner import ConfigObject, get_params, InferenceConfigSchema, TrainvalConfigSchema
 
 import ignite.distributed as idist
 from ignite.contrib.engines import common

--- a/ignite/contrib/engines/__init__.py
+++ b/ignite/contrib/engines/__init__.py
@@ -1,1 +1,1 @@
-from ignite.contrib.engines.tbptt import Tbptt_Events, create_supervised_tbptt_trainer
+from ignite.contrib.engines.tbptt import create_supervised_tbptt_trainer, Tbptt_Events

--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -1,7 +1,7 @@
 import numbers
 import warnings
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence, Union, cast
+from typing import Any, Callable, cast, Dict, Iterable, Mapping, Optional, Sequence, Union
 
 import torch
 import torch.nn as nn
@@ -12,6 +12,7 @@ from torch.utils.data.distributed import DistributedSampler
 import ignite.distributed as idist
 from ignite.contrib.handlers import (
     ClearMLLogger,
+    global_step_from_engine,
     LRScheduler,
     MLflowLogger,
     NeptuneLogger,
@@ -20,7 +21,6 @@ from ignite.contrib.handlers import (
     TensorboardLogger,
     VisdomLogger,
     WandBLogger,
-    global_step_from_engine,
 )
 from ignite.contrib.handlers.base_logger import BaseLogger
 from ignite.contrib.metrics import GpuInfo

--- a/ignite/contrib/engines/tbptt.py
+++ b/ignite/contrib/engines/tbptt.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 from torch.optim.optimizer import Optimizer
 
-from ignite.engine import Engine, EventEnum, _prepare_batch
+from ignite.engine import _prepare_batch, Engine, EventEnum
 from ignite.utils import apply_to_tensor
 
 

--- a/ignite/contrib/handlers/__init__.py
+++ b/ignite/contrib/handlers/__init__.py
@@ -7,16 +7,15 @@ from ignite.contrib.handlers.tqdm_logger import ProgressBar
 from ignite.contrib.handlers.trains_logger import TrainsLogger
 from ignite.contrib.handlers.visdom_logger import VisdomLogger
 from ignite.contrib.handlers.wandb_logger import WandBLogger
-from ignite.handlers import EpochOutputStore  # ref
-from ignite.handlers import global_step_from_engine  # ref
+from ignite.handlers import EpochOutputStore, global_step_from_engine  # ref  # ref
 from ignite.handlers.lr_finder import FastaiLRFinder
 from ignite.handlers.param_scheduler import (
     ConcatScheduler,
     CosineAnnealingScheduler,
+    create_lr_scheduler_with_warmup,
     LinearCyclicalScheduler,
     LRScheduler,
     ParamGroupScheduler,
     PiecewiseLinear,
-    create_lr_scheduler_with_warmup,
 )
 from ignite.handlers.time_profilers import BasicTimeProfiler, HandlersTimeProfiler

--- a/ignite/contrib/handlers/param_scheduler.py
+++ b/ignite/contrib/handlers/param_scheduler.py
@@ -15,13 +15,13 @@ warnings.warn(deprecation_warning, DeprecationWarning, stacklevel=2)
 from ignite.handlers.param_scheduler import (
     ConcatScheduler,
     CosineAnnealingScheduler,
+    create_lr_scheduler_with_warmup,
     CyclicalScheduler,
     LinearCyclicalScheduler,
     LRScheduler,
     ParamGroupScheduler,
     ParamScheduler,
     PiecewiseLinear,
-    create_lr_scheduler_with_warmup,
 )
 
 __all__ = [

--- a/ignite/contrib/handlers/visdom_logger.py
+++ b/ignite/contrib/handlers/visdom_logger.py
@@ -1,6 +1,6 @@
 """Visdom logger and its helper handlers."""
 import os
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, cast, Dict, List, Optional, Union
 
 import torch
 import torch.nn as nn

--- a/ignite/contrib/metrics/regression/geometric_mean_relative_absolute_error.py
+++ b/ignite/contrib/metrics/regression/geometric_mean_relative_absolute_error.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, cast
+from typing import cast, List, Tuple
 
 import torch
 

--- a/ignite/distributed/auto.py
+++ b/ignite/distributed/auto.py
@@ -9,9 +9,7 @@ from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import Sampler
 
 from ignite.distributed import utils as idist
-from ignite.distributed.comp_models import horovod as idist_hvd
-from ignite.distributed.comp_models import native as idist_native
-from ignite.distributed.comp_models import xla as idist_xla
+from ignite.distributed.comp_models import horovod as idist_hvd, native as idist_native, xla as idist_xla
 from ignite.utils import setup_logger
 
 __all__ = ["auto_dataloader", "auto_model", "auto_optim", "DistributedProxySampler"]

--- a/ignite/distributed/comp_models/__init__.py
+++ b/ignite/distributed/comp_models/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Tuple, Type, Union
+from typing import List, Tuple, Type, TYPE_CHECKING, Union
 
 from ignite.distributed.comp_models.base import _SerialModel
 from ignite.distributed.comp_models.horovod import has_hvd_support

--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from numbers import Number
-from typing import Any, Callable, List, Optional, Union, cast
+from typing import Any, Callable, cast, List, Optional, Union
 
 import torch
 

--- a/ignite/distributed/comp_models/horovod.py
+++ b/ignite/distributed/comp_models/horovod.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Callable, Mapping, Optional, Tuple, cast
+from typing import Any, Callable, cast, Mapping, Optional, Tuple
 
 import torch
 

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import warnings
 from distutils.version import LooseVersion
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union, cast
+from typing import Any, Callable, cast, Dict, List, Mapping, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist

--- a/ignite/distributed/comp_models/xla.py
+++ b/ignite/distributed/comp_models/xla.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Mapping, Optional, Tuple, cast
+from typing import Any, Callable, cast, Mapping, Optional, Tuple
 
 import torch
 

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -4,7 +4,7 @@ import math
 import time
 import warnings
 import weakref
-from collections import OrderedDict, defaultdict
+from collections import defaultdict, OrderedDict
 from collections.abc import Mapping
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -2,7 +2,7 @@ import numbers
 import weakref
 from enum import Enum
 from types import DynamicClassAttribute
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TYPE_CHECKING, Union
 
 from torch.utils.data import DataLoader
 

--- a/ignite/handlers/__init__.py
+++ b/ignite/handlers/__init__.py
@@ -10,13 +10,13 @@ from ignite.handlers.param_scheduler import (
     BaseParamScheduler,
     ConcatScheduler,
     CosineAnnealingScheduler,
+    create_lr_scheduler_with_warmup,
     CyclicalScheduler,
     LinearCyclicalScheduler,
     LRScheduler,
     ParamGroupScheduler,
     ParamScheduler,
     PiecewiseLinear,
-    create_lr_scheduler_with_warmup,
 )
 from ignite.handlers.state_param_scheduler import (
     ExpStateScheduler,

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -6,7 +6,7 @@ import tempfile
 import warnings
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
-from typing import IO, Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Tuple, Union
+from typing import Any, Callable, Dict, IO, List, Mapping, NamedTuple, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn

--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Callable, Mapping, Optional, cast
+from typing import Callable, cast, Mapping, Optional
 
 from ignite.base import Serializable
 from ignite.engine import Engine

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -6,7 +6,7 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from copy import copy
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union, cast
+from typing import Any, cast, Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
 import torch
 from torch.optim.lr_scheduler import _LRScheduler

--- a/ignite/handlers/time_profilers.py
+++ b/ignite/handlers/time_profilers.py
@@ -1,6 +1,6 @@
 import functools
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Mapping, Sequence, Tuple, Union, cast
+from typing import Any, Callable, cast, Dict, List, Mapping, Sequence, Tuple, Union
 
 import torch
 

--- a/ignite/metrics/epoch_metric.py
+++ b/ignite/metrics/epoch_metric.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, List, Tuple, Union, cast
+from typing import Callable, cast, List, Tuple, Union
 
 import torch
 

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, Sequence, Union
 
 import torch
 
-from ignite.metrics.gan.utils import InceptionModel, _BaseInceptionMetric
+from ignite.metrics.gan.utils import _BaseInceptionMetric, InceptionModel
 from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce
 
 __all__ = [

--- a/ignite/metrics/gan/inception_score.py
+++ b/ignite/metrics/gan/inception_score.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional, Union
 import torch
 
 from ignite.exceptions import NotComputableError
-from ignite.metrics.gan.utils import InceptionModel, _BaseInceptionMetric
+from ignite.metrics.gan.utils import _BaseInceptionMetric, InceptionModel
 
 # These decorators helps with distributed settings
 from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce

--- a/ignite/metrics/loss.py
+++ b/ignite/metrics/loss.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Sequence, Tuple, Union, cast
+from typing import Callable, cast, Dict, Sequence, Tuple, Union
 
 import torch
 

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from functools import wraps
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import torch
 

--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -1,4 +1,4 @@
-from typing import Callable, Sequence, Union, cast
+from typing import Callable, cast, Sequence, Union
 
 import torch
 

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Sequence, Union, cast
+from typing import Callable, cast, Optional, Sequence, Union
 
 import torch
 

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -6,7 +6,7 @@ import random
 import shutil
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, TextIO, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Callable, cast, Dict, Optional, TextIO, Tuple, Type, TypeVar, Union
 
 import torch
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,27 @@ exclude = '''
                      # the root of the project
 )
 '''
+
+[tool.usort.known]
+first_party = [
+    "ignite",
+]
+third_party = [
+    "clearml",
+    "dill",
+    "matplotlib",
+    "numpy",
+    "pkg_resources",
+    "pytest",
+    "requests",
+    "setuptools",
+    "skimage",
+    "sklearn",
+    "torch",
+    "torchvision",
+]
+
+[tool.ufmt]
+excludes = [
+    "assets/",
+]

--- a/tests/ignite/contrib/engines/test_common.py
+++ b/tests/ignite/contrib/engines/test_common.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, call
+from unittest.mock import call, MagicMock
 
 import pytest
 import torch

--- a/tests/ignite/contrib/engines/test_tbptt.py
+++ b/tests/ignite/contrib/engines/test_tbptt.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 
-from ignite.contrib.engines import Tbptt_Events, create_supervised_tbptt_trainer
+from ignite.contrib.engines import create_supervised_tbptt_trainer, Tbptt_Events
 from ignite.contrib.engines.tbptt import _detach_hidden
 
 

--- a/tests/ignite/contrib/handlers/test_base_logger.py
+++ b/tests/ignite/contrib/handlers/test_base_logger.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, call
+from unittest.mock import call, MagicMock
 
 import pytest
 import torch

--- a/tests/ignite/contrib/handlers/test_clearml_logger.py
+++ b/tests/ignite/contrib/handlers/test_clearml_logger.py
@@ -1,7 +1,7 @@
 import math
 import os
 from collections import defaultdict
-from unittest.mock import ANY, MagicMock, Mock, call
+from unittest.mock import ANY, call, MagicMock, Mock
 
 import clearml
 import pytest
@@ -13,13 +13,13 @@ import ignite.distributed as idist
 from ignite.contrib.handlers.clearml_logger import (
     ClearMLLogger,
     ClearMLSaver,
+    global_step_from_engine,
     GradsHistHandler,
     GradsScalarHandler,
     OptimizerParamsHandler,
     OutputHandler,
     WeightsHistHandler,
     WeightsScalarHandler,
-    global_step_from_engine,
 )
 from ignite.contrib.handlers.trains_logger import TrainsLogger
 from ignite.engine import Engine, Events, State

--- a/tests/ignite/contrib/handlers/test_mlflow_logger.py
+++ b/tests/ignite/contrib/handlers/test_mlflow_logger.py
@@ -1,15 +1,15 @@
 import os
 import sys
-from unittest.mock import MagicMock, call
+from unittest.mock import call, MagicMock
 
 import pytest
 import torch
 
 from ignite.contrib.handlers.mlflow_logger import (
+    global_step_from_engine,
     MLflowLogger,
     OptimizerParamsHandler,
     OutputHandler,
-    global_step_from_engine,
 )
 from ignite.engine import Engine, Events, State
 

--- a/tests/ignite/contrib/handlers/test_neptune_logger.py
+++ b/tests/ignite/contrib/handlers/test_neptune_logger.py
@@ -2,20 +2,20 @@ import math
 import os
 import sys
 import warnings
-from unittest.mock import ANY, MagicMock, call
+from unittest.mock import ANY, call, MagicMock
 
 import pytest
 import torch
 
 import ignite.distributed as idist
 from ignite.contrib.handlers.neptune_logger import (
+    global_step_from_engine,
     GradsScalarHandler,
     NeptuneLogger,
     NeptuneSaver,
     OptimizerParamsHandler,
     OutputHandler,
     WeightsScalarHandler,
-    global_step_from_engine,
 )
 from ignite.engine import Engine, Events, State
 from ignite.handlers.checkpoint import Checkpoint

--- a/tests/ignite/contrib/handlers/test_polyaxon_logger.py
+++ b/tests/ignite/contrib/handlers/test_polyaxon_logger.py
@@ -1,14 +1,14 @@
 import os
-from unittest.mock import MagicMock, call
+from unittest.mock import call, MagicMock
 
 import pytest
 import torch
 
 from ignite.contrib.handlers.polyaxon_logger import (
+    global_step_from_engine,
     OptimizerParamsHandler,
     OutputHandler,
     PolyaxonLogger,
-    global_step_from_engine,
 )
 from ignite.engine import Engine, Events, State
 

--- a/tests/ignite/contrib/handlers/test_tensorboard_logger.py
+++ b/tests/ignite/contrib/handlers/test_tensorboard_logger.py
@@ -1,11 +1,12 @@
 import math
 import os
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import ANY, call, MagicMock, patch
 
 import pytest
 import torch
 
 from ignite.contrib.handlers.tensorboard_logger import (
+    global_step_from_engine,
     GradsHistHandler,
     GradsScalarHandler,
     OptimizerParamsHandler,
@@ -13,7 +14,6 @@ from ignite.contrib.handlers.tensorboard_logger import (
     TensorboardLogger,
     WeightsHistHandler,
     WeightsScalarHandler,
-    global_step_from_engine,
 )
 from ignite.engine import Engine, Events, State
 

--- a/tests/ignite/contrib/handlers/test_visdom_logger.py
+++ b/tests/ignite/contrib/handlers/test_visdom_logger.py
@@ -1,17 +1,17 @@
 import sys
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import ANY, call, MagicMock, patch
 
 import pytest
 import torch
 
 from ignite.contrib.handlers.visdom_logger import (
+    _DummyExecutor,
+    global_step_from_engine,
     GradsScalarHandler,
     OptimizerParamsHandler,
     OutputHandler,
     VisdomLogger,
     WeightsScalarHandler,
-    _DummyExecutor,
-    global_step_from_engine,
 )
 from ignite.engine import Engine, Events, State
 

--- a/tests/ignite/contrib/handlers/test_wandb_logger.py
+++ b/tests/ignite/contrib/handlers/test_wandb_logger.py
@@ -1,13 +1,13 @@
-from unittest.mock import MagicMock, call
+from unittest.mock import call, MagicMock
 
 import pytest
 import torch
 
 from ignite.contrib.handlers.wandb_logger import (
+    global_step_from_engine,
     OptimizerParamsHandler,
     OutputHandler,
     WandBLogger,
-    global_step_from_engine,
 )
 from ignite.engine import Events, State
 

--- a/tests/ignite/distributed/comp_models/test_base.py
+++ b/tests/ignite/distributed/comp_models/test_base.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from ignite.distributed.comp_models.base import ComputationModel, _SerialModel
+from ignite.distributed.comp_models.base import _SerialModel, ComputationModel
 
 
 def test_serial_model():

--- a/tests/ignite/distributed/comp_models/test_xla.py
+++ b/tests/ignite/distributed/comp_models/test_xla.py
@@ -196,7 +196,7 @@ def main_fold(fold):
 def test__xla_dist_model_run_parallel_n_threads_without_sync():
     # tests issue : https://github.com/pytorch/ignite/issues/1096
     import torch_xla.core.xla_model as xm
-    from joblib import Parallel, delayed
+    from joblib import delayed, Parallel
 
     devices = xm.get_xla_supported_devices()
     folds = 1

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -11,7 +11,7 @@ from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import BatchSampler, RandomSampler, Sampler, SequentialSampler, WeightedRandomSampler
 
 import ignite.distributed as idist
-from ignite.distributed.auto import DistributedProxySampler, auto_dataloader, auto_model, auto_optim
+from ignite.distributed.auto import auto_dataloader, auto_model, auto_optim, DistributedProxySampler
 
 
 class DummyDS(Dataset):

--- a/tests/ignite/engine/test_create_supervised.py
+++ b/tests/ignite/engine/test_create_supervised.py
@@ -14,11 +14,11 @@ from torch.optim import SGD
 
 import ignite.distributed as idist
 from ignite.engine import (
-    Engine,
-    Events,
     _check_arg,
     create_supervised_evaluator,
     create_supervised_trainer,
+    Engine,
+    Events,
     supervised_evaluation_step,
     supervised_evaluation_step_amp,
     supervised_training_step_tpu,

--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -14,10 +14,10 @@ from torch.utils.data import BatchSampler, DataLoader, RandomSampler
 import ignite.distributed as idist
 from ignite.engine import Events
 from ignite.engine.deterministic import (
-    DeterministicEngine,
-    ReproducibleBatchSampler,
     _set_rng_states,
+    DeterministicEngine,
     keep_random_state,
+    ReproducibleBatchSampler,
     update_dataloader,
 )
 from ignite.utils import manual_seed

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -1,6 +1,6 @@
 import os
 import time
-from unittest.mock import MagicMock, Mock, call
+from unittest.mock import call, MagicMock, Mock
 
 import numpy as np
 import pytest

--- a/tests/ignite/engine/test_event_handlers.py
+++ b/tests/ignite/engine/test_event_handlers.py
@@ -1,6 +1,6 @@
 import functools
 import gc
-from unittest.mock import MagicMock, call, create_autospec
+from unittest.mock import call, create_autospec, MagicMock
 
 import pytest
 from pytest import raises

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -12,7 +12,7 @@ from pkg_resources import parse_version
 
 import ignite.distributed as idist
 from ignite.engine import Engine, Events, State
-from ignite.handlers import Checkpoint, DiskSaver, EarlyStopping, ModelCheckpoint, global_step_from_engine
+from ignite.handlers import Checkpoint, DiskSaver, EarlyStopping, global_step_from_engine, ModelCheckpoint
 from ignite.handlers.checkpoint import BaseSaveHandler
 
 _PREFIX = "PREFIX"

--- a/tests/ignite/handlers/test_lr_finder.py
+++ b/tests/ignite/handlers/test_lr_finder.py
@@ -12,7 +12,7 @@ from torch.optim import SGD
 
 import ignite.distributed as idist
 from ignite.contrib.handlers import FastaiLRFinder
-from ignite.engine import Engine, Events, create_supervised_trainer
+from ignite.engine import create_supervised_trainer, Engine, Events
 
 matplotlib.use("agg")
 

--- a/tests/ignite/handlers/test_param_scheduler.py
+++ b/tests/ignite/handlers/test_param_scheduler.py
@@ -9,12 +9,12 @@ from ignite.engine import Engine, Events
 from ignite.handlers.param_scheduler import (
     ConcatScheduler,
     CosineAnnealingScheduler,
+    create_lr_scheduler_with_warmup,
     LinearCyclicalScheduler,
     LRScheduler,
     ParamGroupScheduler,
     ParamScheduler,
     PiecewiseLinear,
-    create_lr_scheduler_with_warmup,
 )
 from tests.ignite.contrib.handlers import MockFP16DeepSpeedZeroOptimizer
 

--- a/tests/ignite/metrics/gan/test_utils.py
+++ b/tests/ignite/metrics/gan/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torchvision
 
-from ignite.metrics.gan.utils import InceptionModel, _BaseInceptionMetric
+from ignite.metrics.gan.utils import _BaseInceptionMetric, InceptionModel
 
 
 class DummyInceptionMetric(_BaseInceptionMetric):

--- a/tests/ignite/metrics/nlp/test_bleu.py
+++ b/tests/ignite/metrics/nlp/test_bleu.py
@@ -4,7 +4,7 @@ from collections import Counter
 
 import pytest
 import torch
-from nltk.translate.bleu_score import SmoothingFunction, corpus_bleu, sentence_bleu
+from nltk.translate.bleu_score import corpus_bleu, sentence_bleu, SmoothingFunction
 
 import ignite.distributed as idist
 from ignite.exceptions import NotComputableError

--- a/tests/ignite/metrics/nlp/test_rouge.py
+++ b/tests/ignite/metrics/nlp/test_rouge.py
@@ -8,7 +8,7 @@ import torch
 import ignite.distributed as idist
 from ignite.exceptions import NotComputableError
 from ignite.metrics.nlp import Rouge
-from ignite.metrics.nlp.rouge import RougeL, RougeN, compute_ngram_scores
+from ignite.metrics.nlp.rouge import compute_ngram_scores, RougeL, RougeN
 
 from . import CorpusForTest
 

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -8,7 +8,7 @@ from sklearn.metrics import accuracy_score, confusion_matrix, precision_score, r
 import ignite.distributed as idist
 from ignite.exceptions import NotComputableError
 from ignite.metrics import ConfusionMatrix, IoU, JaccardIndex, mIoU
-from ignite.metrics.confusion_matrix import DiceCoefficient, cmAccuracy, cmPrecision, cmRecall
+from ignite.metrics.confusion_matrix import cmAccuracy, cmPrecision, cmRecall, DiceCoefficient
 
 torch.manual_seed(12)
 

--- a/tests/run_code_style.bat
+++ b/tests/run_code_style.bat
@@ -8,7 +8,7 @@ goto end
 
 :lint
 flake8 ignite tests examples --config setup.cfg
-ufmt check .
+ufmt diff .
 goto end
 
 :fmt

--- a/tests/run_code_style.bat
+++ b/tests/run_code_style.bat
@@ -20,7 +20,7 @@ mypy --config-file mypy.ini
 goto end
 
 :install
-pip install flake8 "black==21.12b0" "usort==1.0.1" "ufmt==1.3.1.post1" "mypy==0.910"
+pip install flake8 "black==21.12b0" "usort==1.0.1" "ufmt==1.3.1.post1" "mypy"
 goto end
 
 :end

--- a/tests/run_code_style.bat
+++ b/tests/run_code_style.bat
@@ -8,13 +8,11 @@ goto end
 
 :lint
 flake8 ignite tests examples --config setup.cfg
-isort . --check --settings setup.cfg
-black . --check --config pyproject.toml
+ufmt check .
 goto end
 
 :fmt
-isort . --settings setup.cfg
-black . --config pyproject.toml
+ufmt format .
 goto end
 
 :mypy
@@ -22,7 +20,7 @@ mypy --config-file mypy.ini
 goto end
 
 :install
-pip install flake8 "black==21.12b0" "isort==5.7.0" "mypy==0.910"
+pip install flake8 "black==21.12b0" "usort==1.0.1" "ufmt==1.3.1.post1" "mypy==0.910"
 goto end
 
 :end

--- a/tests/run_code_style.sh
+++ b/tests/run_code_style.sh
@@ -10,5 +10,5 @@ elif [ $1 = "fmt" ]; then
 elif [ $1 = "mypy" ]; then
     mypy --config-file mypy.ini
 elif [ $1 = "install" ]; then
-    pip install flake8 "black==21.12b0" "usort==1.0.1" "ufmt==1.3.1.post1" "mypy==0.910"
+    pip install flake8 "black==21.12b0" "usort==1.0.1" "ufmt==1.3.1.post1" "mypy"
 fi

--- a/tests/run_code_style.sh
+++ b/tests/run_code_style.sh
@@ -4,13 +4,11 @@ set -xeu
 
 if [ $1 = "lint" ]; then
     flake8 ignite tests examples --config setup.cfg
-    isort . --check --settings setup.cfg
-    black . --check --config pyproject.toml
+    ufmt diff .
 elif [ $1 = "fmt" ]; then
-    isort . --settings setup.cfg
-    black . --config pyproject.toml
+    ufmt format .
 elif [ $1 = "mypy" ]; then
     mypy --config-file mypy.ini
 elif [ $1 = "install" ]; then
-    pip install flake8 "black==21.12b0" "isort==5.7.0" "mypy"
+    pip install flake8 "black==21.12b0" "usort==1.0.1" "ufmt==1.3.1.post1" "mypy==0.910"
 fi


### PR DESCRIPTION
Description:

This switches linting, formatting, and pre-commit checks from using black and isort directly to using [µfmt](https://ufmt.omnilib.dev), which runs [µsort](https://usort.readthedocs.io) and black as an atomic formatting step. This matches what torchvision uses (pytorch/vision#4384).

Covered files were formatted using `./tests/run_code_style.sh fmt` and `pre-commit run` validated the results.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
