### PR TITLE
fix an error message of confusion_matrix.IoU

### DIFF
--- a/ignite/metrics/confusion_matrix.py
+++ b/ignite/metrics/confusion_matrix.py
@@ -239,7 +239,9 @@ def IoU(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> MetricsLambd
 
     if ignore_index is not None:
         if not (isinstance(ignore_index, numbers.Integral) and 0 <= ignore_index < cm.num_classes):
-            raise ValueError(f"ignore_index should be non-negative integer, but given {ignore_index}")
+            raise ValueError(
+                f"ignore_index should be integer and in the range of [0, {cm.num_classes}), but given {ignore_index}"
+            )
 
     # Increase floating point precision and pass to CPU
     cm = cm.to(torch.double)
@@ -393,7 +395,9 @@ def DiceCoefficient(cm: ConfusionMatrix, ignore_index: Optional[int] = None) -> 
 
     if ignore_index is not None:
         if not (isinstance(ignore_index, numbers.Integral) and 0 <= ignore_index < cm.num_classes):
-            raise ValueError(f"ignore_index should be non-negative integer, but given {ignore_index}")
+            raise ValueError(
+                f"ignore_index should be integer and in the range of [0, {cm.num_classes}), but given {ignore_index}"
+            )
 
     # Increase floating point precision and pass to CPU
     cm = cm.to(torch.double)

--- a/tests/ignite/metrics/test_confusion_matrix.py
+++ b/tests/ignite/metrics/test_confusion_matrix.py
@@ -189,16 +189,16 @@ def test_iou_wrong_input():
         IoU(None)
 
     cm = ConfusionMatrix(num_classes=10)
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given -1"):
         IoU(cm, ignore_index=-1)
 
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given a"):
         IoU(cm, ignore_index="a")
 
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given 10"):
         IoU(cm, ignore_index=10)
 
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given 11"):
         IoU(cm, ignore_index=11)
 
 
@@ -403,16 +403,16 @@ def test_dice_coefficient_wrong_input():
         DiceCoefficient(None)
 
     cm = ConfusionMatrix(num_classes=10)
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given -1"):
         DiceCoefficient(cm, ignore_index=-1)
 
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given a"):
         DiceCoefficient(cm, ignore_index="a")
 
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given 10"):
         DiceCoefficient(cm, ignore_index=10)
 
-    with pytest.raises(ValueError, match="ignore_index should be non-negative integer"):
+    with pytest.raises(ValueError, match=r"ignore_index should be integer and in the range of \[0, 10\), but given 11"):
         DiceCoefficient(cm, ignore_index=11)
 
 


### PR DESCRIPTION
Description:

An error message in ignite.metrics.confusion_matrix.IoU is confusing and does not match the condition check, which might lead to misunderstanding. I update the error message to make it match the  condition check.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
