### PR TITLE
add before and after events filter

### DIFF
--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -64,20 +64,20 @@ class CallableEventWithFilter:
                 the event type was fired
             every: a value specifying how often the event should be fired
             once: a value specifying when the event should be fired (if only once)
-            before: a value specifying the step that event should be fired before
-            after: a value specifying the step that event should be fired after
+            before: a value specifying the number of occurrence that event should be fired before
+            after: a value specifying the number of occurrence that event should be fired after
 
         Returns:
             CallableEventWithFilter: A new event having the same value but a different filter function
         """
 
-        if not (
-            (event_filter is not None)
-            ^ (every is not None)
-            ^ (once is not None)
-            ^ (before is not None)
-            ^ (after is not None)
-        ):
+        if sum((
+            event_filter is not None,
+            every is not None,
+            once is not None,
+            before is not None,
+            after is not None,
+        )) != 1:
             raise ValueError("Only one of the input arguments should be specified")
 
         if (event_filter is not None) and not callable(event_filter):

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -143,11 +143,11 @@ class CallableEventWithFilter:
     @staticmethod
     def before_and_after_event_filter(before: Optional[int] = None, after: Optional[int] = None) -> Callable:
         """A wrapper for before and after event filter."""
-        before = float("inf") if before is None else before
-        after = 0 if after is None else after
+        before_: Union[int, float] = float("inf") if before is None else before
+        after_: int = 0 if after is None else after
 
         def wrapper(engine: "Engine", event: int) -> bool:
-            if event > after and event < before:
+            if event > after_ and event < before_:
                 return True
             return False
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -298,6 +298,16 @@ class Events(EventEnum):
         def call_once(engine):
             # do something on 50th iteration
 
+        # d) "before" event filter
+        @engine.on(Events.EPOCH_STARTED(before=10))
+        def call_before(engine):
+            # do something in 1 to 9 epoch
+
+        # e) "after" event filter
+        @engine.on(Events.ITERATION_STARTED(after=1000))
+        def call_after(engine):
+            # do something after the 1000th iteration
+
     Event filter function `event_filter` accepts as input `engine` and `event` and should return True/False.
     Argument `event` is the value of iteration or epoch, depending on which type of Events the function is passed.
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -141,7 +141,7 @@ class CallableEventWithFilter:
         return wrapper
 
     @staticmethod
-    def before_and_after_event_filter(before: int = None, after: int = None) -> Callable:
+    def before_and_after_event_filter(before: Optional[int] = None, after: Optional[int] = None) -> Callable:
         """A wrapper for before and after event filter."""
         before = float("inf") if before is None else before
         after = 0 if after is None else after

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -71,13 +71,18 @@ class CallableEventWithFilter:
             CallableEventWithFilter: A new event having the same value but a different filter function
         """
 
-        if sum((
-            event_filter is not None,
-            every is not None,
-            once is not None,
-            before is not None,
-            after is not None,
-        )) != 1:
+        if (
+            sum(
+                (
+                    event_filter is not None,
+                    every is not None,
+                    once is not None,
+                    before is not None,
+                    after is not None,
+                )
+            )
+            != 1
+        ):
             raise ValueError("Only one of the input arguments should be specified")
 
         if (event_filter is not None) and not callable(event_filter):

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -583,4 +583,5 @@ def test_list_of_events():
 
     _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(once=1), [1, 1])
     _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(once=10), [1, 10])
-    _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(every=3), [1, 3, 6, 9, 12, 15])
+    _test(Events.ITERATION_STARTED(once=8) | Events.ITERATION_STARTED(before=3), [1, 2, 8])
+    _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(after=12), [1, 13, 14, 15])

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -145,6 +145,12 @@ def test_callable_events_with_wrong_inputs():
     with pytest.raises(ValueError, match=r"Argument once should be integer and positive"):
         Events.ITERATION_STARTED(once=-1)
 
+    with pytest.raises(ValueError, match=r"Argument before should be integer and greater or equal to zero"):
+        Events.ITERATION_STARTED(before=-1)
+
+    with pytest.raises(ValueError, match=r"Argument after should be integer and greater or equal to zero"):
+        Events.ITERATION_STARTED(after=-1)
+
     with pytest.raises(ValueError, match=r"but will be called with"):
         Events.ITERATION_STARTED(event_filter=lambda x: x)
 
@@ -583,5 +589,6 @@ def test_list_of_events():
 
     _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(once=1), [1, 1])
     _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(once=10), [1, 10])
+    _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(every=3), [1, 3, 6, 9, 12, 15])
     _test(Events.ITERATION_STARTED(once=8) | Events.ITERATION_STARTED(before=3), [1, 2, 8])
     _test(Events.ITERATION_STARTED(once=1) | Events.ITERATION_STARTED(after=12), [1, 13, 14, 15])

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -313,14 +313,17 @@ def test_every_event_filter_with_engine():
     _test_every_event_filter_with_engine()
 
 
-@pytest.mark.parametrize("event_name, event_attr, before, expect_calls", [
-    (Events.ITERATION_COMPLETED, "iteration", 0, 0),
-    (Events.ITERATION_COMPLETED, "iteration", 300, 299),
-    (Events.ITERATION_COMPLETED, "iteration", 501, 500),
-    (Events.EPOCH_COMPLETED, "epoch", 0, 0),
-    (Events.EPOCH_COMPLETED, "epoch", 3, 2),
-    (Events.EPOCH_COMPLETED, "epoch", 6, 5)
-])
+@pytest.mark.parametrize(
+    "event_name, event_attr, before, expect_calls",
+    [
+        (Events.ITERATION_COMPLETED, "iteration", 0, 0),
+        (Events.ITERATION_COMPLETED, "iteration", 300, 299),
+        (Events.ITERATION_COMPLETED, "iteration", 501, 500),
+        (Events.EPOCH_COMPLETED, "epoch", 0, 0),
+        (Events.EPOCH_COMPLETED, "epoch", 3, 2),
+        (Events.EPOCH_COMPLETED, "epoch", 6, 5),
+    ],
+)
 def test_before_event_filter_with_engine(event_name, event_attr, before, expect_calls):
 
     data = range(100)
@@ -338,14 +341,17 @@ def test_before_event_filter_with_engine(event_name, event_attr, before, expect_
     assert num_calls == expect_calls
 
 
-@pytest.mark.parametrize("event_name, event_attr, after, expect_calls", [
-    (Events.ITERATION_STARTED, "iteration", 0, 500),
-    (Events.ITERATION_COMPLETED, "iteration", 300, 200),
-    (Events.ITERATION_COMPLETED, "iteration", 500, 0),
-    (Events.EPOCH_STARTED, "epoch", 0, 5),
-    (Events.EPOCH_COMPLETED, "epoch", 3, 2),
-    (Events.EPOCH_COMPLETED, "epoch", 5, 0),
-])
+@pytest.mark.parametrize(
+    "event_name, event_attr, after, expect_calls",
+    [
+        (Events.ITERATION_STARTED, "iteration", 0, 500),
+        (Events.ITERATION_COMPLETED, "iteration", 300, 200),
+        (Events.ITERATION_COMPLETED, "iteration", 500, 0),
+        (Events.EPOCH_STARTED, "epoch", 0, 5),
+        (Events.EPOCH_COMPLETED, "epoch", 3, 2),
+        (Events.EPOCH_COMPLETED, "epoch", 5, 0),
+    ],
+)
 def test_after_event_filter_with_engine(event_name, event_attr, after, expect_calls):
 
     data = range(100)
@@ -363,10 +369,10 @@ def test_after_event_filter_with_engine(event_name, event_attr, after, expect_ca
     assert num_calls == expect_calls
 
 
-@pytest.mark.parametrize("event_name, event_attr, before, after, expect_calls", [
-    (Events.ITERATION_STARTED, "iteration", 300, 100, 199),
-    (Events.EPOCH_COMPLETED, "epoch", 4, 1, 2)
-])
+@pytest.mark.parametrize(
+    "event_name, event_attr, before, after, expect_calls",
+    [(Events.ITERATION_STARTED, "iteration", 300, 100, 199), (Events.EPOCH_COMPLETED, "epoch", 4, 1, 2)],
+)
 def test_before_and_after_event_filter_with_engine(event_name, event_attr, before, after, expect_calls):
 
     data = range(100)

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -313,77 +313,75 @@ def test_every_event_filter_with_engine():
     _test_every_event_filter_with_engine()
 
 
-def test_before_event_filter_with_engine():
+@pytest.mark.parametrize("event_name, event_attr, before, expect_calls", [
+    (Events.ITERATION_COMPLETED, "iteration", 0, 0),
+    (Events.ITERATION_COMPLETED, "iteration", 300, 299),
+    (Events.ITERATION_COMPLETED, "iteration", 501, 500),
+    (Events.EPOCH_COMPLETED, "epoch", 0, 0),
+    (Events.EPOCH_COMPLETED, "epoch", 3, 2),
+    (Events.EPOCH_COMPLETED, "epoch", 6, 5)
+])
+def test_before_event_filter_with_engine(event_name, event_attr, before, expect_calls):
 
     data = range(100)
 
-    def _test(event_name, event_attr, before, expect_calls):
-        engine = Engine(lambda e, b: 1)
-        num_calls = 0
+    engine = Engine(lambda e, b: 1)
+    num_calls = 0
 
-        @engine.on(event_name(before=before))
-        def _before_event():
-            nonlocal num_calls
-            num_calls += 1
-            assert getattr(engine.state, event_attr) < before
+    @engine.on(event_name(before=before))
+    def _before_event():
+        nonlocal num_calls
+        num_calls += 1
+        assert getattr(engine.state, event_attr) < before
 
-        engine.run(data, max_epochs=5)
-        assert num_calls == expect_calls
-
-    _test(Events.ITERATION_COMPLETED, "iteration", 0, 0)
-    _test(Events.ITERATION_COMPLETED, "iteration", 300, 299)
-    _test(Events.ITERATION_COMPLETED, "iteration", 501, 500)
-
-    _test(Events.EPOCH_COMPLETED, "epoch", 0, 0)
-    _test(Events.EPOCH_COMPLETED, "epoch", 3, 2)
-    _test(Events.EPOCH_COMPLETED, "epoch", 6, 5)
+    engine.run(data, max_epochs=5)
+    assert num_calls == expect_calls
 
 
-def test_after_event_filter_with_engine():
-
-    data = range(100)
-
-    def _test(event_name, event_attr, after, expect_calls):
-        engine = Engine(lambda e, b: 1)
-        num_calls = 0
-
-        @engine.on(event_name(after=after))
-        def _after_event():
-            nonlocal num_calls
-            num_calls += 1
-            assert getattr(engine.state, event_attr) > after
-
-        engine.run(data, max_epochs=5)
-        assert num_calls == expect_calls
-
-    _test(Events.ITERATION_STARTED, "iteration", 0, 500)
-    _test(Events.ITERATION_COMPLETED, "iteration", 300, 200)
-    _test(Events.ITERATION_COMPLETED, "iteration", 500, 0)
-
-    _test(Events.EPOCH_STARTED, "epoch", 0, 5)
-    _test(Events.EPOCH_COMPLETED, "epoch", 3, 2)
-    _test(Events.EPOCH_COMPLETED, "epoch", 5, 0)
-
-
-def test_before_and_after_event_filter_with_engine():
+@pytest.mark.parametrize("event_name, event_attr, after, expect_calls", [
+    (Events.ITERATION_STARTED, "iteration", 0, 500),
+    (Events.ITERATION_COMPLETED, "iteration", 300, 200),
+    (Events.ITERATION_COMPLETED, "iteration", 500, 0),
+    (Events.EPOCH_STARTED, "epoch", 0, 5),
+    (Events.EPOCH_COMPLETED, "epoch", 3, 2),
+    (Events.EPOCH_COMPLETED, "epoch", 5, 0),
+])
+def test_after_event_filter_with_engine(event_name, event_attr, after, expect_calls):
 
     data = range(100)
 
-    def _test(event_name, event_attr, before, after, expect_calls):
-        engine = Engine(lambda e, b: 1)
-        num_calls = 0
+    engine = Engine(lambda e, b: 1)
+    num_calls = 0
 
-        @engine.on(event_name(before=before, after=after))
-        def _before_and_after_event():
-            nonlocal num_calls
-            num_calls += 1
-            assert getattr(engine.state, event_attr) > after
+    @engine.on(event_name(after=after))
+    def _after_event():
+        nonlocal num_calls
+        num_calls += 1
+        assert getattr(engine.state, event_attr) > after
 
-        engine.run(data, max_epochs=5)
-        assert num_calls == expect_calls
+    engine.run(data, max_epochs=5)
+    assert num_calls == expect_calls
 
-    _test(Events.ITERATION_STARTED, "iteration", 300, 100, 199)
-    _test(Events.EPOCH_COMPLETED, "epoch", 4, 1, 2)
+
+@pytest.mark.parametrize("event_name, event_attr, before, after, expect_calls", [
+    (Events.ITERATION_STARTED, "iteration", 300, 100, 199),
+    (Events.EPOCH_COMPLETED, "epoch", 4, 1, 2)
+])
+def test_before_and_after_event_filter_with_engine(event_name, event_attr, before, after, expect_calls):
+
+    data = range(100)
+
+    engine = Engine(lambda e, b: 1)
+    num_calls = 0
+
+    @engine.on(event_name(before=before, after=after))
+    def _before_and_after_event():
+        nonlocal num_calls
+        num_calls += 1
+        assert getattr(engine.state, event_attr) > after
+
+    engine.run(data, max_epochs=5)
+    assert num_calls == expect_calls
 
 
 def test_once_event_filter_with_engine():


### PR DESCRIPTION
Description:

add before and after events filter

```python
@trainer.on(Events.EPOCH_COMPLETED(before=10))
def foo1():
    pass

@trainer.on(Events.EPOCH_COMPLETED(after=10))
def foo2():
    pass
```

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
