### PR TITLE
Build docker images on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,24 +408,24 @@ jobs:
             cd docker
             export PTH_VERSION=`python -c "import configparser; cfg=configparser.ConfigParser(); cfg.read('docker.cfg'); print(cfg.get('DEFAULT', 'build_docker_image_pytorch_version'))"`
             export HVD_VERSION=`python -c "import configparser; cfg=configparser.ConfigParser(); cfg.read('docker.cfg'); print(cfg.get('DEFAULT', 'build_docker_image_hvd_version'))"`
-            bash build.sh hvd hvd-base
-            bash build.sh hvd hvd-vision
-            bash build.sh hvd hvd-nlp
             bash build.sh hvd hvd-apex
             bash build.sh hvd hvd-apex-vision
             bash build.sh hvd hvd-apex-nlp
+            bash build.sh hvd hvd-base
+            bash build.sh hvd hvd-vision
+            bash build.sh hvd hvd-nlp
 
       - run:
           name: Build all PyTorch-Ignite images
           command: |
             cd docker
             export PTH_VERSION=`python -c "import configparser; cfg=configparser.ConfigParser(); cfg.read('docker.cfg'); print(cfg.get('DEFAULT', 'build_docker_image_pytorch_version'))"`
-            bash build.sh main base
-            bash build.sh main vision
-            bash build.sh main nlp
             bash build.sh main apex
             bash build.sh main apex-vision
             bash build.sh main apex-nlp
+            bash build.sh main base
+            bash build.sh main vision
+            bash build.sh main nlp
 
       - run:
           name: Build all MS DeepSpeed flavoured PyTorch-Ignite images

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,12 +1,13 @@
 name: Trigger Build And Publish Docker Images
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - docker/**
-      - ".github/workflows/docker-publish.yml"
+  # push:
+  #   branches:
+  #     - master
+  #   paths:
+  #     - docker/**
+  #     - ".github/workflows/docker-publish.yml"
+  push
 
 jobs:
   build-publish:


### PR DESCRIPTION
Description:
- Try to build apex images first

Failure logs:
- https://app.circleci.com/pipelines/github/pytorch/ignite/2530/workflows/d99f08cf-ac0a-4656-8220-a816d506f937/jobs/7740

```
/lib/python3.8/site-packages/torch/include/THC -I/usr/local/cuda/include -I/opt/conda/include/python3.8 -c csrc/mlp_cuda.cu -o build/temp.linux-x86_64-3.8/csrc/mlp_cuda.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options '-fPIC' -O3 -DVERSION_GE_1_1 -DVERSION_GE_1_3 -DVERSION_GE_1_5 --threads 4 -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE="_gcc" -DPYBIND11_STDLIB="_libstdcpp" -DPYBIND11_BUILD_ABI="_cxxabi1011" -DTORCH_EXTENSION_NAME=mlp_cuda -D_GLIBCXX_USE_CXX11_ABI=0 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=compute_70 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_80,code=sm_80 -std=c++14
  nvcc warning : The 'compute_35', 'compute_37', 'compute_50', 'sm_35', 'sm_37' and 'sm_50' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
  Killed
  Killed
  error: command '/usr/local/cuda/bin/nvcc' failed with exit status 255
  ----------------------------------------
  ERROR: Failed building wheel for apex
Failed to build apex
ERROR: Failed to build one or more wheels
```