### PR TITLE
Fix attribute error in `Checkpoint::reload_objects` when `save_handler` is not of type `DiskSaver`

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -670,7 +670,8 @@ class Checkpoint(Serializable):
             `DataParallel`_, method ``load_state_dict`` will applied to their internal wrapped model (``obj.module``).
 
         Note:
-            This method works only when the ``save_handler`` is of type :class:`~ignite.handlers.checkpoint.DiskSaver`.
+            This method works only when the ``save_handler`` is of types string,
+            :class:`~pathlib.Path` or :class:`~ignite.handlers.checkpoint.DiskSaver`.
 
         .. _DistributedDataParallel: https://pytorch.org/docs/stable/generated/
             torch.nn.parallel.DistributedDataParallel.html

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -669,10 +669,17 @@ class Checkpoint(Serializable):
             If ``to_load`` contains objects of type torch `DistributedDataParallel`_ or
             `DataParallel`_, method ``load_state_dict`` will applied to their internal wrapped model (``obj.module``).
 
+        Note:
+            This method works only when the ``save_handler`` is of type :class:`~ignite.handlers.checkpoint.DiskSaver`.
+
         .. _DistributedDataParallel: https://pytorch.org/docs/stable/generated/
             torch.nn.parallel.DistributedDataParallel.html
         .. _DataParallel: https://pytorch.org/docs/stable/generated/torch.nn.DataParallel.html
         """
+        if not isinstance(self.save_handler, DiskSaver):
+            raise AttributeError(
+                f"Checkpoint's `save_handler` should be of type `DiskSaver`, given {type(self.save_handler)}"
+            )
 
         global_step = filename_components.get("global_step", None)
 

--- a/tests/ignite/handlers/test_checkpoint.py
+++ b/tests/ignite/handlers/test_checkpoint.py
@@ -78,6 +78,10 @@ def test_checkpoint_wrong_input():
     with pytest.raises(TypeError, match="If `include_self` is True, then `to_save` must be mutable"):
         Checkpoint(ImmutableMapping(), lambda x: x, include_self=True)
 
+    checkpoint = Checkpoint(to_save, lambda x: x)
+    with pytest.raises(AttributeError, match="Checkpoint's `save_handler` should be of type `DiskSaver`"):
+        checkpoint.reload_objects(to_save)
+
 
 def test_save_handler_as_str(dirname):
     to_save = {"model": model}


### PR DESCRIPTION
Fixes #2998
