### PR TITLE
Add get_param method to ParamGroupScheduler

### DIFF
--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -734,8 +734,8 @@ class ConcatScheduler(ParamScheduler):
                 By default, the first scheduler's parameter name is taken.
 
         Returns:
-            list of [event_index, value_0, value_1, ...], where values correspond to `param_names`.
-
+            list:
+                list of [event_index, value_0, value_1, ...], where values correspond to `param_names`.
         """
         if param_names is not None:
             if not isinstance(param_names, (list, tuple)):
@@ -892,7 +892,6 @@ class LRScheduler(ParamScheduler):
 
         Returns:
             event_index, value
-
         """
 
         if not isinstance(lr_scheduler, _LRScheduler):
@@ -1392,9 +1391,9 @@ class ParamGroupScheduler:
                 :class:`ignite.handlers.param_scheduler.ParamGroupScheduler`.
 
         Returns:
-            list of [event_index, scheduler_0_value, scheduler_1_value, ...], where `scheduler_i_value`
-            corresponds to the simulated param of scheduler `i` at `event_index`th event.
-
+            list:
+                list of [event_index, scheduler_0_value, scheduler_1_value, ...], where scheduler_i_value
+                corresponds to the simulated param of scheduler i at 'event_index'th event.
         """
 
         # This scheduler uses `torch.optim.lr_scheduler._LRScheduler` which
@@ -1423,6 +1422,7 @@ class ParamGroupScheduler:
             return values
 
     def get_param(self) -> List[Union[float, List[float]]]:
+        """Method to get current `schedulers`' parameter values"""
         return [scheduler.get_param() for scheduler in self.schedulers]
 
 

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -1422,7 +1422,11 @@ class ParamGroupScheduler:
             return values
 
     def get_param(self) -> List[Union[float, List[float]]]:
-        """Method to get current `schedulers`' parameter values"""
+        """
+        Method to get current `schedulers`' parameter values
+        
+        .. versionadded:: 0.5.0
+        """
         return [scheduler.get_param() for scheduler in self.schedulers]
 
 

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -1424,7 +1424,7 @@ class ParamGroupScheduler:
     def get_param(self) -> List[Union[float, List[float]]]:
         """
         Method to get current `schedulers`' parameter values
-        
+
         .. versionadded:: 0.5.0
         """
         return [scheduler.get_param() for scheduler in self.schedulers]

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -1392,7 +1392,8 @@ class ParamGroupScheduler:
                 :class:`ignite.handlers.param_scheduler.ParamGroupScheduler`.
 
         Returns:
-            event_index, value
+            list of [event_index, scheduler_0_value, scheduler_1_value, ...], where `scheduler_i_value`
+            corresponds to the simulated param of scheduler `i` at `event_index`th event.
 
         """
 
@@ -1420,6 +1421,9 @@ class ParamGroupScheduler:
                 s.optimizer.load_state_dict(objs["optimizer"])
 
             return values
+
+    def get_param(self) -> List[Union[float, List[float]]]:
+        return [scheduler.get_param() for scheduler in self.schedulers]
 
 
 class ReduceLROnPlateauScheduler(ParamScheduler):


### PR DESCRIPTION
In PR #2704 , in order to be able to have multiple groups in `FastaiLRFinder` when `step_mode != 'exp'`, I suggested this code:
https://github.com/pytorch/ignite/pull/2704/files#r975195661

which uses `ParamGroupScheduler`. `FastaiLRFinder` calls `get_param` on its scheduler in 
https://github.com/pytorch/ignite/blob/daa3c96d381f23b9900012f5defd6325abebbb63/ignite/handlers/lr_finder.py#L160

but `ParamGroupScheduler` has not this method. This PR adds that method.
