### PR TITLE
Update Doctest for precision_recall_curve.py

### DIFF
--- a/ignite/contrib/metrics/precision_recall_curve.py
+++ b/ignite/contrib/metrics/precision_recall_curve.py
@@ -65,9 +65,9 @@ class PrecisionRecallCurve(EpochMetric):
 
         .. testoutput::
 
-            Precision [1.0, 1.0, 1.0]
-            Recall [1.0, 0.5, 0.0]
-            Thresholds [0.7109, 0.9997]
+            Precision [0.5, 0.6667, 1.0, 1.0, 1.0]
+            Recall [1.0, 1.0, 1.0, 0.5, 0.0]
+            Thresholds [0.0474, 0.5987, 0.7109, 0.9997]
 
     """
 


### PR DESCRIPTION
* In accordance with the Update of Scikit-Learn with version 1.1.1

Fixes #2850 

Description:
- The failure happens with [Precision Recall Curve](https://pytorch.org/ignite/generated/ignite.contrib.metrics.PrecisionRecallCurve.html)
- This was an issue with `scikit-learn` which was resolved in their [PR - FIX compute precision-recall at 100% recall](https://github.com/scikit-learn/scikit-learn/pull/23214)
	- This was because `precision_recall_curve()` was not returning the full curve at high recall
	- Read more about the issue [here](https://github.com/scikit-learn/scikit-learn/issues/23213)
- This Issue persisted Till now because `scikit-learn==1.0.2`  was being installed and the change in Precision Recall Curve was in version `scikit-learn==1.1.1`
- Possible reason why this was happening - Python 3.7 was being used, when that changed and [3.7 was dropped from CI](https://github.com/pytorch/ignite/pull/2836) 

Changes:
- Updated the Doctests to match with Scikit-Learn

Old DocTest Returns:
```md
Precision [1.0, 1.0, 1.0]
Recall [1.0, 0.5, 0.0]
Thresholds [0.7109, 0.9997]
```
Updated to New DocTest Returns:
```md
Precision [0.5, 0.6667, 1.0, 1.0, 1.0]
Recall [1.0, 1.0, 1.0, 0.5, 0.0]
Thresholds [0.0474, 0.5987, 0.7109, 0.9997]
```

Check list:

- [ ] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
