### PR TITLE
Fix typo in engine run method

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -671,7 +671,7 @@ class Engine(Serializable):
             if max_epochs is not None:
                 if max_epochs < self.state.epoch:
                     raise ValueError(
-                        "Argument max_epochs should be greater than or equal to the start"
+                        "Argument max_epochs should be greater than or equal to the start "
                         f"epoch defined in the state: {max_epochs} vs {self.state.epoch}. "
                         "Please, set engine.state.max_epochs = None "
                         "before calling engine.run() in order to restart the training from the beginning."

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -671,8 +671,8 @@ class Engine(Serializable):
             if max_epochs is not None:
                 if max_epochs < self.state.epoch:
                     raise ValueError(
-                        "Argument max_epochs should be larger than the start epoch "
-                        f"defined in the state: {max_epochs} vs {self.state.epoch}. "
+                        "Argument max_epochs should be greater than or equal to the start"
+                        f"epoch defined in the state: {max_epochs} vs {self.state.epoch}. "
                         "Please, set engine.state.max_epochs = None "
                         "before calling engine.run() in order to restart the training from the beginning."
                     )

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -1207,7 +1207,7 @@ def test_engine_run_resume(data, epoch_length):
     assert engine.state.iteration == 7 * real_epoch_length
 
     # error
-    with pytest.raises(ValueError, match="Argument max_epochs should be larger than the start epoch"):
+    with pytest.raises(ValueError, match="Argument max_epochs should be greater than or equal to the start epoch"):
         engine.run(data, max_epochs=4, epoch_length=epoch_length)
 
     # restart from 0 to 7 (As state.epoch == max_epochs(=7),

--- a/tests/ignite/engine/test_engine_state_dict.py
+++ b/tests/ignite/engine/test_engine_state_dict.py
@@ -144,7 +144,7 @@ def test_load_state_dict_with_params_overriding_integration():
     assert state.iteration == state_dict["epoch_length"] * new_max_epochs
     assert state.epoch == new_max_epochs
 
-    with pytest.raises(ValueError, match=r"Argument max_epochs should be larger than the start epoch"):
+    with pytest.raises(ValueError, match=r"Argument max_epochs should be greater than or equal to the start epoch"):
         engine.load_state_dict(state_dict)
         engine.run(data, max_epochs=3)
 
@@ -270,7 +270,7 @@ def test_restart_training():
     state = engine.run(data, max_epochs=5)
     with pytest.raises(
         ValueError,
-        match=r"Argument max_epochs should be larger than the start epoch defined in the state: 2 vs 5. "
+        match=r"Argument max_epochs should be greater than or equal to the start epoch defined in the state: 2 vs 5. "
         r"Please, .+ "
         r"before calling engine.run\(\) in order to restart the training from the beginning.",
     ):


### PR DESCRIPTION
Description:
Typo fixed in code and tests.

Follow-up to PR#2645
