### PR TITLE
Change LinearCyclicalScheduler to triangle wave to sawtooth wave

### DIFF
--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -348,11 +348,8 @@ class CyclicalScheduler(ParamScheduler):
             self.start_value *= self.start_value_mult
         if self.event_index != 0 and self.event_index == self.total_cycle_size:
             self.event_index = 0
-            # self.cycle_size = math.ceil(self.cycle_size * self.cycle_mult)
-            # self.warmup_duration = math.ceil(self.warmup_duration * self.cycle_mult)
             self.cycle_size = int(self.cycle_size * self.cycle_mult)
             self.warmup_duration = int(self.warmup_duration * self.cycle_mult)
-
             self.total_cycle_size = self.warmup_duration + self.cycle_size
             self.cycle += 1
             self.end_value *= self.end_value_mult
@@ -468,6 +465,9 @@ class LinearCyclicalScheduler(CyclicalScheduler):
 
     .. versionchanged:: 0.4.13
         Added cyclic warm-up to the scheduler using ``warmup_duration``.
+
+    .. versionchanged:: 0.5.0
+        Added monotonic argument ....
     """
 
     def __init__(self, *args, monotonic=False, **kwagrs):

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -475,7 +475,8 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         self.monotonic = monotonic
         if self.warmup_duration > 0 and not self.monotonic:
             raise ValueError(
-                "Invalid combination when warmup_duration > 0 and monotonic=False, please use either set warmup_duration=0 or monotonic=True"  # noqa E501
+                "Invalid combination when warmup_duration > 0 and monotonic=False, "
+                "please use either set warmup_duration=0 or monotonic=True"
             )
 
     def get_param(self) -> float:

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -390,6 +390,9 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         save_history: whether to log the parameter values to
             `engine.state.param_history`, (default=False).
         param_group_index: optimizer's parameters group to use.
+        monotonic: whether to schedule only one half of the cycle: descending or ascending.
+            If True, this argument can not be used together with ``warmup_duration``.
+            (default=False).
 
     Note:
         If the scheduler is bound to an 'ITERATION_*' event, 'cycle_size' should
@@ -467,7 +470,7 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         Added cyclic warm-up to the scheduler using ``warmup_duration``.
 
     .. versionchanged:: 0.5.0
-        Added monotonic argument ....
+        Added monotonic argument.
     """
 
     def __init__(self, *args, monotonic=False, **kwagrs):

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -470,19 +470,19 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         Added cyclic warm-up to the scheduler using ``warmup_duration``.
     """
 
-    def __init__(self, use_legacy=False, **kwargs):
-        super(LinearCyclicalScheduler, self).__init__(**kwargs)
-        self.use_legacy = use_legacy
+    def __init__(self, *args, use_sawtooth=False, **kwargs):
+        super(LinearCyclicalScheduler, self).__init__(*args, **kwargs)
+        self.use_sawtooth = use_sawtooth
+        if self.use_sawtooth and self.warmup_duration != 0:
+            raise ValueError("can not use use_sawtooth option and warmup duration please remove one of them")
 
     def get_param(self) -> float:
         """Method to get current optimizer's parameter value"""
         cycle_progress = self.event_index / self.cycle_size
-        if self.use_legacy:
-            if self.warmup_duration != 0:
-                raise ValueError("can not use use_legacy option and warmup duration please remove one of them")
-            return self.end_value + (self.start_value - self.end_value) * abs(cycle_progress - 0.5) * 2
-        else:
+        if self.use_sawtooth:
             return self.start_value + (self.end_value - self.start_value) * cycle_progress
+        else:
+            return self.end_value + (self.start_value - self.end_value) * abs(cycle_progress - 0.5) * 2
 
 
 class CosineAnnealingScheduler(CyclicalScheduler):

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -470,16 +470,19 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         Added cyclic warm-up to the scheduler using ``warmup_duration``.
     """
 
-    def __init__(self, *args, use_sawtooth=False, **kwargs):
-        super(LinearCyclicalScheduler, self).__init__(*args, **kwargs)
-        self.use_sawtooth = use_sawtooth
-        if self.use_sawtooth and self.warmup_duration != 0:
-            raise ValueError("can not use use_sawtooth option and warmup duration please remove one of them")
+    def __init__(self, *args, monotonic=False, **kwagrs):
+        super(LinearCyclicalScheduler, self).__init__(*args, **kwagrs)
+        self.monotonic = monotonic
+        if self.warmup_duration > 0 and not self.monotonic:
+            raise ValueError(
+                "Invalid combination when warmup_duration > 0 and monotonic=False, please use either set warmup_duration=0 or monotonic=True"  # noqa E501
+            )
 
     def get_param(self) -> float:
         """Method to get current optimizer's parameter value"""
         cycle_progress = self.event_index / self.cycle_size
-        if self.use_sawtooth:
+
+        if self.monotonic:
             return self.start_value + (self.end_value - self.start_value) * cycle_progress
         else:
             return self.end_value + (self.start_value - self.end_value) * abs(cycle_progress - 0.5) * 2

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -473,7 +473,7 @@ class LinearCyclicalScheduler(CyclicalScheduler):
         Added monotonic argument.
     """
 
-    def __init__(self, *args, monotonic=False, **kwagrs):
+    def __init__(self, *args: Any, monotonic: bool = False, **kwagrs: Any):
         super(LinearCyclicalScheduler, self).__init__(*args, **kwagrs)
         self.monotonic = monotonic
         if self.warmup_duration > 0 and not self.monotonic:

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -729,7 +729,7 @@ class ConcatScheduler(ParamScheduler):
         for s, sd in zip(self.schedulers, sds):
             s.load_state_dict(sd)
         super(ConcatScheduler, self).load_state_dict(state_dict)
-        self._setup_scheduler()
+        self._current_scheduler = self.schedulers[self._scheduler_index]
 
     def _setup_scheduler(self) -> None:
         self._current_scheduler = self.schedulers[self._scheduler_index]

--- a/tests/ignite/handlers/test_param_scheduler.py
+++ b/tests/ignite/handlers/test_param_scheduler.py
@@ -70,7 +70,8 @@ def test_linear_scheduler_asserts():
 
     with pytest.raises(
         ValueError,
-        match=r"Invalid combination when warmup_duration > 0 and monotonic=False, please use either set warmup_duration=0 or monotonic=True",  # noqa E501
+        match=r"Invalid combination when warmup_duration > 0 and monotonic=False, "
+        r"please use either set warmup_duration=0 or monotonic=True",
     ):
         LinearCyclicalScheduler(optimizer, "lr", 1, 0, cycle_size=2, warmup_duration=1)
 

--- a/tests/ignite/handlers/test_param_scheduler.py
+++ b/tests/ignite/handlers/test_param_scheduler.py
@@ -68,6 +68,11 @@ def test_linear_scheduler_asserts():
     with pytest.raises(ValueError, match=r"Argument cycle_size should be positive and larger than 1"):
         LinearCyclicalScheduler(optimizer, "lr", 1, 0, cycle_size=1)
 
+    with pytest.raises(
+        ValueError, match=r"can not use use_sawtooth option and warmup duration please remove one of them"
+    ):
+        LinearCyclicalScheduler(optimizer, "lr", 1, 0, cycle_size=2, warmup_duration=1, use_sawtooth=True)
+
 
 def test_linear_scheduler():
     tensor = torch.zeros([1], requires_grad=True)
@@ -138,6 +143,79 @@ def test_linear_scheduler():
                     0.7,
                     0.8,
                     0.9,
+                ],
+            )
+        )
+        scheduler.load_state_dict(state_dict)
+
+
+def test_linear_scheduler_use_sawtooth():
+    tensor = torch.zeros([1], requires_grad=True)
+    optimizer = torch.optim.SGD([tensor], lr=0)
+    scheduler = LinearCyclicalScheduler(optimizer, "lr", 1, 0, 10, use_sawtooth=True)
+    state_dict = scheduler.state_dict()
+
+    def save_lr(engine):
+        lrs.append(optimizer.param_groups[0]["lr"])
+
+    trainer = Engine(lambda engine, batch: None)
+    trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+    trainer.add_event_handler(Events.ITERATION_COMPLETED, save_lr)
+    lr_values_in_cycle = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
+    for _ in range(2):
+        lrs = []
+        trainer.run([0] * 10, max_epochs=2)
+        assert lrs == pytest.approx([*lr_values_in_cycle, *lr_values_in_cycle])
+        scheduler.load_state_dict(state_dict)
+
+    optimizer = torch.optim.SGD([tensor], lr=0)
+    scheduler = LinearCyclicalScheduler(optimizer, "lr", 1, 0, 10, cycle_mult=2, use_sawtooth=True)
+    state_dict = scheduler.state_dict()
+
+    trainer = Engine(lambda engine, batch: None)
+    trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+    trainer.add_event_handler(Events.ITERATION_COMPLETED, save_lr)
+
+    for _ in range(2):
+        lrs = []
+        trainer.run([0] * 10, max_epochs=3)
+
+        assert lrs == list(
+            map(
+                pytest.approx,
+                [
+                    # Cycle 1
+                    1.0,
+                    0.9,
+                    0.8,
+                    0.7,
+                    0.6,
+                    0.5,
+                    0.4,
+                    0.3,
+                    0.2,
+                    0.1,
+                    # Cycle 2
+                    1.0,
+                    0.95,
+                    0.9,
+                    0.85,
+                    0.8,
+                    0.75,
+                    0.7,
+                    0.65,
+                    0.6,
+                    0.55,
+                    0.5,
+                    0.45,
+                    0.4,
+                    0.35,
+                    0.3,
+                    0.25,
+                    0.2,
+                    0.15,
+                    0.1,
+                    0.05,
                 ],
             )
         )

--- a/tests/ignite/handlers/test_param_scheduler.py
+++ b/tests/ignite/handlers/test_param_scheduler.py
@@ -68,6 +68,12 @@ def test_linear_scheduler_asserts():
     with pytest.raises(ValueError, match=r"Argument cycle_size should be positive and larger than 1"):
         LinearCyclicalScheduler(optimizer, "lr", 1, 0, cycle_size=1)
 
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid combination when warmup_duration > 0 and monotonic=False, please use either set warmup_duration=0 or monotonic=True",  # noqa E501
+    ):
+        LinearCyclicalScheduler(optimizer, "lr", 1, 0, cycle_size=2, warmup_duration=1)
+
 
 def test_linear_scheduler():
     tensor = torch.zeros([1], requires_grad=True)
@@ -138,6 +144,102 @@ def test_linear_scheduler():
                     0.7,
                     0.8,
                     0.9,
+                ],
+            )
+        )
+        scheduler.load_state_dict(state_dict)
+
+
+def test_linear_scheduler_warmup_duration():
+    tensor = torch.zeros([1], requires_grad=True)
+    optimizer = torch.optim.SGD([tensor], lr=0.0)
+
+    scheduler = LinearCyclicalScheduler(optimizer, "lr", 1, 0, 10, warmup_duration=5, monotonic=True)
+    state_dict = scheduler.state_dict()
+
+    def save_lr(engine):
+        lrs.append(optimizer.param_groups[0]["lr"])
+
+    trainer = Engine(lambda engine, batch: None)
+    trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+    trainer.add_event_handler(Events.ITERATION_COMPLETED, save_lr)
+    lr_values_in_cycle = [
+        1.0,
+        0.9,
+        0.8,
+        0.7,
+        0.6,
+        0.5,
+        0.4,
+        0.3,
+        0.2,
+        0.1,
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+        0.9,
+        0.8,
+        0.7,
+        0.6,
+    ]
+    for _ in range(2):
+        lrs = []
+        trainer.run([0] * 10, max_epochs=2)
+
+        assert lrs == pytest.approx(lr_values_in_cycle)
+        scheduler.load_state_dict(state_dict)
+
+    optimizer = torch.optim.SGD([tensor], lr=0)
+    scheduler = LinearCyclicalScheduler(optimizer, "lr", 1, 0, 10, cycle_mult=2, warmup_duration=5, monotonic=True)
+    state_dict = scheduler.state_dict()
+
+    trainer = Engine(lambda engine, batch: None)
+    trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+    trainer.add_event_handler(Events.ITERATION_COMPLETED, save_lr)
+
+    for _ in range(2):
+        lrs = []
+        trainer.run([0] * 10, max_epochs=3)
+
+        assert lrs == list(
+            map(
+                pytest.approx,
+                [
+                    # Cycle 1
+                    1.0,
+                    0.9,
+                    0.8,
+                    0.7,
+                    0.6,
+                    0.5,
+                    0.4,
+                    0.3,
+                    0.2,
+                    0.1,
+                    0.0,
+                    0.2,
+                    0.4,
+                    0.6,
+                    0.8,
+                    # Cycle 2
+                    1.0,
+                    0.95,
+                    0.9,
+                    0.85,
+                    0.8,
+                    0.75,
+                    0.7,
+                    0.65,
+                    0.6,
+                    0.55,
+                    0.5,
+                    0.45,
+                    0.4,
+                    0.35,
+                    0.3,
                 ],
             )
         )


### PR DESCRIPTION
Fixes #3185 

Description:

Add monotonic variable in LinearCyclicalScheduler
LinearCyclicalScheduler's get_param method is modified

Add Test case LinearCyclicalScheduler ValueError
Add Test case LinearCyclicalScheduler with warmup duration


Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
