### PR TITLE
Use class to organize distributed tests in modules

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -44,7 +44,7 @@ def _prepare_batch(
 def supervised_training_step(
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
-    loss_fn: Union[Callable, torch.nn.Module],
+    loss_fn: Union[Callable[[Any, Any], torch.Tensor], torch.nn.Module],
     device: Optional[Union[str, torch.device]] = None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
@@ -57,7 +57,7 @@ def supervised_training_step(
     Args:
         model: the model to train.
         optimizer: the optimizer to use.
-        loss_fn: the loss function to use.
+        loss_fn: the loss function that receives `y_pred` and `y`, and returns the loss as a tensor.
         device: device type specification (default: None).
             Applies to batches after starting the engine. Model *will not* be moved.
             Device can be CPU, GPU.
@@ -120,7 +120,7 @@ def supervised_training_step(
 def supervised_training_step_amp(
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
-    loss_fn: Union[Callable, torch.nn.Module],
+    loss_fn: Union[Callable[[Any, Any], torch.Tensor], torch.nn.Module],
     device: Optional[Union[str, torch.device]] = None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
@@ -134,7 +134,7 @@ def supervised_training_step_amp(
     Args:
         model: the model to train.
         optimizer: the optimizer to use.
-        loss_fn: the loss function to use.
+        loss_fn: the loss function that receives `y_pred` and `y`, and returns the loss as a tensor.
         device: device type specification (default: None).
             Applies to batches after starting the engine. Model *will not* be moved.
             Device can be CPU, GPU.
@@ -212,7 +212,7 @@ def supervised_training_step_amp(
 def supervised_training_step_apex(
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
-    loss_fn: Union[Callable, torch.nn.Module],
+    loss_fn: Union[Callable[[Any, Any], torch.Tensor], torch.nn.Module],
     device: Optional[Union[str, torch.device]] = None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
@@ -225,7 +225,7 @@ def supervised_training_step_apex(
     Args:
         model: the model to train.
         optimizer: the optimizer to use.
-        loss_fn: the loss function to use.
+        loss_fn: the loss function that receives `y_pred` and `y`, and returns the loss as a tensor.
         device: device type specification (default: None).
             Applies to batches after starting the engine. Model *will not* be moved.
             Device can be CPU, GPU.
@@ -295,7 +295,7 @@ def supervised_training_step_apex(
 def supervised_training_step_tpu(
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
-    loss_fn: Union[Callable, torch.nn.Module],
+    loss_fn: Union[Callable[[Any, Any], torch.Tensor], torch.nn.Module],
     device: Optional[Union[str, torch.device]] = None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
@@ -308,7 +308,7 @@ def supervised_training_step_tpu(
     Args:
         model: the model to train.
         optimizer: the optimizer to use.
-        loss_fn: the loss function to use.
+        loss_fn: the loss function that receives `y_pred` and `y`, and returns the loss as a tensor.
         device: device type specification (default: None).
             Applies to batches after starting the engine. Model *will not* be moved.
             Device can be CPU, TPU.
@@ -404,7 +404,7 @@ def _check_arg(
 def create_supervised_trainer(
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
-    loss_fn: Union[Callable, torch.nn.Module],
+    loss_fn: Union[Callable[[Any, Any], torch.Tensor], torch.nn.Module],
     device: Optional[Union[str, torch.device]] = None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
@@ -420,7 +420,7 @@ def create_supervised_trainer(
     Args:
         model: the model to train.
         optimizer: the optimizer to use.
-        loss_fn: the loss function to use.
+        loss_fn: the loss function that receives `y_pred` and `y`, and returns the loss as a tensor.
         device: device type specification (default: None).
             Applies to batches after starting the engine. Model *will not* be moved.
             Device can be CPU, GPU or TPU.

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -397,6 +397,7 @@ is_xla_single_device_stash_key = pytest.StashKey[bool]()
             ],
         ),
     ],
+    scope="class",
 )
 def distributed(request, local_rank, world_size):
     if request.param in ("nccl", "gloo_cpu", "gloo"):

--- a/tests/ignite/metrics/test_precision.py
+++ b/tests/ignite/metrics/test_precision.py
@@ -417,211 +417,210 @@ def test_incorrect_y_classes(average):
     assert pr._updated is False
 
 
-def test_distrib_integration_multiclass(distributed):
-    from ignite.engine import Engine
+@pytest.mark.usefixtures("distributed")
+class TestDistributed:
+    def test_integration_multiclass(self):
+        from ignite.engine import Engine
 
-    rank = idist.get_rank()
-    torch.manual_seed(12)
+        rank = idist.get_rank()
+        torch.manual_seed(12)
 
-    def _test(average, n_epochs, metric_device):
-        n_iters = 60
-        s = 16
-        n_classes = 7
+        def _test(average, n_epochs, metric_device):
+            n_iters = 60
+            s = 16
+            n_classes = 7
 
-        offset = n_iters * s
-        y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
-        y_preds = torch.rand(offset * idist.get_world_size(), n_classes).to(device)
+            offset = n_iters * s
+            y_true = torch.randint(0, n_classes, size=(offset * idist.get_world_size(),)).to(device)
+            y_preds = torch.rand(offset * idist.get_world_size(), n_classes).to(device)
 
-        def update(engine, i):
-            return (
-                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset, :],
-                y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+            def update(engine, i):
+                return (
+                    y_preds[i * s + rank * offset : (i + 1) * s + rank * offset, :],
+                    y_true[i * s + rank * offset : (i + 1) * s + rank * offset],
+                )
+
+            engine = Engine(update)
+
+            pr = Precision(average=average, device=metric_device)
+            pr.attach(engine, "pr")
+            assert pr._updated is False
+
+            data = list(range(n_iters))
+            engine.run(data=data, max_epochs=n_epochs)
+
+            assert "pr" in engine.state.metrics
+            assert pr._updated is True
+            res = engine.state.metrics["pr"]
+            if isinstance(res, torch.Tensor):
+                # Fixes https://github.com/pytorch/ignite/issues/1635#issuecomment-863026919
+                assert res.device.type == "cpu"
+                res = res.cpu().numpy()
+
+            sk_average_parameter = ignite_average_to_scikit_average(average, "multiclass")
+            true_res = precision_score(
+                y_true.cpu().numpy(), torch.argmax(y_preds, dim=1).cpu().numpy(), average=sk_average_parameter
             )
 
-        engine = Engine(update)
+            assert pytest.approx(res) == true_res
 
-        pr = Precision(average=average, device=metric_device)
-        pr.attach(engine, "pr")
-        assert pr._updated is False
+        metric_devices = [torch.device("cpu")]
+        device = idist.device()
+        if device.type != "xla":
+            metric_devices.append(idist.device())
+        for _ in range(2):
+            for metric_device in metric_devices:
+                _test(average=False, n_epochs=1, metric_device=metric_device)
+                _test(average=False, n_epochs=2, metric_device=metric_device)
+                _test(average="macro", n_epochs=1, metric_device=metric_device)
+                _test(average="macro", n_epochs=2, metric_device=metric_device)
+                _test(average="weighted", n_epochs=1, metric_device=metric_device)
+                _test(average="weighted", n_epochs=2, metric_device=metric_device)
+                _test(average="micro", n_epochs=1, metric_device=metric_device)
+                _test(average="micro", n_epochs=2, metric_device=metric_device)
 
-        data = list(range(n_iters))
-        engine.run(data=data, max_epochs=n_epochs)
+    def test_integration_multilabel(self):
+        from ignite.engine import Engine
 
-        assert "pr" in engine.state.metrics
-        assert pr._updated is True
-        res = engine.state.metrics["pr"]
-        if isinstance(res, torch.Tensor):
-            # Fixes https://github.com/pytorch/ignite/issues/1635#issuecomment-863026919
-            assert res.device.type == "cpu"
-            res = res.cpu().numpy()
+        rank = idist.get_rank()
+        torch.manual_seed(12)
 
-        sk_average_parameter = ignite_average_to_scikit_average(average, "multiclass")
-        true_res = precision_score(
-            y_true.cpu().numpy(), torch.argmax(y_preds, dim=1).cpu().numpy(), average=sk_average_parameter
-        )
+        def _test(average, n_epochs, metric_device):
+            n_iters = 60
+            s = 16
+            n_classes = 7
 
-        assert pytest.approx(res) == true_res
+            offset = n_iters * s
+            y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(), n_classes, 6, 8)).to(device)
+            y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(), n_classes, 6, 8)).to(device)
 
-    metric_devices = [torch.device("cpu")]
-    device = idist.device()
-    if device.type != "xla":
-        metric_devices.append(idist.device())
-    for _ in range(2):
-        for metric_device in metric_devices:
-            _test(average=False, n_epochs=1, metric_device=metric_device)
-            _test(average=False, n_epochs=2, metric_device=metric_device)
-            _test(average="macro", n_epochs=1, metric_device=metric_device)
-            _test(average="macro", n_epochs=2, metric_device=metric_device)
-            _test(average="weighted", n_epochs=1, metric_device=metric_device)
-            _test(average="weighted", n_epochs=2, metric_device=metric_device)
-            _test(average="micro", n_epochs=1, metric_device=metric_device)
-            _test(average="micro", n_epochs=2, metric_device=metric_device)
+            def update(engine, i):
+                return (
+                    y_preds[i * s + rank * offset : (i + 1) * s + rank * offset, ...],
+                    y_true[i * s + rank * offset : (i + 1) * s + rank * offset, ...],
+                )
 
+            engine = Engine(update)
 
-def test_distrib_integration_multilabel(distributed):
-    from ignite.engine import Engine
+            pr = Precision(average=average, is_multilabel=True, device=metric_device)
+            pr.attach(engine, "pr")
+            assert pr._updated is False
 
-    rank = idist.get_rank()
-    torch.manual_seed(12)
+            data = list(range(n_iters))
+            engine.run(data=data, max_epochs=n_epochs)
 
-    def _test(average, n_epochs, metric_device):
-        n_iters = 60
-        s = 16
-        n_classes = 7
+            assert "pr" in engine.state.metrics
+            assert pr._updated is True
+            res = engine.state.metrics["pr"]
+            res2 = pr.compute()
+            if isinstance(res, torch.Tensor):
+                res = res.cpu().numpy()
+                res2 = res2.cpu().numpy()
+                assert (res == res2).all()
+            else:
+                assert res == res2
 
-        offset = n_iters * s
-        y_true = torch.randint(0, 2, size=(offset * idist.get_world_size(), n_classes, 6, 8)).to(device)
-        y_preds = torch.randint(0, 2, size=(offset * idist.get_world_size(), n_classes, 6, 8)).to(device)
+            np_y_preds = to_numpy_multilabel(y_preds)
+            np_y_true = to_numpy_multilabel(y_true)
+            assert pr._type == "multilabel"
+            sk_average_parameter = ignite_average_to_scikit_average(average, "multilabel")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+                assert precision_score(np_y_true, np_y_preds, average=sk_average_parameter) == pytest.approx(res)
 
-        def update(engine, i):
-            return (
-                y_preds[i * s + rank * offset : (i + 1) * s + rank * offset, ...],
-                y_true[i * s + rank * offset : (i + 1) * s + rank * offset, ...],
-            )
+        metric_devices = ["cpu"]
+        device = idist.device()
+        if device.type != "xla":
+            metric_devices.append(idist.device())
+        for _ in range(2):
+            for metric_device in metric_devices:
+                _test(average=False, n_epochs=1, metric_device=metric_device)
+                _test(average=False, n_epochs=2, metric_device=metric_device)
+                _test(average="macro", n_epochs=1, metric_device=metric_device)
+                _test(average="macro", n_epochs=2, metric_device=metric_device)
+                _test(average="micro", n_epochs=1, metric_device=metric_device)
+                _test(average="micro", n_epochs=2, metric_device=metric_device)
+                _test(average="weighted", n_epochs=1, metric_device=metric_device)
+                _test(average="weighted", n_epochs=2, metric_device=metric_device)
+                _test(average="samples", n_epochs=1, metric_device=metric_device)
+                _test(average="samples", n_epochs=2, metric_device=metric_device)
 
-        engine = Engine(update)
+    def test_accumulator_device(self):
+        # Binary accuracy on input of shape (N, 1) or (N, )
 
-        pr = Precision(average=average, is_multilabel=True, device=metric_device)
-        pr.attach(engine, "pr")
-        assert pr._updated is False
+        def _test(average, metric_device):
+            pr = Precision(average=average, device=metric_device)
+            assert pr._device == metric_device
+            assert pr._updated is False
+            # Since the shape of the accumulated amount isn't known before the first update
+            # call, the internal variables aren't tensors on the right device yet.
 
-        data = list(range(n_iters))
-        engine.run(data=data, max_epochs=n_epochs)
+            y_pred = torch.randint(0, 2, size=(10,))
+            y = torch.randint(0, 2, size=(10,)).long()
+            pr.update((y_pred, y))
 
-        assert "pr" in engine.state.metrics
-        assert pr._updated is True
-        res = engine.state.metrics["pr"]
-        res2 = pr.compute()
-        if isinstance(res, torch.Tensor):
-            res = res.cpu().numpy()
-            res2 = res2.cpu().numpy()
-            assert (res == res2).all()
-        else:
-            assert res == res2
+            assert pr._updated is True
 
-        np_y_preds = to_numpy_multilabel(y_preds)
-        np_y_true = to_numpy_multilabel(y_true)
-        assert pr._type == "multilabel"
-        sk_average_parameter = ignite_average_to_scikit_average(average, "multilabel")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=UndefinedMetricWarning)
-            assert precision_score(np_y_true, np_y_preds, average=sk_average_parameter) == pytest.approx(res)
-
-    metric_devices = ["cpu"]
-    device = idist.device()
-    if device.type != "xla":
-        metric_devices.append(idist.device())
-    for _ in range(2):
-        for metric_device in metric_devices:
-            _test(average=False, n_epochs=1, metric_device=metric_device)
-            _test(average=False, n_epochs=2, metric_device=metric_device)
-            _test(average="macro", n_epochs=1, metric_device=metric_device)
-            _test(average="macro", n_epochs=2, metric_device=metric_device)
-            _test(average="micro", n_epochs=1, metric_device=metric_device)
-            _test(average="micro", n_epochs=2, metric_device=metric_device)
-            _test(average="weighted", n_epochs=1, metric_device=metric_device)
-            _test(average="weighted", n_epochs=2, metric_device=metric_device)
-            _test(average="samples", n_epochs=1, metric_device=metric_device)
-            _test(average="samples", n_epochs=2, metric_device=metric_device)
-
-
-def test_distrib_accumulator_device(distributed):
-    # Binary accuracy on input of shape (N, 1) or (N, )
-
-    def _test(average, metric_device):
-        pr = Precision(average=average, device=metric_device)
-        assert pr._device == metric_device
-        assert pr._updated is False
-        # Since the shape of the accumulated amount isn't known before the first update
-        # call, the internal variables aren't tensors on the right device yet.
-
-        y_pred = torch.randint(0, 2, size=(10,))
-        y = torch.randint(0, 2, size=(10,)).long()
-        pr.update((y_pred, y))
-
-        assert pr._updated is True
-
-        assert (
-            pr._numerator.device == metric_device
-        ), f"{type(pr._numerator.device)}:{pr._numerator.device} vs {type(metric_device)}:{metric_device}"
-
-        if average != "samples":
-            # For average='samples', `_denominator` is of type `int` so it has not `device` member.
             assert (
-                pr._denominator.device == metric_device
-            ), f"{type(pr._denominator.device)}:{pr._denominator.device} vs {type(metric_device)}:{metric_device}"
+                pr._numerator.device == metric_device
+            ), f"{type(pr._numerator.device)}:{pr._numerator.device} vs {type(metric_device)}:{metric_device}"
 
-        if average == "weighted":
-            assert pr._weight.device == metric_device, f"{type(pr._weight.device)}:{pr._weight.device} vs "
-            f"{type(metric_device)}:{metric_device}"
+            if average != "samples":
+                # For average='samples', `_denominator` is of type `int` so it has not `device` member.
+                assert (
+                    pr._denominator.device == metric_device
+                ), f"{type(pr._denominator.device)}:{pr._denominator.device} vs {type(metric_device)}:{metric_device}"
 
-    metric_devices = [torch.device("cpu")]
-    device = idist.device()
-    if device.type != "xla":
-        metric_devices.append(idist.device())
-    for metric_device in metric_devices:
-        _test(False, metric_device=metric_device)
-        _test("macro", metric_device=metric_device)
-        _test("micro", metric_device=metric_device)
-        _test("weighted", metric_device=metric_device)
+            if average == "weighted":
+                assert pr._weight.device == metric_device, f"{type(pr._weight.device)}:{pr._weight.device} vs "
+                f"{type(metric_device)}:{metric_device}"
 
+        metric_devices = [torch.device("cpu")]
+        device = idist.device()
+        if device.type != "xla":
+            metric_devices.append(idist.device())
+        for metric_device in metric_devices:
+            _test(False, metric_device=metric_device)
+            _test("macro", metric_device=metric_device)
+            _test("micro", metric_device=metric_device)
+            _test("weighted", metric_device=metric_device)
 
-def test_distrib_multilabel_accumulator_device(distributed):
-    # Multiclass input data of shape (N, ) and (N, C)
+    def test_multilabel_accumulator_device(self):
+        # Multiclass input data of shape (N, ) and (N, C)
 
-    def _test(average, metric_device):
-        pr = Precision(is_multilabel=True, average=average, device=metric_device)
+        def _test(average, metric_device):
+            pr = Precision(is_multilabel=True, average=average, device=metric_device)
 
-        assert pr._updated is False
-        assert pr._device == metric_device
+            assert pr._updated is False
+            assert pr._device == metric_device
 
-        y_pred = torch.randint(0, 2, size=(10, 4, 20, 23))
-        y = torch.randint(0, 2, size=(10, 4, 20, 23)).long()
-        pr.update((y_pred, y))
+            y_pred = torch.randint(0, 2, size=(10, 4, 20, 23))
+            y = torch.randint(0, 2, size=(10, 4, 20, 23)).long()
+            pr.update((y_pred, y))
 
-        assert pr._updated is True
+            assert pr._updated is True
 
-        assert (
-            pr._numerator.device == metric_device
-        ), f"{type(pr._numerator.device)}:{pr._numerator.device} vs {type(metric_device)}:{metric_device}"
-
-        if average != "samples":
-            # For average='samples', `_denominator` is of type `int` so it has not `device` member.
             assert (
-                pr._denominator.device == metric_device
-            ), f"{type(pr._denominator.device)}:{pr._denominator.device} vs {type(metric_device)}:{metric_device}"
+                pr._numerator.device == metric_device
+            ), f"{type(pr._numerator.device)}:{pr._numerator.device} vs {type(metric_device)}:{metric_device}"
 
-        if average == "weighted":
-            assert pr._weight.device == metric_device, f"{type(pr._weight.device)}:{pr._weight.device} vs "
-            f"{type(metric_device)}:{metric_device}"
+            if average != "samples":
+                # For average='samples', `_denominator` is of type `int` so it has not `device` member.
+                assert (
+                    pr._denominator.device == metric_device
+                ), f"{type(pr._denominator.device)}:{pr._denominator.device} vs {type(metric_device)}:{metric_device}"
 
-    metric_devices = [torch.device("cpu")]
-    device = idist.device()
-    if device.type != "xla":
-        metric_devices.append(idist.device())
-    for metric_device in metric_devices:
-        _test(False, metric_device=metric_device)
-        _test("macro", metric_device=metric_device)
-        _test("micro", metric_device=metric_device)
-        _test("weighted", metric_device=metric_device)
-        _test("samples", metric_device=metric_device)
+            if average == "weighted":
+                assert pr._weight.device == metric_device, f"{type(pr._weight.device)}:{pr._weight.device} vs "
+                f"{type(metric_device)}:{metric_device}"
+
+        metric_devices = [torch.device("cpu")]
+        device = idist.device()
+        if device.type != "xla":
+            metric_devices.append(idist.device())
+        for metric_device in metric_devices:
+            _test(False, metric_device=metric_device)
+            _test("macro", metric_device=metric_device)
+            _test("micro", metric_device=metric_device)
+            _test("weighted", metric_device=metric_device)
+            _test("samples", metric_device=metric_device)


### PR DESCRIPTION
As already suggested by @vfdev-5

Description:

The gola of the PR is to reduce the number of distributed context setup/destroy calls.

We can either use `distributed` fixture per method or write a class like in the PR

For simple test metthods with `distributed` fixture, they are instantiated once per method then. It falls back to scope=function for those test items.