### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [pycodestyle]
 exclude = .eggs,*.egg,build,docs/*,.git,versioneer.py,*/conf.py


### PR DESCRIPTION
Description:
- Fixed setup.cfg warning
```
2023-10-04T00:07:44.1649040Z /usr/share/miniconda3/envs/test/lib/python3.8/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
2023-10-04T00:07:44.1649659Z !!
2023-10-04T00:07:44.1649757Z 
2023-10-04T00:07:44.1649884Z         ********************************************************************************
2023-10-04T00:07:44.1650210Z         The license_file parameter is deprecated, use license_files instead.
2023-10-04T00:07:44.1650423Z 
2023-10-04T00:07:44.1650683Z         By 2023-Oct-30, you need to update your project and remove deprecated calls
2023-10-04T00:07:44.1651015Z         or your builds will no longer be supported.
2023-10-04T00:07:44.1651185Z 
2023-10-04T00:07:44.1651409Z         See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
2023-10-04T00:07:44.1651768Z         ********************************************************************************
```
