### PR TITLE
Improved logging time taken message showing milliseconds

### DIFF
--- a/examples/contrib/cifar10/main.py
+++ b/examples/contrib/cifar10/main.py
@@ -260,7 +260,7 @@ def initialize(config):
 
 def log_metrics(logger, epoch, elapsed, tag, metrics):
     metrics_output = "\n".join([f"\t{k}: {v}" for k, v in metrics.items()])
-    logger.info(f"\nEpoch {epoch} - Evaluation time (seconds): {elapsed:.2f} - {tag} metrics:\n {metrics_output}")
+    logger.info(f"Epoch[{epoch}] - Evaluation time (seconds): {elapsed:.3f}\n - {tag} metrics:\n {metrics_output}")
 
 
 def log_basic_info(logger, config):
@@ -379,9 +379,6 @@ def create_evaluator(model, metrics, config, tag="val"):
 
     for name, metric in metrics.items():
         metric.attach(evaluator, name)
-
-    if idist.get_rank() == 0 and (not config["with_clearml"]):
-        common.ProgressBar(desc=f"Evaluation ({tag})", persist=False).attach(evaluator)
 
     return evaluator
 

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -776,7 +776,7 @@ class Engine(Serializable):
                 # update time wrt handlers
                 self.state.times[Events.EPOCH_COMPLETED.name] = time_taken
                 hours, mins, secs = _to_hours_mins_secs(time_taken)
-                self.logger.info(f"Epoch[{self.state.epoch}] Complete. Time taken: {hours:02d}:{mins:02d}:{secs:02d}")
+                self.logger.info(f"Epoch[{self.state.epoch}] Complete. Time taken: {hours:02d}:{mins:02d}:{secs:06.3f}")
                 if self.should_terminate:
                     break
 
@@ -789,7 +789,7 @@ class Engine(Serializable):
             # update time wrt handlers
             self.state.times[Events.COMPLETED.name] = time_taken
             hours, mins, secs = _to_hours_mins_secs(time_taken)
-            self.logger.info(f"Engine run complete. Time taken: {hours:02d}:{mins:02d}:{secs:02d}")
+            self.logger.info(f"Engine run complete. Time taken: {hours:02d}:{mins:02d}:{secs:06.3f}")
 
         except BaseException as e:
             self._dataloader_iter = None

--- a/ignite/engine/utils.py
+++ b/ignite/engine/utils.py
@@ -21,8 +21,8 @@ def _check_signature(fn: Callable, fn_description: str, *args: Any, **kwargs: An
         )
 
 
-def _to_hours_mins_secs(time_taken: Union[float, int]) -> Tuple[int, int, int]:
-    """Convert seconds to hours, mins, and seconds."""
+def _to_hours_mins_secs(time_taken: Union[float, int]) -> Tuple[int, int, float]:
+    """Convert seconds to hours, mins, seconds and milliseconds."""
     mins, secs = divmod(time_taken, 60)
     hours, mins = divmod(mins, 60)
-    return round(hours), round(mins), round(secs)
+    return round(hours), round(mins), secs


### PR DESCRIPTION
Description:
- Improved logging time taken message showing milliseconds in Engine, utils and Cifar10 example
- removed eval pbar from cifar10

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
