### PR TITLE
Update pytorch-version-tests.yml

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -16,40 +16,41 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10"]
         pytorch-version:
-          [1.12.1, 1.11.0, 1.10.0, 1.9.1, 1.8.1, 1.7.1, 1.6.0, 1.5.1, 1.4.0, 1.3.1]
+          [1.13.1, 1.12.1, 1.11.0, 1.10.0, 1.9.1, 1.8.1, 1.7.1, 1.6.0, 1.5.1, 1.4.0]
         exclude:
-          - pytorch-version: 1.3.1
-            python-version: 3.8
-          - pytorch-version: 1.3.1
-            python-version: 3.9
           - pytorch-version: 1.4.0
             python-version: 3.9
+          - pytorch-version: 1.4.0
+            python-version: 3.10
+            
           - pytorch-version: 1.5.1
             python-version: 3.9
+          - pytorch-version: 1.5.1
+            python-version: 3.10
+
           - pytorch-version: 1.6.0
             python-version: 3.9
+          - pytorch-version: 1.6.0
+            python-version: 3.10
+
           # disabling python 3.9 support with PyTorch 1.7.1 and 1.8.1, to stop repeated pytorch-version test fail.
           # https://github.com/pytorch/ignite/issues/2383
           - pytorch-version: 1.7.1
             python-version: 3.9
-          - pytorch-version: 1.8.1
-            python-version: 3.9
-          - pytorch-version: 1.3.1
-            python-version: 3.10
-          - pytorch-version: 1.4.0
-            python-version: 3.10
-          - pytorch-version: 1.5.1
-            python-version: 3.10
-          - pytorch-version: 1.6.0
-            python-version: 3.10
           - pytorch-version: 1.7.1
             python-version: 3.10
+
+          - pytorch-version: 1.8.1
+            python-version: 3.9
           - pytorch-version: 1.8.1
             python-version: 3.10
+
           - pytorch-version: 1.9.1
             python-version: 3.10
+
           - pytorch-version: 1.10.0
             python-version: 3.10
+
           - pytorch-version: 1.11.0
             python-version: 3.10
 
@@ -90,13 +91,6 @@ jobs:
           conda install pytorch=${{ matrix.pytorch-version }} torchvision cpuonly python=${{ matrix.python-version }} -c pytorch
           pip install -r requirements-dev.txt
           python setup.py install
-
-      - name: Install appropriate Pillow for PyTorch 1.3.1
-        shell: bash -l {0}
-        if: ${{ matrix.pytorch-version == '1.3.1' }}
-        run: |
-          pip install --upgrade 'Pillow<7'
-          python -c "import torchvision"
 
       - name: Download MNIST
         uses: pytorch-ignite/download-mnist-github-action@master

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -87,8 +87,17 @@ jobs:
 
       - name: Install dependencies
         shell: bash -l {0}
+        if: ${{ matrix.pytorch-version != '1.4.0' }}
         run: |
           conda install pytorch=${{ matrix.pytorch-version }} torchvision cpuonly python=${{ matrix.python-version }} -c pytorch
+          pip install -r requirements-dev.txt
+          python setup.py install
+
+      - name: Install appropriate dependencies for PyTorch 1.4.0
+        shell: bash -l {0}
+        if: ${{ matrix.pytorch-version == '1.4.0' }}
+        run: |
+          conda install pytorch=${{ matrix.pytorch-version }} torchvision="0.5.0" cpuonly python=${{ matrix.python-version }} -c pytorch
           pip install -r requirements-dev.txt
           python setup.py install
 

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -93,11 +93,14 @@ jobs:
           pip install -r requirements-dev.txt
           python setup.py install
 
+      # There is no more torchvision 0.5.0 binaries in anaconda pytorch channel:
+      # https://anaconda.org/pytorch/torchvision/files 
       - name: Install appropriate dependencies for PyTorch 1.4.0
         shell: bash -l {0}
         if: ${{ matrix.pytorch-version == '1.4.0' }}
-        run: |
-          conda install pytorch=${{ matrix.pytorch-version }} torchvision="0.5.0" cpuonly python=${{ matrix.python-version }} -c pytorch
+        run: |         
+          conda install pytorch=${{ matrix.pytorch-version }} cpuonly python=${{ matrix.python-version }} -c pytorch
+          pip install torchvision==0.5.0
           pip install -r requirements-dev.txt
           python setup.py install
 


### PR DESCRIPTION
Fixes #2889

Description:
- removed untested configuration v1.3.1 as we previously dropped python 3.7 support
- added v1.13.1 as pt2.0 will be released very soon
- Fixes deps failure with v1.4.0, related to installed torchvision version:
```
    pytorch-1.4.0              |cuda101py38h02f0884_0       302.8 MB
    torchvision-0.13.1         |cpu_py38h164cc8f_0         6.2 MB
```
but correct torchvision version should be `0.5.0`.

CI logs:
- https://github.com/pytorch/ignite/actions/runs/4423968579
  - https://github.com/pytorch/ignite/actions/runs/4423968579/jobs/7757238738

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
