### PR TITLE
Improve collective ops on numeric input

### DIFF
--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -187,10 +187,9 @@ class ComputationModel(metaclass=ABCMeta):
         device = self.device()
         if isinstance(tensor, (Number, float)):
             tensor_to_number = True
-            if self._collective_op_dtype is None:
-                dtype = torch.double if isinstance(tensor, float) else torch.int64
-            else:
-                dtype = self._collective_op_dtype
+            dtype = self._collective_op_dtype
+            if dtype is None and isinstance(tensor, float):
+                dtype = torch.double
             tensor = torch.tensor(tensor, device=device, dtype=dtype)
         elif isinstance(tensor, str):
             tensor_to_str = True

--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -187,7 +187,11 @@ class ComputationModel(metaclass=ABCMeta):
         device = self.device()
         if isinstance(tensor, (Number, float)):
             tensor_to_number = True
-            tensor = torch.tensor(tensor, device=device, dtype=self._collective_op_dtype)
+            if self._collective_op_dtype is None:
+                dtype = torch.double if isinstance(tensor, float) else torch.int64
+            else:
+                dtype = self._collective_op_dtype
+            tensor = torch.tensor(tensor, device=device, dtype=dtype)
         elif isinstance(tensor, str):
             tensor_to_str = True
             max_length = self._get_max_length(tensor, device)


### PR DESCRIPTION
Description:
When `ComputationModel._collective_op_dtype` is `None` and the input to a
collective op is a float number, the constructed intermediate tensor is of
dtype `torch.float32` rather than `torch.double`, hence we would have a loss
in precision.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
