### PR TITLE
[skip ci]Fixed not found link #3037

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ into the following categories:
 
 <details>
 
-- Install [miniconda](https://docs.conda.io/projects/continuumio-conda/en/latest/user-guide/install/index.html) for your system.
+- Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) for your system.
 - Create an isolated conda environment for pytorch-ignite:
 
 ```bash


### PR DESCRIPTION
Fixes #3037 

Description:
previous link is not found. The link is changed to https://docs.conda.io/en/latest/miniconda.html

Check list:

 - [ ] New tests are added (if a new feature is added)
 - [ ] New doc strings: description and/or example code are in RST format
 - [x] Documentation is updated (if required)