### PR TITLE
Fixed mypy failure with DistributedSampler

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -264,7 +264,7 @@ def _setup_common_distrib_training_handlers(
 
         @trainer.on(Events.EPOCH_STARTED)
         def distrib_set_epoch(engine: Engine) -> None:
-            cast(DistributedSampler, train_sampler).set_epoch(engine.state.epoch - 1)
+            train_sampler.set_epoch(engine.state.epoch - 1)
 
 
 def empty_cuda_cache(_: Engine) -> None:


### PR DESCRIPTION
Description:
- Fixed mypy failure with DistributedSampler

Reported in this job: https://github.com/pytorch/ignite/actions/runs/5331802470/jobs/9660132586?pr=2967#step:12:16
```
+ mypy --config-file mypy.ini
ignite/contrib/engines/common.py:267: error: Redundant cast to
"DistributedSampler[Any]"  [redundant-cast]
                cast(DistributedSampler, train_sampler).set_epoch(engine.s...
```

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
