### PR TITLE
Update gh actions on push

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -15,9 +15,6 @@ on:
       - "!docs/**"
       - "!conda.recipe"
 
-  # pull_request:
-  #     paths:
-
 
 jobs:
   code-style:
@@ -25,11 +22,6 @@ jobs:
     steps:
       - if: github.event_name == 'push'
         uses: actions/checkout@v3
-      #       - if: github.event_name == 'pull_request'
-      #         uses: actions/checkout@v2
-      #         with:
-      #           ref: ${{ github.head_ref }}
-
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,15 @@ name: Build docs
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     paths-ignore:
       - "tests/**"
       - "docker/**"
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build-deploy:

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -1,17 +1,12 @@
 name: Run Horovod tests
 on:
-  push:
-    paths:
-      - "ignite/**"
-      - "tests/ignite/**"
-      - "tests/run_cpu_tests.sh"
-      - ".github/workflows/hvd-tests.yml"
   pull_request:
     paths:
       - "ignite/**"
       - "tests/ignite/**"
       - "tests/run_cpu_tests.sh"
       - ".github/workflows/hvd-tests.yml"
+  workflow_dispatch:
 
 concurrency:
   # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -1,17 +1,12 @@
 name: Run TPU tests
 on:
-  push:
-    paths:
-      - "ignite/**"
-      - "tests/ignite/**"
-      - "tests/run_tpu_tests.sh"
-      - ".github/workflows/tpu-tests.yml"
   pull_request:
     paths:
       - "ignite/**"
       - "tests/ignite/**"
       - "tests/run_tpu_tests.sh"
       - ".github/workflows/tpu-tests.yml"
+  workflow_dispatch:
 
 concurrency:
   # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,15 +1,5 @@
 name: Run unit tests
 on:
-  push:
-    paths:
-      - "ignite/**"
-      - "tests/ignite/**"
-      - "tests/run_cpu_tests.sh"
-      - "tests/run_code_style.sh"
-      - "examples/**.py"
-      - "requirements-dev.txt"
-      - ".github/workflows/unit-tests.yml"
-
   pull_request:
     paths:
       - "ignite/**"
@@ -19,6 +9,7 @@ on:
       - "examples/**.py"
       - "requirements-dev.txt"
       - ".github/workflows/unit-tests.yml"
+  workflow_dispatch:
 
 concurrency:
   # <workflow_name>-<branch_name>-<true || commit_sha (if branch is protected)>


### PR DESCRIPTION
Description:
- reduce the number of ci jobs if PR is open from a repo's branch to master : do not run "push"-event jobs, only "pull_request"-event ones

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
