### PR TITLE
Added pytorch=1.10 to pytorch-version-tests

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        pytorch-version: [1.9.1, 1.8.1, 1.7.1, 1.6.0, 1.5.1, 1.4.0, 1.3.1]
+        pytorch-version: [1.10.0, 1.9.1, 1.8.1, 1.7.1, 1.6.0, 1.5.1, 1.4.0, 1.3.1]
         exclude:
           - pytorch-version: 1.3.1
             python-version: 3.8

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -206,7 +206,9 @@ def test_auto_methods_gloo(distributed_context_single_node_gloo):
         # Pytorch <= 1.9.0 => AssertionError
         # Pytorch >  1.9   => ValueError
         # https://github.com/pytorch/pytorch/blob/master/torch/nn/parallel/distributed.py#L1498
-        with pytest.raises((AssertionError, ValueError), match=r"SyncBatchNorm layers only work with (GPU|CUDA) modules"):
+        with pytest.raises(
+            (AssertionError, ValueError), match=r"SyncBatchNorm layers only work with (GPU|CUDA) modules"
+        ):
             model = nn.Sequential(nn.Linear(20, 100), nn.BatchNorm1d(100))
             auto_model(model, sync_bn=True)
 

--- a/tests/ignite/distributed/test_auto.py
+++ b/tests/ignite/distributed/test_auto.py
@@ -206,7 +206,7 @@ def test_auto_methods_gloo(distributed_context_single_node_gloo):
         # Pytorch <= 1.9.0 => AssertionError
         # Pytorch >  1.9   => ValueError
         # https://github.com/pytorch/pytorch/blob/master/torch/nn/parallel/distributed.py#L1498
-        with pytest.raises((AssertionError, ValueError), match=r"SyncBatchNorm layers only work with GPU modules"):
+        with pytest.raises((AssertionError, ValueError), match=r"SyncBatchNorm layers only work with (GPU|CUDA) modules"):
             model = nn.Sequential(nn.Linear(20, 100), nn.BatchNorm1d(100))
             auto_model(model, sync_bn=True)
 


### PR DESCRIPTION
Related to #2598

Description:
- Added pytorch=1.10 to pytorch-version-tests
- Fixed issue with tests/ignite/distributed/test_auto.py::test_auto_methods_gloo



Check list:

- [ ] Should fix issue with `test_auto_methods_gloo`: https://github.com/pytorch/ignite/actions/runs/2498331137
