### PR TITLE
make lr finder error message more helpful.

### DIFF
--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -162,18 +162,18 @@ class FastaiLRFinder:
                         "if output of the engine is torch.Tensor, then "
                         "it must be 0d torch.Tensor or 1d torch.Tensor with 1 element, "
                         f"but got torch.Tensor of shape {loss.shape}."
-                        "You may wish to use the output_transform kwarg with the attach method e.g.\n"
-                        """
-                        lr_finder = FastaiLRFinder()
-                        with lr_finder.attach(trainer, output_transform=lambda x:x["train_loss"]) as trainer_with_lr_finder:
-                            trainer_with_lr_finder.run(dataloader_train)
-                        """
                     )
             else:
                 raise TypeError(
                     "output of the engine should be of type float or 0d torch.Tensor "
                     "or 1d torch.Tensor with 1 element, "
                     f"but got output of type {type(loss).__name__}"
+                    "You may wish to use the output_transform kwarg with the attach method e.g.\n"
+                    """
+                    lr_finder = FastaiLRFinder()
+                    with lr_finder.attach(trainer, output_transform=lambda x:x["train_loss"]) as trainer_with_lr_finder:
+                        trainer_with_lr_finder.run(dataloader_train)
+                    """
                 )
         loss = idist.all_reduce(loss)
         lr = self._lr_schedule.get_param()

--- a/ignite/handlers/lr_finder.py
+++ b/ignite/handlers/lr_finder.py
@@ -161,7 +161,13 @@ class FastaiLRFinder:
                     raise ValueError(
                         "if output of the engine is torch.Tensor, then "
                         "it must be 0d torch.Tensor or 1d torch.Tensor with 1 element, "
-                        f"but got torch.Tensor of shape {loss.shape}"
+                        f"but got torch.Tensor of shape {loss.shape}."
+                        "You may wish to use the output_transform kwarg with the attach method e.g.\n"
+                        """
+                        lr_finder = FastaiLRFinder()
+                        with lr_finder.attach(trainer, output_transform=lambda x:x["train_loss"]) as trainer_with_lr_finder:
+                            trainer_with_lr_finder.run(dataloader_train)
+                        """
                     )
             else:
                 raise TypeError(


### PR DESCRIPTION
Fixes #3152

Description:
Small change to an error message to help users encountering type errors when using the fast ai learning rate finder. As mentioned in original issue, there's no compelling reason to update the docs. Helping users to transform the trainer output if that is the cause of the error should be sufficient.
