### PR TITLE
Feature add ZeRO support to Checkpoint in a distributed configuration

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -173,7 +173,7 @@ class Checkpoint(Serializable):
 
     .. warning::
 
-        When running on XLA devices or using :class:`~torch.distributed.ZeroRedundancyOptimizer`, it
+        When running on XLA devices or using :class:`~torch.distributed.optim.ZeroRedundancyOptimizer`, it
         should be run in all processes, otherwise application can get stuck on saving the checkpoint.
 
         .. code-block:: python

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -11,7 +11,10 @@ from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Tup
 
 import torch
 import torch.nn as nn
-from torch.distributed.optim import ZeroRedundancyOptimizer
+from packaging.version import Version
+
+if Version(torch.__version__) >= Version("1.9.0"):
+    from torch.distributed.optim import ZeroRedundancyOptimizer
 
 import ignite.distributed as idist
 from ignite.base import Serializable
@@ -468,7 +471,7 @@ class Checkpoint(Serializable):
             for k, obj in self.to_save.items():
                 if isinstance(obj, (nn.DataParallel, nn.parallel.DistributedDataParallel)):
                     obj = obj.module
-                elif isinstance(obj, ZeroRedundancyOptimizer):
+                elif Version(torch.__version__) >= Version("1.9.0") and isinstance(obj, ZeroRedundancyOptimizer):
                     obj.consolidate_state_dict(to=self.save_on_rank)
                     if self.save_on_rank != idist.get_rank():
                         continue

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -174,7 +174,7 @@ class Checkpoint(Serializable):
     .. warning::
 
         When running on XLA devices or using :class:`~torch.distributed.optim.ZeroRedundancyOptimizer`, it
-        should be run in all processes, otherwise application can get stuck on saving the checkpoint.
+        should be run in all processes, otherwise application can get stuck while saving the checkpoint.
 
         .. code-block:: python
 
@@ -470,6 +470,8 @@ class Checkpoint(Serializable):
                     obj = obj.module
                 elif isinstance(obj, ZeroRedundancyOptimizer):
                     obj.consolidate_state_dict(to=self.save_on_rank)
+                    if self.save_on_rank != idist.get_rank():
+                        continue
                 checkpoint[k] = obj.state_dict()
         return checkpoint
 

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -1259,11 +1259,6 @@ def _test_checkpoint_with_ZeRO(device, dirname, local_rank):
 
     engine = Engine(lambda e, b: None)
     checkpointer(engine)
-    idist.barrier()
-
-    opt.consolidate_state_dict(to=1)
-
-    idist.barrier()
 
     mocked_opt.consolidate_state_dict.assert_called_once_with(to=1)
 

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -10,7 +10,9 @@ import pytest
 import torch
 import torch.nn as nn
 from packaging.version import Version
-from torch.distributed.optim import ZeroRedundancyOptimizer
+
+if Version(torch.__version__) >= Version("1.9.0"):
+    from torch.distributed.optim import ZeroRedundancyOptimizer
 
 import ignite.distributed as idist
 from ignite.engine import Engine, Events, State
@@ -1279,7 +1281,9 @@ def test_distrib_gloo_cpu_or_gpu(distributed_context_single_node_gloo, dirname, 
     _test_save_model_optimizer_lr_scheduler_with_state_dict(device, rank_zero_dirname / "2", just_on_zero_rank=True)
     _test_checkpoint_with_ddp(device)
     _test_checkpoint_load_objects_ddp(device)
-    _test_checkpoint_with_ZeRO(device, dirname, local_rank)
+
+    if Version(torch.__version__) >= Version("1.9.0"):
+        _test_checkpoint_with_ZeRO(device, dirname, local_rank)
 
 
 @pytest.mark.distributed

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -11,9 +11,6 @@ import torch
 import torch.nn as nn
 from packaging.version import Version
 
-if Version(torch.__version__) >= Version("1.9.0"):
-    from torch.distributed.optim import ZeroRedundancyOptimizer
-
 import ignite.distributed as idist
 from ignite.engine import Engine, Events, State
 from ignite.handlers import Checkpoint, DiskSaver, EarlyStopping, global_step_from_engine, ModelCheckpoint
@@ -1247,6 +1244,9 @@ def _test_checkpoint_load_objects_ddp(device):
 
 
 def _test_checkpoint_with_ZeRO(device, dirname, local_rank):
+
+    from torch.distributed.optim import ZeroRedundancyOptimizer
+
     model = DummyModel().to(device)
     opt = ZeroRedundancyOptimizer(model.parameters(), torch.optim.SGD, lr=0.01)
     mocked_opt = MagicMock(ZeroRedundancyOptimizer, wraps=opt)
@@ -1282,7 +1282,9 @@ def test_distrib_gloo_cpu_or_gpu(distributed_context_single_node_gloo, dirname, 
     _test_checkpoint_with_ddp(device)
     _test_checkpoint_load_objects_ddp(device)
 
-    if Version(torch.__version__) >= Version("1.9.0"):
+    from ignite.handlers.checkpoint import HAVE_ZERO
+
+    if HAVE_ZERO:
         _test_checkpoint_with_ZeRO(device, dirname, local_rank)
 
 


### PR DESCRIPTION
Fixes #2623 

Description: To call `consolidate_state_dict` method of ZeRO optimizer on all ranks to before calling `state_dict` on target rank, the one responsible for saving the checkpoint.

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
