### PR TITLE
Fix Discord PR extension workflow output

### DIFF
--- a/.github/workflows/discord_issues.yml
+++ b/.github/workflows/discord_issues.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - labeled
-  pull_request:
-    types:
-      - labeled
   workflow_dispatch:
     inputs:
       issue_number:
@@ -15,7 +12,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   discord:

--- a/.github/workflows/discord_pull_requests.yaml
+++ b/.github/workflows/discord_pull_requests.yaml
@@ -25,5 +25,5 @@ jobs:
           destination: ${{ secrets.DISCORD_BOT_DESTINATION }}
           issue_number: ${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}
           issue_comment: Hey 👋, I've just created a [thread]($THREAD_LINK$) for this pull request on [PyTorch-Ignite Discord](https://pytorch-ignite.ai/chat) where you can quickly talk to the community on the topic.
-          discord_message: New PR created in `${{ github.repository }}`:<https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.pull_request.number }}>
+          discord_message: New PR created in `${{ github.repository }}`:<https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request_number || github.event.pull_request.number }}>
 

--- a/.github/workflows/discord_pull_requests.yaml
+++ b/.github/workflows/discord_pull_requests.yaml
@@ -8,6 +8,7 @@ on:
     inputs:
       pull_request_number:
         description: 'Pull request number'
+        required: true
 
 permissions:
   pull-requests: write
@@ -24,5 +25,5 @@ jobs:
           destination: ${{ secrets.DISCORD_BOT_DESTINATION }}
           issue_number: ${{ github.event.inputs.pull_request_number || github.event.pull_request.number }}
           issue_comment: Hey 👋, I've just created a [thread]($THREAD_LINK$) for this pull request on [PyTorch-Ignite Discord](https://pytorch-ignite.ai/chat) where you can quickly talk to the community on the topic.
-          discord_message: New PR created in `${{ github.repository }}`:<https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}>
+          discord_message: New PR created in `${{ github.repository }}`:<https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.pull_request.number }}>
 


### PR DESCRIPTION
Fixes #3014

Description:
The PR is to fix the wrong output of the Discord PR workflow, which now requires a pull request number to be a triggered. Also the issue workflow can't be triggered now when PR is labelled. This will fix the output of the comments in this extension. This PR also serves as a fix for the #3009.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
