### PR TITLE
Drop python 3.7 from CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,7 +48,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build hvd hvd-base
         working-directory: docker
         run: |
@@ -83,10 +83,10 @@ jobs:
       - name: Remove cache
         run: |
           sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"      
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build hvd hvd-apex
         working-directory: docker
         run: |
@@ -121,10 +121,10 @@ jobs:
       - name: Remove cache
         run: |
           sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"      
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build main base
         working-directory: docker
         run: |
@@ -156,10 +156,10 @@ jobs:
       - name: Remove cache
         run: |
           sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"      
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build main apex
         working-directory: docker
         run: |
@@ -191,10 +191,10 @@ jobs:
       - name: Remove cache
         run: |
           sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"      
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build msdp msdp-apex
         working-directory: docker
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Trigger Circle-CI pipeline
         env:
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - run: sudo npm install katex -g
       - uses: actions/cache@v2
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - uses: actions/cache@v3
         with:
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - run: sudo npm install katex -g
       - uses: actions/cache@v3

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [ 3.8, 3.9, "3.10"]
         pytorch-version:
           [1.12.1, 1.11.0, 1.10.0, 1.9.1, 1.8.1, 1.7.1, 1.6.0, 1.5.1, 1.4.0, 1.3.1]
         exclude:

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        python-version: [ 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
         pytorch-version:
           [1.12.1, 1.11.0, 1.10.0, 1.9.1, 1.8.1, 1.7.1, 1.6.0, 1.5.1, 1.4.0, 1.3.1]
         exclude:

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Trigger Circle-CI pipeline
         env:
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -62,9 +62,10 @@ jobs:
           # mkl version fixed due to https://github.com/pytorch/ignite/issues/2350
           pip install mkl==2021.4.0 requests gsutil
 
-          ## Install torch & xla
-          curl https://raw.githubusercontent.com/abhi-glitchhg/ignite_tpu_script/main/env_setup.py -o pytorch-xla-env-setup.py
-          python pytorch-xla-env-setup.py --version "nightly"
+          ## Install torch & xla and torchvision
+          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch-nightly-cp38-cp38-linux_x86_64.whl
+          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-nightly-cp38-cp38-linux_x86_64.whl
+          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torchvision-nightly-cp38-cp38-linux_x86_64.whl
 
           ## Install test deps and Ignite
           pip install -r requirements-dev.txt

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           architecture: "x64"
 
       - name: Get year & week number

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -63,7 +63,7 @@ jobs:
           pip install mkl==2021.4.0 requests gsutil
 
           ## Install torch & xla
-          curl https://raw.githubusercontent.com/pytorch/xla/master/contrib/scripts/env-setup.py -o pytorch-xla-env-setup.py
+          curl https://raw.githubusercontent.com/abhi-glitchhg/ignite_tpu_script/main/env_setup.py -o pytorch-xla-env-setup.py
           python pytorch-xla-env-setup.py --version "nightly"
 
           ## Install test deps and Ignite

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [ 3.8, 3.9, "3.10"]
         pytorch-channel: [pytorch, pytorch-nightly]
         include:
           # includes a single build on windows

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [ 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
         pytorch-channel: [pytorch, pytorch-nightly]
         include:
           # includes a single build on windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 


### PR DESCRIPTION
Fixes #2834 

I used `grep` command to look for 3.7 in workflow files; and also removed the target version `py37` from `pyproject.toml` file. 


Opening as a draft to check CI is happy with current state. 

