### PR TITLE
Add knob (IGNITE_DISABLE_DISTRIBUTED_METRICS=1) to disable distributed metrics reduction

### DIFF
--- a/ignite/contrib/metrics/precision_recall_curve.py
+++ b/ignite/contrib/metrics/precision_recall_curve.py
@@ -92,7 +92,7 @@ class PrecisionRecallCurve(EpochMetric):
             _prediction_tensor = torch.cat(self._predictions, dim=0)
             _target_tensor = torch.cat(self._targets, dim=0)
 
-            ws = idist.get_world_size()
+            ws = idist.get_metrics_computation_world_size()
             if ws > 1:
                 # All gather across all processes
                 _prediction_tensor = cast(torch.Tensor, idist.all_gather(_prediction_tensor))

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -1,3 +1,4 @@
+import os
 import socket
 from functools import wraps
 from typing import Any, Callable, List, Mapping, Optional, Tuple, Union
@@ -20,6 +21,7 @@ __all__ = [
     "available_backends",
     "model_name",
     "get_world_size",
+    "get_metrics_computation_world_size",
     "get_rank",
     "get_local_rank",
     "get_nproc_per_node",
@@ -139,6 +141,14 @@ def get_world_size() -> int:
         sync(temporary=True)
 
     return _model.get_world_size()
+
+
+def get_metrics_computation_world_size() -> int:
+    """Returns world size of current distributed configuration for metrics computation. Returns 1 if no distributed configuration."""
+    if os.environ.get("IGNITE_DISABLE_DISTRIBUTED_METRICS") == "1":
+        return 1
+
+    return get_world_size()
 
 
 def get_rank() -> int:

--- a/ignite/metrics/epoch_metric.py
+++ b/ignite/metrics/epoch_metric.py
@@ -144,7 +144,7 @@ class EpochMetric(Metric):
             _prediction_tensor = torch.cat(self._predictions, dim=0)
             _target_tensor = torch.cat(self._targets, dim=0)
 
-            ws = idist.get_world_size()
+            ws = idist.get_metrics_computation_world_size()
             if ws > 1:
                 # All gather across all processes
                 _prediction_tensor = cast(torch.Tensor, idist.all_gather(_prediction_tensor))

--- a/ignite/metrics/frequency.py
+++ b/ignite/metrics/frequency.py
@@ -61,8 +61,8 @@ class Frequency(Metric):
     def compute(self) -> float:
         time_divisor = 1.0
 
-        if idist.get_world_size() > 1:
-            time_divisor *= idist.get_world_size()
+        if idist.get_metrics_computation_world_size() > 1:
+            time_divisor *= idist.get_metrics_computation_world_size()
 
         # Returns the average processed objects per second across all workers
         return self._n / self._elapsed * time_divisor

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -554,7 +554,7 @@ def sync_all_reduce(*attrs: Any) -> Callable:
                 raise RuntimeError(
                     "Decorator sync_all_reduce should be used on ignite.metric.Metric class methods only"
                 )
-            ws = idist.get_world_size()
+            ws = idist.get_metrics_computation_world_size()
             unreduced_attrs = {}
             if len(attrs) > 0 and ws > 1:
                 for attr in attrs:

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -154,7 +154,7 @@ class RunningAverage(Metric):
     @sync_all_reduce("src")
     def _get_output_value(self) -> Union[torch.Tensor, float]:
         # we need to compute average instead of sum produced by @sync_all_reduce("src")
-        output = cast(Union[torch.Tensor, float], self.src) / idist.get_world_size()
+        output = cast(Union[torch.Tensor, float], self.src) / idist.get_metrics_computation_world_size()
         return output
 
     def _metric_iteration_completed(self, engine: Engine) -> None:


### PR DESCRIPTION
This is useful for setups where distributed training is used, but evaluation is only performed on a single node (or independently over multiple nodes).

Description: In some setups one may want to have two different fleets for distributed training and (distributed) validation, however ignite currently conflates the two world sizes. Using this PR as a RFC before adding tests and extra documentation (if needed).

Check list:

- [?] New tests are added (if a new feature is added)
- [?] New doc strings: description and/or example code are in RST format
- [?] Documentation is updated (if required)
