### PR TITLE
Fixed 'Open in Colab' button + highlighted packages in text

### DIFF
--- a/examples/notebooks/TextCNN.ipynb
+++ b/examples/notebooks/TextCNN.ipynb
@@ -983,7 +983,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -997,7 +997,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/TextCNN.ipynb
+++ b/examples/notebooks/TextCNN.ipynb
@@ -6,7 +6,7 @@
     "id": "RfRKTxQO51bK"
    },
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/pytorch/ignite/blob/master/examples/notebooks/TextCNN.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pytorch/ignite/blob/master/examples/notebooks/TextCNN.ipynb)"
    ]
   },
   {
@@ -42,7 +42,7 @@
    "source": [
     "## Required Dependencies \n",
     "\n",
-    "In this example we only need torchtext and spacy package, assuming that `torch` and `ignite` are already installed. We can install it using `pip`:\n",
+    "In this example we only need `torchtext` and `spacy` package, assuming that `torch` and `ignite` are already installed. We can install it using `pip`:\n",
     "\n",
     "`pip install torchtext==0.9.1 spacy`\n",
     "\n",
@@ -983,7 +983,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -997,7 +997,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.11.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
These changes are for the file `ignite/examples/notebooks/TextCNN.ipynb`
Description: 
- Fixed the "Open in Colab" button.
- Cleared up confusion regarding packages being installed in the first code block by highlighting 'torchtext' and 'spacy' as packages. 