### PR TITLE
[fix] make sure neptune saves the checkpoint

### DIFF
--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -1,7 +1,7 @@
 """Neptune logger and its helper handlers."""
 import tempfile
-from typing import Any, Callable, List, Mapping, Optional, Union
 import warnings
+from typing import Any, Callable, List, Mapping, Optional, Union
 
 import torch
 from torch.optim import Optimizer

--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -1,6 +1,7 @@
 """Neptune logger and its helper handlers."""
 import tempfile
 from typing import Any, Callable, List, Mapping, Optional, Union
+import warnings
 
 import torch
 from torch.optim import Optimizer
@@ -163,8 +164,6 @@ class NeptuneLogger(BaseLogger):
         self.experiment[key] = val
 
     def __init__(self, api_token: Optional[str] = None, project: Optional[str] = None, **kwargs: Any) -> None:
-        import warnings
-
         try:
             try:
                 # neptune-client<1.0.0 package structure


### PR DESCRIPTION
Neptune logger doesn't actually save the checkpoint.

Simple reproducer:
```python
import torch
import tempfile
import neptune
import time


class Net(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.linear = torch.nn.Linear(8192, 8192)

    def forward(self, x):
        return self.linear(x)


model = Net()

run = neptune.init_run()

start = time.time()
with tempfile.NamedTemporaryFile() as tmp:
    torch.save(model.state_dict(), tmp.file)
    run['model'].upload(tmp.name)  # Fails because (upload is async and once outside of tmp context the file is deleted).

print(time.time() - start)


start = time.time()
with tempfile.NamedTemporaryFile() as tmp:
    torch.save(model.state_dict(), tmp.file)
    # Uploads in chunks.
    run['model_stream'].upload(neptune.types.File.from_stream(tmp.file))  # Works!

print(time.time() - start)

```

Description:

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
