### PR TITLE
Fix visdom bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
             docker exec -it pthd /bin/bash -c "$minst1_cmd"
 
             # 2) mnist_with_visdom.py
-            export visdom_script_cmd='python -c "from visdom.server import download_scripts; download_scripts()"'
+            export visdom_script_cmd='python -c "from visdom.server.build import download_scripts; download_scripts()"'
             export visdom_cmd='python -m visdom.server'
             docker exec -d pthd /bin/bash -c "$visdom_script_cmd && $visdom_cmd"
             export sleep_cmd='sleep 10'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -133,7 +133,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           # 2) mnist_with_visdom.py
-          python -c "from visdom.server import download_scripts; download_scripts()" # download scripts : https://github.com/facebookresearch/visdom/blob/master/py/server.py#L929
+          python -c "from visdom.server.build import download_scripts; download_scripts()" # download scripts : https://github.com/facebookresearch/visdom/blob/master/py/server.py#L929
           python -m visdom.server &
           sleep 10
           python examples/mnist/mnist_with_visdom.py --epochs=1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ tqdm
 scikit-learn
 matplotlib
 tensorboardX
-visdom
+visdom==0.2.2.post1
 # temporary fix for
 # ImportError: cannot import name 'soft_unicode' from 'markupsafe'
 markupsafe==2.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ tqdm
 scikit-learn
 matplotlib
 tensorboardX
-visdom==0.2.2.post1
+visdom==0.2.3
 # temporary fix for
 # ImportError: cannot import name 'soft_unicode' from 'markupsafe'
 markupsafe==2.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ tqdm
 scikit-learn
 matplotlib
 tensorboardX
-visdom==0.2.2.post1
+visdom
 # temporary fix for
 # ImportError: cannot import name 'soft_unicode' from 'markupsafe'
 markupsafe==2.0.1

--- a/tests/ignite/contrib/conftest.py
+++ b/tests/ignite/contrib/conftest.py
@@ -27,7 +27,7 @@ def visdom_server():
         import time
 
         from visdom import Visdom
-        from visdom.server import download_scripts
+        from visdom.server.build import download_scripts
 
         (Path.home() / ".visdom").mkdir(exist_ok=True)
         download_scripts()


### PR DESCRIPTION
Fixes #2745

It's a bug of visdom `0.2.2` https://github.com/fossasia/visdom/issues/878 , they already released `0.2.2.post1` to fix it. Actually rerunning the tests without pip cache will automatically solve the import error since we are not pinning the version in `requirements-dev.txt`, so it will get the fixed version.

But after updating to `0.2.2.post1` tests still fail due to another error, see the code changed.

`visdom` is frequently doing some code refactoring, I'm afraid some errors may occur for the same reason in the future. Should we pin the version or just let the CI fail and fix it?

@vfdev-5 


