### PR TITLE
Fix some bugs in `conftest.py`, one in `_destroy_dist_context` and the other in `distributed`

### DIFF
--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -457,7 +457,6 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> None:
 
                 test_func(**kwargs)
 
-
                 hvd.shutdown()
 
             try:

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -457,11 +457,6 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> None:
 
                 test_func(**kwargs)
 
-                # Added a sleep to avoid flaky failures on circle ci
-                # Sometimes a rank is terminated before final collective
-                # op is finished.
-                # https://github.com/pytorch/ignite/pull/2357
-                time.sleep(2)
 
                 hvd.shutdown()
 

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -364,7 +364,6 @@ is_xla_single_device_stash_key = pytest.StashKey[bool]()
 
 
 @pytest.fixture(
-    scope="module",
     params=[
         pytest.param("nccl", marks=[pytest.mark.distributed, skip_if_has_not_native_dist_support, skip_if_no_gpu]),
         pytest.param("gloo_cpu", marks=[pytest.mark.distributed, skip_if_has_not_native_dist_support]),

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -106,10 +106,14 @@ def _create_dist_context(dist_info, lrank):
 
 def _destroy_dist_context():
 
-    dist.barrier()
-
     if dist.get_rank() == 0:
-        Path("/tmp/free_port").unlink(True)
+        # To support Python 3.7; Otherwise we could do `.unlink(missing_ok=True)`
+        try:
+            Path("/tmp/free_port").unlink()
+        except FileNotFoundError:
+            pass
+
+    dist.barrier()
 
     dist.destroy_process_group()
 

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -107,6 +107,10 @@ def _create_dist_context(dist_info, lrank):
 def _destroy_dist_context():
 
     dist.barrier()
+
+    if idist.get_rank() == 0:
+        Path("/tmp/free_port").unlink(True)
+
     dist.destroy_process_group()
 
     from ignite.distributed.utils import _SerialModel, _set_model

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -490,7 +490,7 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> None:
             if "COLAB_TPU_ADDR" in os.environ:
                 spawn_kwargs["start_method"] = "fork"
             try:
-                xmp.spawn(xla_worker, args=(testfunc), **spawn_kwargs)
+                xmp.spawn(xla_worker, args=(testfunc,), **spawn_kwargs)
             except SystemExit as ex_:
                 assert ex_.code == 0, "Didn't successfully exit in XLA test"
 

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -108,7 +108,7 @@ def _destroy_dist_context():
 
     dist.barrier()
 
-    if idist.get_rank() == 0:
+    if dist.get_rank() == 0:
         Path("/tmp/free_port").unlink(True)
 
     dist.destroy_process_group()
@@ -433,7 +433,7 @@ def distributed(request, local_rank, world_size):
     elif request.param in ("single_device_xla", "xla_nprocs"):
         request.node.stash[is_xla_stash_key] = True
         request.node.stash[is_xla_single_device_stash_key] = request.param == "single_device_xla"
-        yield None
+        yield {"xla_index": -1} if request.param == "xla_nprocs" else None
     else:
         raise RuntimeError(f"Invalid parameter value for `distributed` fixture, given {request.param}")
 
@@ -441,9 +441,57 @@ def distributed(request, local_rank, world_size):
 @pytest.hookimpl
 def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> None:
     if pyfuncitem.stash.get(is_horovod_stash_key, False):
-        nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
-        pyfuncitem.obj = functools.partial(_gloo_hvd_execute, pyfuncitem.obj, (), np=nproc)
+
+        def testfunc_wrapper(test_func, **kwargs):
+            def hvd_worker():
+                import horovod.torch as hvd
+
+                hvd.init()
+                lrank = hvd.local_rank()
+                if torch.cuda.is_available():
+                    torch.cuda.set_device(lrank)
+
+                test_func(**kwargs)
+
+                # Added a sleep to avoid flaky failures on circle ci
+                # Sometimes a rank is terminated before final collective
+                # op is finished.
+                # https://github.com/pytorch/ignite/pull/2357
+                time.sleep(2)
+
+                hvd.shutdown()
+
+            try:
+                # old API
+                from horovod.run.runner import run
+            except ImportError:
+                # new API: https://github.com/horovod/horovod/pull/2099
+                from horovod import run
+
+            nproc = 4 if not torch.cuda.is_available() else torch.cuda.device_count()
+            hvd_kwargs = dict(use_gloo=True, num_proc=nproc)
+            run(hvd_worker, **hvd_kwargs)
+
+        pyfuncitem.obj = functools.partial(testfunc_wrapper, pyfuncitem.obj)
 
     elif pyfuncitem.stash.get(is_xla_stash_key, False) and not pyfuncitem.stash[is_xla_single_device_stash_key]:
-        n = int(os.environ["NUM_TPU_WORKERS"])
-        pyfuncitem.obj = functools.partial(_xla_execute, pyfuncitem.obj, (), n)
+
+        def testfunc_wrapper(testfunc, **kwargs):
+            def xla_worker(index, fn):
+                import torch_xla.core.xla_model as xm
+
+                kwargs["distributed"]["xla_index"] = index
+                xm.rendezvous("init")
+                fn(**kwargs)
+
+            import torch_xla.distributed.xla_multiprocessing as xmp
+
+            spawn_kwargs = {"nprocs": int(os.environ["NUM_TPU_WORKERS"])}
+            if "COLAB_TPU_ADDR" in os.environ:
+                spawn_kwargs["start_method"] = "fork"
+            try:
+                xmp.spawn(xla_worker, args=(testfunc), **spawn_kwargs)
+            except SystemExit as ex_:
+                assert ex_.code == 0, "Didn't successfully exit in XLA test"
+
+        pyfuncitem.obj = functools.partial(testfunc_wrapper, pyfuncitem.obj)


### PR DESCRIPTION
Description:
1. One step in NCCL and Gloo single node distributed settings is to setup a port shared by the processes. This is done using a temporary file in which the rank zero writes the port number and the others read it. Currently this file isn't deleted at the end, so in the case a process other than rank 0 opens the file first, it reads the port being used in the past which results in timeout error in all ranks. This bug is not encountered in GitHub CI because disk resources are newly allocated, so the temporary file does not exist.
2. To reduce setup and teardown time, I had set the scope of `distributed` fixture to `module` so as to have just one distributed setup and teardown for all distributed tests in a module but this caused some non-distributed tests to fail. It turned out that the teardown of the last instance of the fixture (we have an instance for `nccl`, one for `gloo`, one for `gloo_cpu` and...) takes place after running the last test of the module, even if it has not requested the fixture. Running the snippet below which is originally from [pytest website](https://docs.pytest.org/en/7.0.x/how-to/fixtures.html#automatic-grouping-of-tests-by-fixture-instances) shows this fact:

```python
import pytest


@pytest.fixture(scope="module", params=["mod1", "mod2"])
def modarg(request):
    param = request.param
    print("  SETUP modarg", param)
    yield param
    print("  TEARDOWN modarg", param)


@pytest.fixture(scope="function", params=[1, 2])
def otherarg(request):
    param = request.param
    print("  SETUP otherarg", param)
    yield param
    print("  TEARDOWN otherarg", param)


def test_0(otherarg):
    print("  RUN test0 with otherarg", otherarg)


def test_1(modarg):
    print("  RUN test1 with modarg", modarg)

def test_11():
    print("hi")

def test_2(otherarg, modarg):
    print("  RUN test2 with otherarg {} and modarg {}".format(otherarg, modarg))

def test_3():
    print("there!")
```
Output:
![image](https://user-images.githubusercontent.com/22097587/204156307-35af799f-1966-4f63-95c9-f035e8720183.png)

So I changed the scope of the fixture from `module` to `function` to solve the issue.
