### PR TITLE
fix visdom tests

### DIFF
--- a/tests/ignite/contrib/conftest.py
+++ b/tests/ignite/contrib/conftest.py
@@ -1,4 +1,5 @@
 import random
+from pathlib import Path
 
 import pytest
 
@@ -28,6 +29,7 @@ def visdom_server():
         from visdom import Visdom
         from visdom.server import download_scripts
 
+        (Path.home() / ".visdom").mkdir(exist_ok=True)
         download_scripts()
 
         vd_hostname = "localhost"

--- a/tests/ignite/contrib/handlers/test_visdom_logger.py
+++ b/tests/ignite/contrib/handlers/test_visdom_logger.py
@@ -857,7 +857,6 @@ def test_integration_no_server():
         VisdomLogger()
 
 
-@pytest.mark.skip(reason="temporary pass ci")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
 def test_logger_init_hostname_port(visdom_server):
     # Explicit hostname, port
@@ -866,7 +865,6 @@ def test_logger_init_hostname_port(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skip(reason="temporary pass ci")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
 def test_logger_init_env_vars(visdom_server):
     # As env vars
@@ -885,7 +883,6 @@ def _parse_content(content):
     return json.loads(content)
 
 
-@pytest.mark.skip(reason="temporary pass ci")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
 def test_integration_no_executor(visdom_server):
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=0)
@@ -922,7 +919,6 @@ def test_integration_no_executor(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skip(reason="temporary pass ci")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
 def test_integration_with_executor(visdom_server):
     vd_logger = VisdomLogger(server=visdom_server[0], port=visdom_server[1], num_workers=1)
@@ -960,7 +956,6 @@ def test_integration_with_executor(visdom_server):
     vd_logger.close()
 
 
-@pytest.mark.skip(reason="temporary pass ci")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
 def test_integration_with_executor_as_context_manager(visdom_server, visdom_server_stop):
 


### PR DESCRIPTION
Fixes #2738 

The error is that `visdom` failed to start the server since it can not find `$HOME/.visdom` directory. This directory may have been automatically created in the previous version of `visdom`. I have had a test that in a brand-new virtual env, install visdom and try to start server by `python -m visdom.server`, it also failed for the same reason.

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
