### PR TITLE
Fix the broken link for a paper `A Systematic Comparison of Smoothing Techniques for Sentence-Level BLEU`

### DIFF
--- a/ignite/metrics/nlp/bleu.py
+++ b/ignite/metrics/nlp/bleu.py
@@ -76,7 +76,7 @@ class Bleu(Metric):
 
     In addition, a review of smoothing techniques can be found in `Chen et al. 2014`__
 
-    __ http://acl2014.org/acl2014/W14-33/pdf/W14-3346.pdf
+    __ https://aclanthology.org/W14-3346.pdf
 
     - ``update`` must receive output of the form ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y}``.
     - `y_pred` (list(list(str))) - a list of hypotheses sentences.


### PR DESCRIPTION
i think http://acl2014.org/acl2014 is down. So updating the link with aclanthology link. 


