### PR TITLE
Removed warning in DDP if Metric.reset/update are not decorated.

### DIFF
--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -210,17 +210,6 @@ class Metric(metaclass=ABCMeta):
     ):
         self._output_transform = output_transform
 
-        # Check device if distributed is initialized:
-        if idist.get_world_size() > 1:
-
-            # check if reset and update methods are decorated. Compute may not be decorated
-            if not (hasattr(self.reset, "_decorated") and hasattr(self.update, "_decorated")):
-                warnings.warn(
-                    f"{self.__class__.__name__} class does not support distributed setting. "
-                    "Computed result is not collected across all computing devices",
-                    RuntimeWarning,
-                )
-
         # Some metrics have a large performance regression when run on XLA devices, so for now, we disallow it.
         if torch.device(device).type == "xla":
             raise ValueError("Cannot create metric on an XLA device. Use device='cpu' instead.")

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -1,4 +1,3 @@
-import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from functools import wraps

--- a/tests/ignite/metrics/test_metric.py
+++ b/tests/ignite/metrics/test_metric.py
@@ -29,15 +29,6 @@ class DummyMetric1(Metric):
         assert output == self.true_output
 
 
-@pytest.mark.distributed
-@pytest.mark.skipif("WORLD_SIZE" not in os.environ, reason="Skip if WORLD_SIZE not in env vars")
-@pytest.mark.skipif(torch.cuda.is_available(), reason="Skip if GPU")
-def test_metric_warning(distributed_context_single_node_gloo):
-    y = torch.tensor([1.0])
-    with pytest.warns(RuntimeWarning, match=r"DummyMetric1 class does not support distributed setting"):
-        DummyMetric1((y, y))
-
-
 def test_no_transform():
     y_pred = torch.Tensor([[2.0], [-2.0]])
     y = torch.zeros(2)


### PR DESCRIPTION
Description:
- Removed warning in DDP if Metric.reset/update are not decorated.

Context:
`reinit__is_reduced` and `sync_all_reduce` decorators are optional helpers to compute full metric value in distributed context. They should be optional and users basically are free to skip them and perform all_reduce-like ops on accumulated variable during compute on their own. And also make sure that compute wont perform collective ops twice if no reset/update were called. `reinit__is_reduced` decorator is needed to avoid multiple reductions if compute method is called several times without reseting or updating...
If user develop their own metric and prefer to all_reduce with their means, they see a warning in DDP.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
