### PR TITLE
Add ModelCheckpoint documentation example

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -909,21 +909,24 @@ class ModelCheckpoint(Checkpoint):
         with :class:`~ignite.handlers.checkpoint.Checkpoint`
 
     Examples:
-        .. code-block:: python
+        .. testcode:: python
 
             import os
             from ignite.engine import Engine, Events
             from ignite.handlers import ModelCheckpoint
             from torch import nn
             trainer = Engine(lambda engine, batch: None)
-            handler = ModelCheckpoint('/tmp/models', 'myprefix', n_saved=2, create_dir=True)
+            handler = ModelCheckpoint('/tmp/models', 'myprefix', n_saved=2, create_dir=True, require_empty=False)
             model = nn.Linear(3, 3)
             trainer.add_event_handler(Events.EPOCH_COMPLETED(every=2), handler, {'mymodel': model})
             trainer.run([0, 1, 2, 3, 4], max_epochs=6)
-            os.listdir('/tmp/models')
-            # ['myprefix_mymodel_20.pt', 'myprefix_mymodel_30.pt']
-            handler.last_checkpoint
-            # ['/tmp/models/myprefix_mymodel_30.pt']
+            print(sorted(os.listdir('/tmp/models')))
+            print(handler.last_checkpoint)
+
+        .. testoutput:: python
+
+            ['myprefix_mymodel_20.pt', 'myprefix_mymodel_30.pt']
+            /tmp/models/myprefix_mymodel_30.pt
     """
 
     def __init__(

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -879,7 +879,7 @@ class ModelCheckpoint(Checkpoint):
             :class:`~ignite.engine.engine.Engine` object, and return a score (`float`). Objects with highest scores
             will be retained.
         score_name: if ``score_function`` not None, it is possible to store its value using
-            `score_name`. See Notes for more details.
+            `score_name`. See Examples of :class:`~ignite.handlers.checkpoint.Checkpoint` for more details.
         n_saved: Number of objects that should be kept on disk. Older files will be removed. If set to
             `None`, all objects are kept.
         atomic: If True, objects are serialized to a temporary file, and then moved to final

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -850,7 +850,7 @@ class DiskSaver(BaseSaveHandler):
 
 
 class ModelCheckpoint(Checkpoint):
-    """ModelCheckpoint handler is a :class:`~ignite.handlers.checkpoint.Checkpoint` handler that can be used
+    """ModelCheckpoint handler, inherits from :class:`~ignite.handlers.checkpoint.Checkpoint`, can be used
     to periodically save objects to disk only. If needed to store checkpoints to
     another storage type, please consider :class:`~ignite.handlers.checkpoint.Checkpoint`.
     It also provides `last_checkpoint` attribute to show the last saved checkpoint.

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -850,8 +850,10 @@ class DiskSaver(BaseSaveHandler):
 
 
 class ModelCheckpoint(Checkpoint):
-    """ModelCheckpoint handler can be used to periodically save objects to disk only. If needed to store checkpoints to
+    """ModelCheckpoint handler is a :class:`~ignite.handlers.checkpoint.Checkpoint` handler that can be used
+    to periodically save objects to disk only. If needed to store checkpoints to
     another storage type, please consider :class:`~ignite.handlers.checkpoint.Checkpoint`.
+    It also provides `last_checkpoint` attribute to show the last saved checkpoint.
 
     This handler expects two arguments:
 


### PR DESCRIPTION
Fixes #2622

Description:
- Add "See Example of Checkpoint" in the `score_name` of `ModelCheckpoint`.
- Change example from code block to actual test code (doctest).

Check list:
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)

Comments:
1. This is my first contribution to ignite, hopefully this PR can help newcomers to know how to use ModelCheckpoint more quickly.
2. I think the description of ModelCheckpoint handler can mention it is inherited from Checkpoint with convenient DiskSaver and `last_checkpoint` to use (if my understanding is correct). 
