### PR TITLE
skip mkl install on non-x86 arch

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       max-parallel: 10
       fail-fast: false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,4 +31,4 @@ nltk
 # Examples dependencies
 pandas
 gymnasium
-mkl
+mkl;platform_machine=="x86_64"


### PR DESCRIPTION
Description:
- Issue reported on Discord: https://discord.com/channels/831462531327328276/831463420272312330/1143734021604528168

![image](https://github.com/pytorch/ignite/assets/2459423/f7cb377f-9297-43a7-884c-69f13de4265a)

- We can solve it by skipping mkl install on non-x86 arch
- [x] Need a manual check as we haven't yet set CI tests on M1 mac osx

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
