### PR TITLE
[BC-breaking] Align ssim with psnr, metric output is tensor

### DIFF
--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -180,7 +180,7 @@ class SSIM(Metric):
         self._num_examples += y.shape[0]
 
     @sync_all_reduce("_sum_of_ssim", "_num_examples")
-    def compute(self) -> float:
+    def compute(self) -> torch.Tensor:
         if self._num_examples == 0:
             raise NotComputableError("SSIM must have at least one example before it can be computed.")
-        return (self._sum_of_ssim / self._num_examples).item()
+        return self._sum_of_ssim / self._num_examples


### PR DESCRIPTION
Description:
For the current version, the output of psnr and ssim are differnt type, where the type of psnr.comute() is `torch.Tensor` but the ssim.compute() is `float`
```
psnr = PSNR(data_range=1.0)
psnr.update((torch.rand([4, 3, 16, 16]),torch.rand([4, 3, 16, 16])))
psnr = psnr.compute()
print(psnr, type(psnr))

ssim = SSIM(data_range=1.0, gaussian=True, sigma=1.5)
ssim.update((torch.rand([4, 3, 16, 16]), torch.rand([4, 3, 16, 16])))
ssim = ssim.compute()

print(ssim, type(ssim))
```
 This is because in the ssim.py, there used `.item()`

https://github.com/pytorch/ignite/blob/cdf7b47802c8f8f65bd1bfef933e9154d696e317/ignite/metrics/psnr.py#L120-L124

while
https://github.com/pytorch/ignite/blob/cdf7b47802c8f8f65bd1bfef933e9154d696e317/ignite/metrics/ssim.py#L182-L186

The two metrics PSNR and SSIM are always used together. So I think it's better for the same input to have the same type of output. This is intuitive.


Check list:
I dont modify any unit test.
- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
