### PR TITLE
updated test_param_scheduler replacing multiple calls with pytest.parametrize

### DIFF
--- a/tests/ignite/handlers/test_param_scheduler.py
+++ b/tests/ignite/handlers/test_param_scheduler.py
@@ -637,12 +637,12 @@ def test_lr_scheduler_asserts():
     [
         (StepLR, ({"step_size": 5, "gamma": 0.5})),
         (ExponentialLR, ({"gamma": 0.78})),
-        (MultiplicativeLR, ({"lr_lambda": lambda epoch: 0.95})),
+        (MultiplicativeLR if has_multiplicative_lr else None, ({"lr_lambda": lambda epoch: 0.95})),
     ],
 )
 def test_lr_scheduler(torch_lr_scheduler_cls, kwargs):
 
-    if torch_lr_scheduler_cls == MultiplicativeLR and not has_multiplicative_lr:
+    if torch_lr_scheduler_cls is None:
         return
 
     tensor = torch.zeros([1], requires_grad=True)


### PR DESCRIPTION
Addresses #2522

Description:
Updated handlers/test_param_scheduler replacing multiple calls with pytest.parametrize

Haven't converted 

https://github.com/pytorch/ignite/blob/69ea3c8fef56191335771665c6acb9937f7a8668/tests/ignite/handlers/test_param_scheduler.py#L812 
and https://github.com/pytorch/ignite/blob/69ea3c8fef56191335771665c6acb9937f7a8668/tests/ignite/handlers/test_param_scheduler.py#L1228

because it has conditional calls. We could have different fixtures for all the cases but I believe that would make the code less readable, let me know what you think would be best for these tests.
Check list:

- [X] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
