### PR TITLE
Update mean_squared_error.py

### DIFF
--- a/ignite/metrics/mean_squared_error.py
+++ b/ignite/metrics/mean_squared_error.py
@@ -11,7 +11,7 @@ __all__ = ["MeanSquaredError"]
 class MeanSquaredError(Metric):
     r"""Calculates the `mean squared error <https://en.wikipedia.org/wiki/Mean_squared_error>`_.
 
-    .. math:: \text{MSE} = \frac{1}{N} \sum_{i=1}^N \left(y_{i} - x_{i} \right)^2
+    .. math:: \text{MSE} = \frac{1}{N} \sum_{i=1}^N \|y_{i} - x_{i}\|^2
 
     where :math:`y_{i}` is the prediction tensor and :math:`x_{i}` is ground true tensor.
 

--- a/ignite/metrics/root_mean_squared_error.py
+++ b/ignite/metrics/root_mean_squared_error.py
@@ -11,7 +11,7 @@ __all__ = ["RootMeanSquaredError"]
 class RootMeanSquaredError(MeanSquaredError):
     r"""Calculates the `root mean squared error <https://en.wikipedia.org/wiki/Root-mean-square_deviation>`_.
 
-    .. math:: \text{RMSE} = \sqrt{ \frac{1}{N} \sum_{i=1}^N \left(y_{i} - x_{i} \right)^2 }
+    .. math:: \text{RMSE} = \sqrt{ \frac{1}{N} \sum_{i=1}^N \|y_{i} - x_{i} \|^2 }
 
     where :math:`y_{i}` is the prediction tensor and :math:`x_{i}` is ground true tensor.
 


### PR DESCRIPTION
Update docstring of MSE so that it's consistent with the actual behavior.

Description:

MSE is actually computing the sum of squared differences for each element i before taking the average. The current documentation only covers the case where y is a vector (predicting scalar values), but in cases where the prediction has higher dimension than 1 the formula is not valid/clear. 
With the change, it would be valid for both cases.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
