### PR TITLE
[follow-up] NeptuneSaver fixes

### DIFF
--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -1,7 +1,7 @@
 """Neptune logger and its helper handlers."""
 import tempfile
-from typing import Any, Callable, List, Mapping, Optional, Union
 import warnings
+from typing import Any, Callable, List, Mapping, Optional, Union
 
 import torch
 from torch.optim import Optimizer

--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -617,6 +617,10 @@ class NeptuneSaver(BaseSaveHandler):
         neptune_logger: an instance of
             NeptuneLogger class.
 
+    .. Note ::
+
+        NeptuneSaver is currently not supported on Windows.
+
     Examples:
         .. code-block:: python
 

--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -683,14 +683,18 @@ class NeptuneSaver(BaseSaveHandler):
             # neptune>=1.0.0 package structure
             from neptune.types import File
 
-        with tempfile.TemporaryFile() as tmp:
-            torch.save(checkpoint, tmp)
-            tmp.seek(0)
+        with tempfile.NamedTemporaryFile() as tmp:
+            # we can not use tmp.name to open tmp.file twice on Win32
+            # https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
+            torch.save(checkpoint, tmp.file)
+
+            # rewind the buffer
+            tmp.file.seek(0)
 
             # hold onto the file stream for uploading.
             # NOTE: This won't load the whole file in memory and upload
             #       the stream in smaller chunks.
-            self._logger[filename].upload(File.from_stream(tmp))
+            self._logger[filename].upload(File.from_stream(tmp.file))
 
     @idist.one_rank_only(with_barrier=True)
     def remove(self, filename: str) -> None:

--- a/ignite/contrib/handlers/neptune_logger.py
+++ b/ignite/contrib/handlers/neptune_logger.py
@@ -1,6 +1,7 @@
 """Neptune logger and its helper handlers."""
 import tempfile
 from typing import Any, Callable, List, Mapping, Optional, Union
+import warnings
 
 import torch
 from torch.optim import Optimizer
@@ -163,8 +164,6 @@ class NeptuneLogger(BaseLogger):
         self.experiment[key] = val
 
     def __init__(self, api_token: Optional[str] = None, project: Optional[str] = None, **kwargs: Any) -> None:
-        import warnings
-
         try:
             try:
                 # neptune-client<1.0.0 package structure


### PR DESCRIPTION
Fixes 

* Correctly rewind the temporary files buffer.
* Correctly remove the file from a run. `delete_files` is not supported on `Run` object.
* Update the saver doc to reflect that Windows is not supported (as `TemporaryFile` and `NamedTemporaryFile` don't work correctly on Windows)



Description:

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
