### PR TITLE
fixed output_list | now it has only 5 elements instead of 5*batchsize

### DIFF
--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -159,10 +159,10 @@ class SSIM(Metric):
         y_pred = F.pad(y_pred, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
         y = F.pad(y, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
 
-        input_list = torch.cat([y_pred, y, y_pred * y_pred, y * y, y_pred * y])
-        outputs = F.conv2d(input_list, self._kernel, groups=channel)
-
-        output_list = [outputs[x * y_pred.size(0) : (x + 1) * y_pred.size(0)] for x in range(len(outputs))]
+        input_list= [y_pred, y, y_pred * y_pred, y * y, y_pred * y]
+        outputs = F.conv2d(torch.cat(input_list), self._kernel, groups=channel)
+        
+        output_list = [outputs[x * y_pred.size(0) : (x + 1) * y_pred.size(0)] for x in range(len(input_list))]
 
         mu_pred_sq = output_list[0].pow(2)
         mu_target_sq = output_list[1].pow(2)

--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -159,10 +159,10 @@ class SSIM(Metric):
         y_pred = F.pad(y_pred, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
         y = F.pad(y, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
 
-        input_list= [y_pred, y, y_pred * y_pred, y * y, y_pred * y]
+        input_list = [y_pred, y, y_pred * y_pred, y * y, y_pred * y]
         outputs = F.conv2d(torch.cat(input_list), self._kernel, groups=channel)
-        
-        output_list = [outputs[x * y_pred.size(0) : (x + 1) * y_pred.size(0)] for x in range(len(input_list))]
+        batch_size = y_pred.size(0)
+        output_list = [outputs[x * batch_size : (x + 1) * batch_size] for x in range(len(input_list))]
 
         mu_pred_sq = output_list[0].pow(2)
         mu_target_sq = output_list[1].pow(2)


### PR DESCRIPTION
Fixes #2913

Description:
---
This pull request updates the code in `ignite/metrics/ssim.py` so it won't create extra `torch.Tensor`s.
The changes involve modifying the list comprehension that creates the  `output_list`, which has the wrong length of `BatchSize*5` instead of it being `5` (the same as `len([y_pred, y, y_pred * y_pred, y * y, y_pred * y])`). The elements with index>4 are empty tensors with shape `(0,C,H1,W1)` in the  `output_list`

Instead of concatenating the tensor inputs in `torch.cat([y_pred, y, y_pred * y_pred, y * y, y_pred * y])`, I have created a list of the input tensors as `input_list= [y_pred, y, y_pred * y_pred, y * y, y_pred * y]`, which I believe was the actual intention of the author.
Now we have access to the Length of this list, which we will use to retrieve `input_list` elements after passing them through a `conv2d` layer.
I then passed the concatenated input tensor using `torch.cat(input_list)` which has a size of `(B*5, C, H1, W1)` to the `F.conv2d` function call.

After that, the `outputs` which is a tensor with shape `(B*5, C, H, W)` is sliced for every `Batch` element to return a list of `5` elements. this is where the previous code had a problem and instead of a list of `5` (or `len(input_list)`) tensors, it was returning a list of  `B*5` elements, where only its first five elements were actual tensors and the rest where empty when the `Batch_size>1`.
(the previous code was calling `tesnor[index1:index2]` where `index1` and `index2` were larger than `tensor.size(0)` which was returning empty tensors)


We can see in lines `167-173` that the elements with indices `0-4` are being used, which proves this issue.

I have tested these changes on my local machine and confirmed that they do not introduce any new issues. Please let me know if there are any concerns or feedback regarding these changes.

Thanks for considering this pull request!


Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
