### PR TITLE
Fix docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,10 +68,12 @@ togglebutton_hint = "Show default setup"
 togglebutton_hint_hide = "Hide default setup"
 
 # Copy defaults.rst to source/generated to be discoverable in docstrings
-src_folder = os.path.dirname(__file__)
-gen_folder = os.path.join(src_folder, "generated")
-os.makedirs(gen_folder, exist_ok=True)
-shutil.copy(os.path.join(src_folder, "defaults.rst"), gen_folder)
+# Skip this step for previous versions of ignite
+if os.path.exists("defaults.rst"):
+    src_folder = os.path.dirname(__file__)
+    gen_folder = os.path.join(src_folder, "generated")
+    os.makedirs(gen_folder, exist_ok=True)
+    shutil.copy(os.path.join(src_folder, "defaults.rst"), gen_folder)
 
 # katex options
 katex_prerender = True


### PR DESCRIPTION
Fixes #2464 

Description: After #2457, the docs builds failed due to mention of the new file (`defaults.rst`) in the master `conf.py` which is used to build docs for all other versions as well. For now, this PR skips the copy operation when the file is not found to make the `conf.py` compatible with other versions.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
