### PR TITLE
Added graceful exit if data download errored

### DIFF
--- a/examples/super_resolution/main.py
+++ b/examples/super_resolution/main.py
@@ -73,8 +73,12 @@ class SRDataset(torch.utils.data.Dataset):
         return len(self.dataset)
 
 
-trainset = torchvision.datasets.Caltech101(root="./data", download=True)
-testset = torchvision.datasets.Caltech101(root="./data", download=False)
+try:
+    trainset = torchvision.datasets.Caltech101(root="./data", download=True)
+    testset = torchvision.datasets.Caltech101(root="./data", download=False)
+except RuntimeError:
+    print("Dataset download problem, exiting without error code")
+    exit(0)
 
 trainset_sr = SRDataset(trainset, scale_factor=opt.upscale_factor, crop_size=opt.crop_size)
 testset_sr = SRDataset(testset, scale_factor=opt.upscale_factor, crop_size=opt.crop_size)


### PR DESCRIPTION
Description:
- Added graceful exit if data download errored
- Fixing issue:
```
 ===> Loading datasets
Traceback (most recent call last):
  File "examples/super_resolution/main.py", line 76, in <module>
    trainset = torchvision.datasets.Caltech101(root="./data", download=True)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torchvision/datasets/caltech.py", line 50, in __init__
    self.download()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torchvision/datasets/caltech.py", line 131, in download
    download_and_extract_archive(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 434, in download_and_extract_archive
    download_url(url, download_root, filename, md5)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 139, in download_url
    return download_file_from_google_drive(file_id, root, filename, md5)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 246, in download_file_from_google_drive
    raise RuntimeError(
RuntimeError: The daily quota of the file 101_ObjectCategories.tar.gz is exceeded and it can't be downloaded. This is a limitation of Google Drive and can only be overcome by trying again later.
```


Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
