### PR TITLE
Fixed test in test_precision_recall_curve and tests/ignite/contrib/metrics/regression

### DIFF
--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -138,7 +138,7 @@ class CallableEventWithFilter:
         return EventsList() | self | other
 
 
-class EventEnum(CallableEventWithFilter, Enum):  # type: ignore[misc]
+class EventEnum(CallableEventWithFilter, Enum):
     """Base class for all :class:`~ignite.engine.events.Events`. User defined custom events should also inherit
     this class.
 

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
@@ -150,12 +150,10 @@ def _test_distrib_compute(device):
 
 
 def _test_distrib_integration(device):
-
-    rank = idist.get_rank()
-    torch.manual_seed(12)
-
     def _test(n_epochs, metric_device):
         metric_device = torch.device(metric_device)
+        rank = idist.get_rank()
+        torch.manual_seed(rank)
         n_iters = 80
         size = 105
 
@@ -187,7 +185,7 @@ def _test_distrib_integration(device):
         e = np.abs(np_y_true - np_y_preds)
         np_res = np.median(e)
 
-        assert pytest.approx(res, rel=1) == np_res
+        assert pytest.approx(res, rel=1e-3) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
@@ -185,7 +185,7 @@ def _test_distrib_integration(device):
         e = np.abs(np_y_true - np_y_preds)
         np_res = np.median(e)
 
-        assert pytest.approx(res, rel=1e-3) == np_res
+        assert pytest.approx(res) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
@@ -160,8 +160,8 @@ def _test_distrib_integration(device):
         size = 105
 
         offset = n_iters * size
-        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
-        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
+        y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
 
         def update(engine, i):
             return (
@@ -187,7 +187,7 @@ def _test_distrib_integration(device):
         e = np.abs(np_y_true - np_y_preds)
         np_res = np.median(e)
 
-        assert pytest.approx(res) == np_res
+        assert pytest.approx(res, rel=1) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_error.py
@@ -158,13 +158,15 @@ def _test_distrib_integration(device):
         metric_device = torch.device(metric_device)
         n_iters = 80
         size = 105
-        y_true = torch.rand(size=(size,)).to(device)
-        y_preds = torch.rand(size=(size,)).to(device)
+
+        offset = n_iters * size
+        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
 
         def update(engine, i):
             return (
-                y_preds[i * size : (i + 1) * size],
-                y_true[i * size : (i + 1) * size],
+                y_preds[i * size + rank * offset : (i + 1) * size + rank * offset],
+                y_true[i * size + rank * offset : (i + 1) * size + rank * offset],
             )
 
         engine = Engine(update)

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -159,13 +159,15 @@ def _test_distrib_integration(device):
         metric_device = torch.device(metric_device)
         n_iters = 80
         size = 105
-        y_true = torch.rand(size=(size,)).to(device)
-        y_preds = torch.rand(size=(size,)).to(device)
+
+        offset = n_iters * size
+        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
 
         def update(engine, i):
             return (
-                y_preds[i * size : (i + 1) * size],
-                y_true[i * size : (i + 1) * size],
+                y_preds[i * size + rank * offset : (i + 1) * size + rank * offset],
+                y_true[i * size + rank * offset : (i + 1) * size + rank * offset],
             )
 
         engine = Engine(update)

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -151,12 +151,10 @@ def _test_distrib_compute(device):
 
 
 def _test_distrib_integration(device):
-
-    rank = idist.get_rank()
-    torch.manual_seed(12)
-
     def _test(n_epochs, metric_device):
         metric_device = torch.device(metric_device)
+        rank = idist.get_rank()
+        torch.manual_seed(rank)
         n_iters = 80
         size = 105
 

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -193,9 +193,9 @@ def _test_distrib_integration(device):
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837
         if np_y_preds.shape[0] % 2 == 0:
-            assert pytest.approx(res, rel=1e-2) == np_res_prepend
+            assert pytest.approx(res) == np_res_prepend
         else:
-            assert pytest.approx(res, rel=1e-2) == np_res
+            assert pytest.approx(res) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_absolute_percentage_error.py
@@ -161,8 +161,8 @@ def _test_distrib_integration(device):
         size = 105
 
         offset = n_iters * size
-        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
-        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
+        y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
 
         def update(engine, i):
             return (
@@ -195,9 +195,9 @@ def _test_distrib_integration(device):
         # when the length of the array/tensor is even. So this is a hack to avoid that.
         # issue: https://github.com/pytorch/pytorch/issues/1837
         if np_y_preds.shape[0] % 2 == 0:
-            assert pytest.approx(res) == np_res_prepend
+            assert pytest.approx(res, rel=1e-2) == np_res_prepend
         else:
-            assert pytest.approx(res) == np_res
+            assert pytest.approx(res, rel=1e-2) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
@@ -161,8 +161,8 @@ def _test_distrib_integration(device):
         size = 151
 
         offset = n_iters * size
-        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
-        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
+        y_true = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.rand(size=(offset * idist.get_world_size(),)).to(device)
 
         def update(engine, i):
             return (
@@ -188,7 +188,7 @@ def _test_distrib_integration(device):
         e = np.abs(np_y_true - np_y_preds) / np.abs(np_y_true - np_y_true.mean())
         np_res = np.median(e)
 
-        assert pytest.approx(res) == np_res
+        assert pytest.approx(res, rel=1e-3) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
@@ -151,12 +151,10 @@ def _test_distrib_compute(device):
 
 
 def _test_distrib_integration(device):
-
-    rank = idist.get_rank()
-    torch.manual_seed(12)
-
     def _test(n_epochs, metric_device):
         metric_device = torch.device(metric_device)
+        rank = idist.get_rank()
+        torch.manual_seed(rank)
         n_iters = 80
         size = 151
 

--- a/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
@@ -159,13 +159,15 @@ def _test_distrib_integration(device):
         metric_device = torch.device(metric_device)
         n_iters = 80
         size = 151
-        y_true = torch.rand(size=(size,)).to(device)
-        y_preds = torch.rand(size=(size,)).to(device)
+
+        offset = n_iters * size
+        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
 
         def update(engine, i):
             return (
-                y_preds[i * size : (i + 1) * size],
-                y_true[i * size : (i + 1) * size],
+                y_preds[i * size + rank * offset : (i + 1) * size + rank * offset],
+                y_true[i * size + rank * offset : (i + 1) * size + rank * offset],
             )
 
         engine = Engine(update)

--- a/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/contrib/metrics/regression/test_median_relative_absolute_error.py
@@ -186,7 +186,7 @@ def _test_distrib_integration(device):
         e = np.abs(np_y_true - np_y_preds) / np.abs(np_y_true - np_y_true.mean())
         np_res = np.median(e)
 
-        assert pytest.approx(res, rel=1e-3) == np_res
+        assert pytest.approx(res) == np_res
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/test_precision_recall_curve.py
+++ b/tests/ignite/contrib/metrics/test_precision_recall_curve.py
@@ -194,7 +194,6 @@ def _test_distrib_compute(device):
 
 
 def _test_distrib_integration(device):
-
     def _test(n_epochs, metric_device):
         metric_device = torch.device(metric_device)
         rank = idist.get_rank()

--- a/tests/ignite/contrib/metrics/test_precision_recall_curve.py
+++ b/tests/ignite/contrib/metrics/test_precision_recall_curve.py
@@ -231,9 +231,9 @@ def _test_distrib_integration(device):
         assert precision.shape == sk_precision.shape
         assert recall.shape == sk_recall.shape
         assert thresholds.shape == sk_thresholds.shape
-        assert pytest.approx(precision.cpu().numpy()) == sk_precision
-        assert pytest.approx(recall.cpu().numpy()) == sk_recall
-        assert pytest.approx(thresholds.cpu().numpy()) == sk_thresholds
+        assert pytest.approx(precision.cpu().numpy(), rel=1e-1) == sk_precision
+        assert pytest.approx(recall.cpu().numpy(), rel=1e-1) == sk_recall
+        assert pytest.approx(thresholds.cpu().numpy(), rel=1e-1) == sk_thresholds
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/test_precision_recall_curve.py
+++ b/tests/ignite/contrib/metrics/test_precision_recall_curve.py
@@ -231,9 +231,9 @@ def _test_distrib_integration(device):
         assert precision.shape == sk_precision.shape
         assert recall.shape == sk_recall.shape
         assert thresholds.shape == sk_thresholds.shape
-        assert pytest.approx(precision.cpu().numpy(), rel=1e-1) == sk_precision
-        assert pytest.approx(recall.cpu().numpy(), rel=1e-1) == sk_recall
-        assert pytest.approx(thresholds.cpu().numpy(), rel=1e-1) == sk_thresholds
+        assert pytest.approx(precision.cpu().numpy(), rel=1e-3) == sk_precision
+        assert pytest.approx(recall.cpu().numpy(), rel=1e-3) == sk_recall
+        assert pytest.approx(thresholds.cpu().numpy(), rel=1e-3) == sk_thresholds
 
     metric_devices = ["cpu"]
     if device.type != "xla":

--- a/tests/ignite/contrib/metrics/test_precision_recall_curve.py
+++ b/tests/ignite/contrib/metrics/test_precision_recall_curve.py
@@ -202,13 +202,15 @@ def _test_distrib_integration(device):
         metric_device = torch.device(metric_device)
         n_iters = 80
         size = 151
-        y_true = torch.randint(0, 2, (size,)).to(device)
-        y_preds = torch.randint(0, 2, (size,)).to(device)
+
+        offset = n_iters * size
+        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
+        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(),)).to(device)
 
         def update(engine, i):
             return (
-                y_preds[i * size : (i + 1) * size],
-                y_true[i * size : (i + 1) * size],
+                y_preds[i * size + rank * offset : (i + 1) * size + rank * offset],
+                y_true[i * size + rank * offset : (i + 1) * size + rank * offset],
             )
 
         engine = Engine(update)

--- a/tests/ignite/contrib/metrics/test_precision_recall_curve.py
+++ b/tests/ignite/contrib/metrics/test_precision_recall_curve.py
@@ -195,11 +195,10 @@ def _test_distrib_compute(device):
 
 def _test_distrib_integration(device):
 
-    rank = idist.get_rank()
-    torch.manual_seed(12)
-
     def _test(n_epochs, metric_device):
         metric_device = torch.device(metric_device)
+        rank = idist.get_rank()
+        torch.manual_seed(rank)
         n_iters = 80
         size = 151
 


### PR DESCRIPTION
Related to #2490 

I couldn't figure out why the test was passing initially, I probably needed to gather data from all the processes with idist.all_gather. But as per the conversation in the mentioned PR I have made the changes to it. Let me know if anything needs to be I will be happy to fix it.
