### PR TITLE
Rewritten Engine's terminate and terminate_epoch logic

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -438,14 +438,28 @@ class Engine(Serializable):
         return self._fire_event(event_name)
 
     def terminate(self) -> None:
-        """Sends terminate signal to the engine, so that it terminates completely the run after
-        the current iteration."""
+        """Sends terminate signal to the engine, so that it terminates completely the run. The run is
+        terminated after the event on which ``terminate`` method was called. The following events are triggered:
+
+        - ...
+        - Terminating event
+        - :attr:`~ignite.engine.events.Events.TERMINATE`
+        - :attr:`~ignite.engine.events.Events.COMPLETED`
+        """
         self.logger.info("Terminate signaled. Engine will stop after current iteration is finished.")
         self.should_terminate = True
 
     def terminate_epoch(self) -> None:
-        """Sends terminate signal to the engine, so that it terminates the current epoch
-        after the current iteration."""
+        """Sends terminate signal to the engine, so that it terminates the current epoch. The run
+        continues from the next epoch. The following events are triggered:
+
+        - ...
+        - Event on which ``terminate_epoch`` method is called
+        - :attr:`~ignite.engine.events.Events.TERMINATE_SINGLE_EPOCH`
+        - :attr:`~ignite.engine.events.Events.EPOCH_COMPLETED`
+        - :attr:`~ignite.engine.events.Events.EPOCH_STARTED`
+        - ...
+        """
         self.logger.info(
             "Terminate current epoch is signaled. "
             "Current epoch iteration will stop after current iteration is finished."

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -301,7 +301,12 @@ class Engine(Serializable):
 
         self._assert_allowed_event(event_name)
 
-        event_args = (Exception(),) if event_name == Events.EXCEPTION_RAISED else ()
+        event_args = ()  # type: Tuple[Any, ...]
+        if event_name == Events.EXCEPTION_RAISED:
+            event_args += (Exception(),)
+        elif event_name == Events.TERMINATE_SINGLE_EPOCH:
+            event_args += (0,)
+
         try:
             _check_signature(handler, "handler", self, *(event_args + args), **kwargs)
             self._event_handlers[event_name].append((handler, (self,) + args, kwargs))
@@ -755,38 +760,40 @@ class Engine(Serializable):
         self.should_terminate = self.should_terminate_single_epoch = False
         self._init_timers(self.state)
         try:
-            start_time = time.time()
-            self._fire_event(Events.STARTED)
-            if self.should_terminate:
-                self._fire_event(Events.TERMINATE)
+            try:
+                start_time = time.time()
+                self._fire_event(Events.STARTED)
+                self._maybe_terminate()
 
-            while not self._is_done(self.state) and not self.should_terminate:
-                self.state.epoch += 1
-                handlers_start_time = time.time()
-                self._fire_event(Events.EPOCH_STARTED)
-                epoch_time_taken = time.time() - handlers_start_time
+                while not self._is_done(self.state) and not self.should_terminate:
+                    self.state.epoch += 1
+                    handlers_start_time = time.time()
+                    self._fire_event(Events.EPOCH_STARTED)
+                    epoch_time_taken = time.time() - handlers_start_time
+                    self._maybe_terminate()
 
-                if not self.should_terminate:
                     if self._dataloader_iter is None:
                         self._setup_engine()
 
                     epoch_time_taken += self._run_once_on_dataset()
 
-                # time is available for handlers but must be updated after fire
-                self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
+                    # time is available for handlers but must be updated after fire
+                    self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
 
-                handlers_start_time = time.time()
-                if self.should_terminate:
-                    self._fire_event(Events.TERMINATE)
-                else:
+                    handlers_start_time = time.time()
                     self._fire_event(Events.EPOCH_COMPLETED)
-                epoch_time_taken += time.time() - handlers_start_time
-                # update time wrt handlers
-                self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
-                hours, mins, secs = _to_hours_mins_secs(epoch_time_taken)
-                self.logger.info(f"Epoch[{self.state.epoch}] Complete. Time taken: {hours:02d}:{mins:02d}:{secs:02d}")
-                if self.should_terminate:
-                    break
+                    epoch_time_taken += time.time() - handlers_start_time
+                    # update time wrt handlers
+                    self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
+                    self._maybe_terminate()
+
+                    hours, mins, secs = _to_hours_mins_secs(epoch_time_taken)
+                    self.logger.info(
+                        f"Epoch[{self.state.epoch}] Complete. Time taken: {hours:02d}:{mins:02d}:{secs:02d}"
+                    )
+
+            except _EngineTerminateException:
+                self._fire_event(Events.TERMINATE)
 
             time_taken = time.time() - start_time
             # time is available for handlers but must be updated after fire
@@ -807,6 +814,13 @@ class Engine(Serializable):
         self._dataloader_iter = None
         return self.state
 
+    def _maybe_terminate(self) -> None:
+        if self.should_terminate:
+            raise _EngineTerminateException()
+
+        if self.should_terminate_single_epoch:
+            raise _EngineTerminateSingleEpochException()
+
     def _run_once_on_dataset(self) -> float:
         start_time = time.time()
 
@@ -826,8 +840,12 @@ class Engine(Serializable):
                     # Avoid Events.GET_BATCH_STARTED triggered twice when data iter is restarted
                     if self.last_event_name != Events.DATALOADER_STOP_ITERATION:
                         self._fire_event(Events.GET_BATCH_STARTED)
+                        self._maybe_terminate()
+
                     self.state.batch = next(self._dataloader_iter)
                     self._fire_event(Events.GET_BATCH_COMPLETED)
+                    self._maybe_terminate()
+
                     iter_counter += 1
                     should_exit = False
                 except StopIteration:
@@ -856,24 +874,20 @@ class Engine(Serializable):
                         break
 
                     self._fire_event(Events.DATALOADER_STOP_ITERATION)
-                    self._setup_dataloader_iter()
+                    self._maybe_terminate()
 
+                    self._setup_dataloader_iter()
                     should_exit = True
 
                     continue
 
                 self.state.iteration += 1
                 self._fire_event(Events.ITERATION_STARTED)
+                self._maybe_terminate()
 
-                if not (self.should_terminate or self.should_terminate_single_epoch):
-                    self.state.output = self._process_function(self, self.state.batch)
-                    self._fire_event(Events.ITERATION_COMPLETED)
-
-                if self.should_terminate or self.should_terminate_single_epoch:
-                    self._fire_event(Events.TERMINATE_SINGLE_EPOCH, iter_counter=iter_counter)
-                    self.should_terminate_single_epoch = False
-                    self._setup_dataloader_iter()
-                    break
+                self.state.output = self._process_function(self, self.state.batch)
+                self._fire_event(Events.ITERATION_COMPLETED)
+                self._maybe_terminate()
 
                 if self.state.epoch_length is not None and iter_counter == self.state.epoch_length:
                     break
@@ -881,6 +895,11 @@ class Engine(Serializable):
                 if self.state.max_iters is not None and self.state.iteration == self.state.max_iters:
                     self.should_terminate = True
                     break
+
+        except _EngineTerminateSingleEpochException:
+            self._fire_event(Events.TERMINATE_SINGLE_EPOCH, iter_counter=iter_counter)
+            self.should_terminate_single_epoch = False
+            self._setup_dataloader_iter()
 
         except Exception as e:
             self.logger.error(f"Current run is terminating due to exception: {e}")
@@ -893,3 +912,19 @@ def _get_none_data_iter(size: int) -> Iterator:
     # Sized iterator for data as None
     for _ in range(size):
         yield None
+
+
+class _EngineTerminateSingleEpochException(Exception):
+    """
+    Exception associated with Terminate Single Epoch event
+    """
+
+    pass
+
+
+class _EngineTerminateException(Exception):
+    """
+    Exception associated with Terminate event
+    """
+
+    pass

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -881,7 +881,7 @@ class Engine(Serializable):
 
                 if self.state.max_iters is not None and self.state.iteration == self.state.max_iters:
                     self.should_terminate = True
-                    break
+                    raise _EngineTerminateException()
 
         except _EngineTerminateSingleEpochException:
             self._fire_event(Events.TERMINATE_SINGLE_EPOCH, iter_counter=iter_counter)

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -888,6 +888,11 @@ class Engine(Serializable):
             self.should_terminate_single_epoch = False
             self._setup_dataloader_iter()
 
+        except _EngineTerminateException as e:
+            # we need to reraise this exception such that it is not handled
+            # as a general exception by the code below
+            raise e
+
         except Exception as e:
             self.logger.error(f"Current run is terminating due to exception: {e}")
             self._handle_exception(e)

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -299,7 +299,7 @@ class Events(EventEnum):
     """triggered when the run is about to end completely, after receiving terminate() call."""
     TERMINATE_SINGLE_EPOCH = "terminate_single_epoch"
     """triggered when the run is about to end the current epoch,
-    after receiving a terminate_epoch() or terminate() call."""
+    after receiving a terminate_epoch() call."""
 
     def __or__(self, other: Any) -> "EventsList":
         return EventsList() | self | other

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -172,6 +172,10 @@ def test_terminate_stops_run_mid_epoch(data, epoch_length):
         if engine.state.iteration == iteration_to_stop:
             engine.terminate()
 
+    @engine.on(Events.EXCEPTION_RAISED)
+    def assert_no_exceptions(ee):
+        assert False, f"Engine should terminate without raising an exception, got '{type(ee)}'"
+
     engine.add_event_handler(Events.ITERATION_STARTED, start_of_iteration_handler)
     state = engine.run(data, max_epochs=max_epochs, epoch_length=epoch_length)
     # completes the iteration but doesn't increment counter (this happens just before a new iteration starts)
@@ -235,6 +239,10 @@ def test_terminate_events_sequence(terminate_event, e, i):
     @engine.on(terminate_event)
     def call_terminate():
         engine.terminate()
+
+    @engine.on(Events.EXCEPTION_RAISED)
+    def assert_no_exceptions(ee):
+        assert False, f"Engine should terminate without raising an exception, got '{type(ee)}'"
 
     engine.run(data, max_epochs=max_epochs)
 

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -1060,7 +1060,7 @@ def test_run_with_invalid_max_iters_and_max_epoch():
         engine.run([0] * 20, max_iters=max_iters, max_epochs=max_epochs)
 
 
-def test_epoch_events_fired():
+def test_epoch_events_fired_max_iters():
     max_iters = 32
     engine = Engine(lambda e, b: 1)
 


### PR DESCRIPTION
Description:
- terminate() work on all events, called on catched _EngineTerminateException
- terminate_epoch() work on iteration-based events, called on catched  _EngineTerminateSingleEpochExpection
- Fixed issue when attaching handlers on Events.TERMINATE_SINGLE_EPOCH
- Added tests

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)


@sadra-barikbin can you please review and comment out what do you think ?
