### PR TITLE
Fix anaconda binaries upload

### DIFF
--- a/conda.recipe/build_and_upload.sh
+++ b/conda.recipe/build_and_upload.sh
@@ -26,4 +26,5 @@ conda config --set anaconda_upload no
 conda build --no-test --output-folder conda_build conda.recipe -c pytorch
 
 # Upload to Anaconda
+conda config --set anaconda_upload yes
 ls conda_build/*/*.tar.bz2 | xargs -I {} anaconda -v -t $ANACONDA_TOKEN upload -u $UPLOAD_USER {}


### PR DESCRIPTION
Description:
- Fixing failing anaconda nightly binaries upload: https://github.com/pytorch/ignite/actions/runs/7777732594/job/21206409973
```
Packaging ignite
Packaging ignite-0.5.0.dev20240205-py_0
number of files: 109
Fixing permissions
INFO :: Time taken to mark (prefix)
        0 replacements in 0 files was 0.01 seconds
Renaming work directory '/usr/share/miniconda3/envs/test/conda-bld/ignite_1707091964922/work' to '/usr/share/miniconda3/envs/test/conda-bld/ignite_1707091964922/work_moved_ignite-0.5.0.dev20240205-py_0_linux-64_main_build_loop'
shutil.move(work)=/usr/share/miniconda3/envs/test/conda-bld/ignite_1707091964922/work, dest=/usr/share/miniconda3/envs/test/conda-bld/ignite_1707091964922/work_moved_ignite-0.5.0.dev20240205-py_0_linux-64_main_build_loop)
['conda_build/noarch/ignite-0.5.0.dev20240205-py_0.tar.bz2']
# Automatic uploading is disabled
# If you want to upload package(s) to anaconda.org later, type:


# To have conda build upload to anaconda.org automatically, use
# conda config --set anaconda_upload yes
anaconda upload \
    conda_build/noarch/ignite-0.5.0.dev20240205-py_0.tar.bz2
anaconda_upload is not set.  Not uploading wheels: []

INFO :: The inputs making up the hashes for the built packages are as follows:
{
  "ignite-0.5.0.dev20240205-py_0.tar.bz2": {
    "recipe": {}
  }
}
```
