### PR TITLE
Added every_before_after event filter

### DIFF
--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -71,18 +71,14 @@ class CallableEventWithFilter:
             CallableEventWithFilter: A new event having the same value but a different filter function
         """
 
-        if (
-            sum(
-                (
-                    event_filter is not None,
-                    every is not None,
-                    once is not None,
-                    (before is not None or after is not None),
-                )
-            )
-            != 1
+        if (event_filter is not None) and (
+            once is not None or every is not None or before is not None or after is not None
         ):
-            raise ValueError("Only one of the input arguments should be specified except before and after")
+            raise ValueError("Only One of the Input Arguments should be Specified, except Before, after and Every")
+        if not (event_filter is not None) and not (
+            once is not None or every is not None or before is not None or after is not None
+        ):
+            raise ValueError("All of the Arguments cannot be undefined")
 
         if (event_filter is not None) and not callable(event_filter):
             raise TypeError("Argument event_filter should be a callable")

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -318,10 +318,10 @@ class Events(EventEnum):
         def call_before(engine):
             # do something in 11 to 29 epoch
 
-        # e) once "every" iterations "before" and "after" evnt filter
+        # e) Mixing "every" and "before" / "after" event filters
         @engine.on(Events.EPOCH_STARTED(every=5, before=25, after=8))
         def call_every_itr_before_after(engine):
-            # do something on 9, 14, 19, 24 iterations
+            # do something on 9, 14, 19, 24 epochs
 
     Event filter function `event_filter` accepts as input `engine` and `event` and should return True/False.
     Argument `event` is the value of iteration or epoch, depending on which type of Events the function is passed.

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -81,7 +81,7 @@ class CallableEventWithFilter:
             )
             != 1
         ):
-            raise ValueError("Only one of the Input Arguments should be Sepcified, except before, after and every")
+            raise ValueError("Only one of the input arguments should be specified, " "except before, after and every")
 
         if (event_filter is not None) and not callable(event_filter):
             raise TypeError("Argument event_filter should be a callable")

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -82,7 +82,7 @@ class CallableEventWithFilter:
             )
             != 1
         ):
-            raise ValueError("Only one of the input arguments should be specified, " "except before, after and every")
+            raise ValueError("Only one of the input arguments should be specified, except before, after and every")
 
         if (event_filter is not None) and not callable(event_filter):
             raise TypeError("Argument event_filter should be a callable")

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -110,7 +110,10 @@ class CallableEventWithFilter:
             event_filter = self.once_event_filter(once)
 
         if before is not None or after is not None:
-            event_filter = self.before_and_after_event_filter(before, after)
+            if every is not None:
+                event_filter = self.before_and_after_every_event_filter(every, before, after)
+            else:
+                event_filter = self.before_and_after_event_filter(before, after)
 
         # check signature:
         if event_filter is not None:
@@ -148,6 +151,21 @@ class CallableEventWithFilter:
 
         def wrapper(engine: "Engine", event: int) -> bool:
             if event > after_ and event < before_:
+                return True
+            return False
+
+        return wrapper
+
+    @staticmethod
+    def before_and_after_every_event_filter(
+        every: int, before: Optional[int] = None, after: Optional[int] = None
+    ) -> Callable:
+        """A wrapper which triggers for every `every` iterations after `after` and before `before`."""
+        before_: Union[int, float] = float("inf") if before is None else before
+        after_: int = 0 if after is None else after
+
+        def wrapper(engine: "Engine", event: int) -> bool:
+            if after_ < event < before_ and (event - after - 1) % every == 0:
                 return True
             return False
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -165,7 +165,7 @@ class CallableEventWithFilter:
         after_: int = 0 if after is None else after
 
         def wrapper(engine: "Engine", event: int) -> bool:
-            if after_ < event < before_ and (event - after - 1) % every == 0:
+            if after_ < event < before_ and (event - after_ - 1) % every == 0:
                 return True
             return False
 

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -309,6 +309,10 @@ class Events(EventEnum):
         def call_before(engine):
             # do something in 11 to 29 epoch
 
+        # e) once "every" iterations "before" and "after" evnt filter
+        @engine.on(Events.EPOCH_STARTED(every=5, before=25, after=8))
+        def call_every_itr_before_after(engine):
+            # do something on 9, 14, 19, 24 iterations
 
     Event filter function `event_filter` accepts as input `engine` and `event` and should return True/False.
     Argument `event` is the value of iteration or epoch, depending on which type of Events the function is passed.

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -71,14 +71,17 @@ class CallableEventWithFilter:
             CallableEventWithFilter: A new event having the same value but a different filter function
         """
 
-        if (event_filter is not None) and (
-            once is not None or every is not None or before is not None or after is not None
+        if (
+            sum(
+                (
+                    event_filter is not None,
+                    once is not None,
+                    (every is not None or before is not None or after is not None),
+                )
+            )
+            != 1
         ):
-            raise ValueError("Only One of the Input Arguments should be Specified, except Before, after and Every")
-        if not (event_filter is not None) and not (
-            once is not None or every is not None or before is not None or after is not None
-        ):
-            raise ValueError("All of the Arguments cannot be undefined")
+            raise ValueError("Only one of the Input Arguments should be Sepcified, except before, after and every")
 
         if (event_filter is not None) and not callable(event_filter):
             raise TypeError("Argument event_filter should be a callable")
@@ -107,7 +110,7 @@ class CallableEventWithFilter:
 
         if before is not None or after is not None:
             if every is not None:
-                event_filter = self.before_and_after_every_event_filter(every, before, after)
+                event_filter = self.every_before_and_after_event_filter(every, before, after)
             else:
                 event_filter = self.before_and_after_event_filter(before, after)
 
@@ -153,7 +156,7 @@ class CallableEventWithFilter:
         return wrapper
 
     @staticmethod
-    def before_and_after_every_event_filter(
+    def every_before_and_after_event_filter(
         every: int, before: Optional[int] = None, after: Optional[int] = None
     ) -> Callable:
         """A wrapper which triggers for every `every` iterations after `after` and before `before`."""

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -129,8 +129,9 @@ def test_custom_events_with_events_list():
 
 
 def test_callable_events_with_wrong_inputs():
+    def ef(e, i):
+        return 1
 
-    ef = lambda e, i: 1
     for event_filter in [None, ef]:
         for every in [None, 2]:
             for once in [None, 2]:
@@ -142,7 +143,8 @@ def test_callable_events_with_wrong_inputs():
                     except ValueError:
                         with pytest.raises(
                             ValueError,
-                            match=r"Only one of the Input Arguments should be Sepcified, except before, after and every",
+                            match=r"Only one of the input arguments should be specified, "
+                            "except before, after and every",
                         ):
                             Events.ITERATION_STARTED(
                                 event_filter=event_filter, once=once, every=every, before=before, after=after

--- a/tests/ignite/engine/test_custom_events.py
+++ b/tests/ignite/engine/test_custom_events.py
@@ -132,15 +132,47 @@ def test_callable_events_with_wrong_inputs():
     def ef(e, i):
         return 1
 
+    expected_raise = {
+        # event_filter, every, once, before, after
+        (None, None, None, None, None): True,  # raises ValueError
+        (ef, None, None, None, None): False,
+        (None, 2, None, None, None): False,
+        (ef, 2, None, None, None): True,
+        (None, None, 2, None, None): False,
+        (ef, None, 2, None, None): True,
+        (None, 2, 2, None, None): True,
+        (ef, 2, 2, None, None): True,
+        (None, None, None, 30, None): False,
+        (ef, None, None, 30, None): True,
+        (None, 2, None, 30, None): False,
+        (ef, 2, None, 30, None): True,
+        (None, None, 2, 30, None): True,
+        (ef, None, 2, 30, None): True,
+        (None, 2, 2, 30, None): True,
+        (ef, 2, 2, 30, None): True,
+        # event_filter, every, once, before, after
+        (None, None, None, None, 10): False,
+        (ef, None, None, None, 10): True,
+        (None, 2, None, None, 10): False,
+        (ef, 2, None, None, 10): True,
+        (None, None, 2, None, 10): True,
+        (ef, None, 2, None, 10): True,
+        (None, 2, 2, None, 10): True,
+        (ef, 2, 2, None, 10): True,
+        (None, None, None, 25, 8): False,
+        (ef, None, None, 25, 8): True,
+        (None, 2, None, 25, 8): False,
+        (ef, 2, None, 25, 8): True,
+        (None, None, 2, 25, 8): True,
+        (ef, None, 2, 25, 8): True,
+        (None, 2, 2, 25, 8): True,
+        (ef, 2, 2, 25, 8): True,
+    }
     for event_filter in [None, ef]:
         for every in [None, 2]:
             for once in [None, 2]:
                 for before, after in [(None, None), (None, 10), (30, None), (25, 8)]:
-                    try:
-                        assert Events.ITERATION_STARTED(
-                            event_filter=event_filter, once=once, every=every, before=before, after=after
-                        )
-                    except ValueError:
+                    if expected_raise[(event_filter, every, once, before, after)]:
                         with pytest.raises(
                             ValueError,
                             match=r"Only one of the input arguments should be specified, "
@@ -149,6 +181,10 @@ def test_callable_events_with_wrong_inputs():
                             Events.ITERATION_STARTED(
                                 event_filter=event_filter, once=once, every=every, before=before, after=after
                             )
+                    else:
+                        Events.ITERATION_STARTED(
+                            event_filter=event_filter, once=once, every=every, before=before, after=after
+                        )
 
     with pytest.raises(TypeError, match=r"Argument event_filter should be a callable"):
         Events.ITERATION_STARTED(event_filter="123")


### PR DESCRIPTION
Related to #2853 

Description:

* New Feature
* Executes after every `every` Iterations
* For after=8, before=25, every=5 Executes on Iterations 9 14 19 24

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
