### PR TITLE
Improve RunningAverage reset when epoch_bound=False

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -531,7 +531,7 @@
     indexName: 'pytorch-ignite',
     placeholder: 'Search PyTorch-Ignite docs',
     searchParameters: {
-      facetFilters: [[`version:${VERSION}`, 'tags:ignite-web']],
+      facetFilters: [`version:${VERSION}`, 'tags:API-reference'],
     }
   });
   </script>

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -143,6 +143,8 @@ class RunningAverage(Metric):
         if self.epoch_bound:
             # restart average every epoch
             engine.add_event_handler(Events.EPOCH_STARTED, self.started)
+        else:
+            engine.add_event_handler(Events.EPOCH_STARTED(once=1), self.started)
         # compute metric
         engine.add_event_handler(Events.ITERATION_COMPLETED, self.iteration_completed)
         # apply running average

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -144,7 +144,7 @@ class RunningAverage(Metric):
             # restart average every epoch
             engine.add_event_handler(Events.EPOCH_STARTED, self.started)
         else:
-            engine.add_event_handler(Events.EPOCH_STARTED(once=1), self.started)
+            engine.add_event_handler(Events.STARTED, self.started)
         # compute metric
         engine.add_event_handler(Events.ITERATION_COMPLETED, self.iteration_completed)
         # apply running average

--- a/tests/ignite/metrics/test_running_average.py
+++ b/tests/ignite/metrics/test_running_average.py
@@ -146,9 +146,7 @@ def test_epoch_unbound():
 
     running_avg_acc = [None]
 
-    @trainer.on(Events.STARTED)
-    def running_avg_output_init(engine):
-        engine.state.running_avg_output = None
+    trainer.state.running_avg_output = None
 
     @trainer.on(Events.ITERATION_COMPLETED, running_avg_acc)
     def manual_running_avg_acc(engine, running_avg_acc):
@@ -187,7 +185,8 @@ def test_epoch_unbound():
 
     trainer.run(data, max_epochs=3)
 
-    running_avg_acc[:] = [None]
+    running_avg_acc[0] = None
+    trainer.state.running_avg_output = None
     trainer.run(data, max_epochs=3)
 
 

--- a/tests/ignite/metrics/test_running_average.py
+++ b/tests/ignite/metrics/test_running_average.py
@@ -188,7 +188,7 @@ def test_epoch_unbound():
     trainer.run(data, max_epochs=3)
 
     running_avg_acc[:] = [None]
-    trainer.run([1] * n_iters, max_epochs=3)
+    trainer.run(data, max_epochs=3)
 
 
 def test_multiple_attach():

--- a/tests/ignite/metrics/test_running_average.py
+++ b/tests/ignite/metrics/test_running_average.py
@@ -125,9 +125,9 @@ def test_epoch_unbound():
     batch_size = 10
     n_classes = 10
     data = list(range(n_iters))
-    loss_values = iter(range(n_epochs * n_iters))
-    y_true_batch_values = iter(np.random.randint(0, n_classes, size=(n_epochs * n_iters, batch_size)))
-    y_pred_batch_values = iter(np.random.rand(n_epochs * n_iters, batch_size, n_classes))
+    loss_values = iter(range(2 * n_epochs * n_iters))
+    y_true_batch_values = iter(np.random.randint(0, n_classes, size=(2 * n_epochs * n_iters, batch_size)))
+    y_pred_batch_values = iter(np.random.rand(2 * n_epochs * n_iters, batch_size, n_classes))
 
     def update_fn(engine, batch):
         loss_value = next(loss_values)
@@ -186,6 +186,9 @@ def test_epoch_unbound():
         ), f"{engine.state.running_avg_output} vs {engine.state.metrics['running_avg_output']}"
 
     trainer.run(data, max_epochs=3)
+
+    running_avg_acc[:] = [None]
+    trainer.run([1] * n_iters, max_epochs=3)
 
 
 def test_multiple_attach():


### PR DESCRIPTION
Description:
When `epoch_bound=False`, an explicit `metric.reset()` was required before
another `engine.run`. This PR gets `RunningAverage` to reset itself automatically.

Check list:

- [x] New tests are added (if a new feature is added)
