### PR TITLE
Fix issue with setuptools.distutils.version

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -96,7 +96,7 @@ jobs:
 
           # pytorch>=1.9.0,<1.11.0 is using "from setuptools import distutils; distutils.version.LooseVersion" anti-pattern 
           # which raises the error: AttributeError: module 'distutils' has no attribute 'version' for setuptools>59
-          bad_pth_version=$(python -c "import torch; print('.'.join(torch.__version__.split('.')[:2])) in ['1.9', '1.10']")
+          bad_pth_version=$(python -c "import torch; print('.'.join(torch.__version__.split('.')[:2]) in ['1.9', '1.10'])")
           if [ "${bad_pth_version}" == "True" ]; then
             pip install --upgrade "setuptools<59"
             python -c "from setuptools import distutils; distutils.version.LooseVersion"

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -97,7 +97,7 @@ jobs:
           # pytorch>=1.9.0,<1.11.0 is using "from setuptools import distutils; distutils.version.LooseVersion" anti-pattern 
           # which raises the error: AttributeError: module 'distutils' has no attribute 'version' for setuptools>59
           bad_pth_version=$(python -c "import torch; print('.'.join(torch.__version__.split('.')[:2])) in ['1.9', '1.10']")
-          if [ "${bad_pth_version}" -eq "True" ]; then
+          if [ "${bad_pth_version}" == "True" ]; then
             pip install --upgrade "setuptools<59"
             python -c "from setuptools import distutils; distutils.version.LooseVersion"
           fi

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -94,6 +94,14 @@ jobs:
           pip install -r requirements-dev.txt
           python setup.py install
 
+          # pytorch>=1.9.0,<1.11.0 is using "from setuptools import distutils; distutils.version.LooseVersion" anti-pattern 
+          # which raises the error: AttributeError: module 'distutils' has no attribute 'version' for setuptools>59
+          bad_pth_version=$(python -c "import torch; print('.'.join(torch.__version__.split('.')[:2])) in ['1.9', '1.10']")
+          if [ "${bad_pth_version}" -eq "True" ]; then
+            pip install --upgrade "setuptools<59"
+            python -c "from setuptools import distutils; distutils.version.LooseVersion"
+          fi
+
       # There is no more torchvision 0.5.0 binaries in anaconda pytorch channel:
       # https://anaconda.org/pytorch/torchvision/files 
       - name: Install appropriate dependencies for PyTorch 1.4.0


### PR DESCRIPTION
Description:
- Fixed issue with pytorch missing `setuptools.distutils.version`:
```
AttributeError: module 'distutils' has no attribute 'version' for setuptools
```

- https://github.com/pytorch/ignite/actions/runs/6424252884
