### PR TITLE
Fix dill version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest
 codecov
 pytest-cov
 pytest-xdist
-dill
+dill==0.3.4
 # workaround for issue fixed in https://github.com/pytorch/pytorch/pull/69904
 # to be removed after next Pytroch release (1.11)
 setuptools==59.5.0


### PR DESCRIPTION
Fixes #2577

Description:

Because of a deep `dill` modification about `abc` class handling, the version have to be pinned to `0.3.4`.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
