### PR TITLE
[Follow-up] Make `RunningAverage` and `Rouge` serializable

### DIFF
--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -554,31 +554,40 @@ class Metric(Serializable, metaclass=ABCMeta):
         `_state_dict_all_req_keys` attribute. Can be used to save internal state of the class.
 
         If there's an active distributed configuration, some collective operations is done and
-        the list of values across ranks is saved under each attribute's name in the dict.
+        the list of values across ranks is saved under each attribute's name in the dict, for numeric
+        and tensor values.
         """
-        state = OrderedDict()
+        state: Dict[str, Union[torch.Tensor, List, Dict, None]] = OrderedDict()
         for attr_name in self._state_dict_all_req_keys:
             if attr_name not in self.__dict__:
                 raise ValueError(
                     f"Found a value in _state_dict_all_req_keys that is not among metric attributes: {attr_name}"
                 )
             attr = getattr(self, attr_name)
-            if not isinstance(attr, (int, float, torch.Tensor)):
-                raise TypeError(
-                    "Currently, only numeric or tensor-typed attributes of the metric"
-                    " could be added to its state_dict."
-                )
-            if idist.get_world_size() == 1:
-                state[attr_name] = [attr]
+            if isinstance(attr, Mapping):
+                state[attr_name] = {k: m.state_dict() for k, m in attr.items()}
+            elif isinstance(attr, Sequence):
+                state[attr_name] = [m.state_dict() for m in attr]
+            elif isinstance(attr, Metric):
+                state[attr_name] = attr.state_dict()
+            elif isinstance(attr, (int, float, torch.Tensor)):
+                if idist.get_world_size() == 1:
+                    state[attr_name] = [attr]
+                else:
+                    if isinstance(attr, (int, float)):
+                        attr_type = type(attr)
+                        attr = float(attr)
+                    gathered_attr = idist.all_gather(attr)
+                    if isinstance(attr, float):
+                        gathered_attr = [attr_type(process_attr) for process_attr in cast(torch.Tensor, gathered_attr)]
+                    state[attr_name] = cast(Union[torch.Tensor, List], gathered_attr)
+            elif attr is None:
+                state[attr_name] = None
             else:
-                if isinstance(attr, (int, float)):
-                    attr_type = type(attr)
-                    attr = float(attr)
-                gathered_attr = cast(List[Any], idist.all_gather(attr))
-                if isinstance(attr, float):
-                    gathered_attr = [attr_type(process_attr) for process_attr in gathered_attr]
-                state[attr_name] = gathered_attr
-
+                raise TypeError(
+                    "Found attribute of unsupported type. Currently, supported types include"
+                    " numeric types, tensor, Metric or sequence/mapping of metrics."
+                )
         return state
 
     def load_state_dict(self, state_dict: Mapping) -> None:
@@ -593,8 +602,26 @@ class Metric(Serializable, metaclass=ABCMeta):
         """
         super().load_state_dict(state_dict)
         rank = idist.get_rank()
-        for attr in self._state_dict_all_req_keys:
-            setattr(self, attr, state_dict[attr][rank])
+        for attr_name in self._state_dict_all_req_keys:
+            attr = getattr(self, attr_name)
+            if isinstance(attr, Mapping):
+                for metric_name in attr:
+                    attr[metric_name].load_state_dict(state_dict[attr_name][metric_name])
+            elif isinstance(attr, Sequence):
+                for i, metric in enumerate(attr):
+                    metric.load_state_dict(state_dict[attr_name][i])
+            elif isinstance(attr, Metric):
+                attr.load_state_dict(state_dict[attr_name])
+            elif state_dict[attr_name] is None:
+                setattr(self, attr_name, None)
+            else:
+                world_size = idist.get_world_size()
+                len_rank_slice = len(state_dict[attr_name]) // world_size
+                if len_rank_slice == 1:
+                    setattr(self, attr_name, state_dict[attr_name][rank])
+                else:
+                    rank_slice = slice(rank * len_rank_slice, (rank + 1) * len_rank_slice)
+                    setattr(self, attr_name, state_dict[attr_name][rank_slice])
 
     def __add__(self, other: Any) -> "MetricsLambda":
         from ignite.metrics.metrics_lambda import MetricsLambda

--- a/ignite/metrics/nlp/rouge.py
+++ b/ignite/metrics/nlp/rouge.py
@@ -380,6 +380,8 @@ class Rouge(Metric):
         ``update`` method has changed and now works on batch of inputs.
     """
 
+    _state_dict_all_req_keys = ("internal_metrics",)
+
     def __init__(
         self,
         variants: Optional[Sequence[Union[str, int]]] = None,

--- a/ignite/metrics/running_average.py
+++ b/ignite/metrics/running_average.py
@@ -87,9 +87,7 @@ class RunningAverage(Metric):
     """
 
     required_output_keys = None
-    # TODO Shall we put `src` here? Then we should add a new branch for metric-typed attributes in `state_dict`
-    # and `load_state_dict`. Examples; This class; `Rouge` which has a `List[_BaseRouge]`.
-    _state_dict_all_req_keys = ("_value",)
+    _state_dict_all_req_keys = ("_value", "src")
 
     def __init__(
         self,


### PR DESCRIPTION
Now `state_dict` could serialize metric attributes that themselves are metric or simple collections of metrics.(For `Rouge`). If an attribute is `None`, `state_dict` sets the same in the dict (for `_value` in `RunningAverage`)
