### PR TITLE
Fix: change the dtype of self._kernel when input args have a different dtype

### DIFF
--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -13,7 +13,10 @@ class SSIM(Metric):
     """
     Computes Structural Similarity Index Measure
 
-    - ``update`` must receive output of the form ``(y_pred, y)``.
+    - ``update`` must receive output of the form ``(y_pred, y)``. They have to be of the same type.
+        Valid :class:`torch.dtype` are the following:
+        - on CPU: torch.float32.
+        - on cuda: torch.float16, torch.float32, torch.float64.
 
     Args:
         data_range: Range of the image. Typically, ``1.0`` or ``255``.

--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -161,7 +161,7 @@ class SSIM(Metric):
         y_pred = F.pad(y_pred, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
         y = F.pad(y, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
 
-        if y_pred.dtype != torch.get_default_dtype():
+        if y_pred.dtype != self._kernel.dtype:
             self._kernel = self._kernel.to(dtype=y_pred.dtype)
 
         input_list = [y_pred, y, y_pred * y_pred, y * y, y_pred * y]

--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -15,8 +15,8 @@ class SSIM(Metric):
 
     - ``update`` must receive output of the form ``(y_pred, y)``. They have to be of the same type.
         Valid :class:`torch.dtype` are the following:
-        - on CPU: torch.float32.
-        - on cuda: torch.float16, torch.float32, torch.float64.
+        - on CPU: `torch.float32`, `torch.float64`.
+        - on cuda: `torch.float16`, `torch.float32`, `torch.float64`.
 
     Args:
         data_range: Range of the image. Typically, ``1.0`` or ``255``.

--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -16,7 +16,7 @@ class SSIM(Metric):
     - ``update`` must receive output of the form ``(y_pred, y)``. They have to be of the same type.
         Valid :class:`torch.dtype` are the following:
         - on CPU: `torch.float32`, `torch.float64`.
-        - on cuda: `torch.float16`, `torch.float32`, `torch.float64`.
+        - on CUDA: `torch.float16`, `torch.bfloat16`, `torch.float32`, `torch.float64`.
 
     Args:
         data_range: Range of the image. Typically, ``1.0`` or ``255``.

--- a/ignite/metrics/ssim.py
+++ b/ignite/metrics/ssim.py
@@ -161,6 +161,9 @@ class SSIM(Metric):
         y_pred = F.pad(y_pred, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
         y = F.pad(y, [self.pad_w, self.pad_w, self.pad_h, self.pad_h], mode="reflect")
 
+        if y_pred.dtype != torch.get_default_dtype():
+            self._kernel = self._kernel.to(dtype=y_pred.dtype)
+
         input_list = [y_pred, y, y_pred * y_pred, y * y, y_pred * y]
         outputs = F.conv2d(torch.cat(input_list), self._kernel, groups=channel)
         batch_size = y_pred.size(0)

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -70,7 +70,9 @@ def test_invalid_ssim():
     "shape, kernel_size, gaussian, use_sample_covariance",
     [[(8, 3, 224, 224), 7, False, True], [(12, 3, 28, 28), 11, True, False]],
 )
-def test_ssim(available_device, shape, kernel_size, gaussian, use_sample_covariance, dtype=torch.float32, precision=7e-5):
+def test_ssim(
+    available_device, shape, kernel_size, gaussian, use_sample_covariance, dtype=torch.float32, precision=7e-5
+):
     y_pred = torch.rand(shape, device=available_device, dtype=dtype)
     y = y_pred * 0.8
 
@@ -127,23 +129,14 @@ def test_ssim_variable_batchsize(available_device):
 
 
 @pytest.mark.parametrize(
-    "dtype, precision",
-    [(torch.bfloat16, 2e-3), (torch.float16, 4e-4), (torch.float32, 2e-5), (torch.float64, 2e-5)]
+    "dtype, precision", [(torch.bfloat16, 2e-3), (torch.float16, 4e-4), (torch.float32, 2e-5), (torch.float64, 2e-5)]
 )
 def test_cuda_ssim_dtypes(available_device, dtype, precision):
     # Checks https://github.com/pytorch/ignite/pull/3034
     if available_device == "cpu" and dtype in [torch.float16, torch.bfloat16]:
         pytest.skip(reason=f"Unsupported dtype {dtype} on CPU device")
 
-    test_ssim(
-        available_device,
-        (12, 3, 28, 28),
-        11,
-        True,
-        False,
-        dtype=dtype,
-        precision=precision
-    )
+    test_ssim(available_device, (12, 3, 28, 28), 11, True, False, dtype=dtype, precision=precision)
 
 
 @pytest.mark.parametrize("metric_device", ["cpu", "process_device"])

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -127,7 +127,6 @@ def test_cuda_ssim_dtypes(available_device):
     # Checks https://github.com/pytorch/ignite/pull/3034
     # this test should not be run on CPU
     if available_device == "cpu":
-        assert True
         return
 
     for dtype in [torch.float16, torch.float32, torch.float64]:

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -123,22 +123,22 @@ def test_ssim_variable_batchsize(available_device):
     assert np.allclose(out, expected)
 
 
-def test_cuda_ssim_dtypes(available_device):
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.float64])
+def test_cuda_ssim_dtypes(available_device, dtype):
     # Checks https://github.com/pytorch/ignite/pull/3034
     # this test should not be run on CPU
     if available_device == "cpu":
         return
 
-    for dtype in [torch.float16, torch.float32, torch.float64]:
-        test_ssim(
-            available_device,
-            (12, 3, 28, 28),
-            11,
-            True,
-            False,
-            dtype=dtype,
-            precision=4e-4
-        )
+    test_ssim(
+        available_device,
+        (12, 3, 28, 28),
+        11,
+        True,
+        False,
+        dtype=dtype,
+        precision=4e-4
+    )
 
 
 @pytest.mark.parametrize("metric_device", ["cpu", "process_device"])

--- a/tests/ignite/metrics/test_ssim.py
+++ b/tests/ignite/metrics/test_ssim.py
@@ -127,8 +127,8 @@ def test_ssim_variable_batchsize(available_device):
 def test_cuda_ssim_dtypes(available_device, dtype):
     # Checks https://github.com/pytorch/ignite/pull/3034
     # this test should not be run on CPU
-    if available_device == "cpu":
-        return
+    if available_device == "cpu" and dtype == torch.float16:
+        pytest.skip(reason="Unsupported dtype float16 on CPU device")
 
     test_ssim(
         available_device,


### PR DESCRIPTION
When the SSIM metric is given a float16 (Half) or float64 (Double), it fails because self._kernel will be of the default type.

There is two ways around that:
1. set the default dtype to Half or Double: `torch.set_default_dtype(torch.float16)`.
2. change self._kernel to take the dtype of the input tensor.

This pull request put the second option in action. The result is now transparent to the user who can use float16 or float64 **on GPU** directly.

A new test has been added to ensure of the right behaviour of this change.

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
