### PR TITLE
Migrate the macOS runners label from macos-m1-12 to macos-m1-stable

### DIFF
--- a/.github/workflows/mps-tests.yml
+++ b/.github/workflows/mps-tests.yml
@@ -38,7 +38,7 @@ jobs:
         pytorch-channel: ["pytorch"]
         skip-distrib-tests: [1]
       fail-fast: false
-    runs-on: ["macos-m1-12"]
+    runs-on: ["macos-m1-stable"]
     timeout-minutes: 60
     
     steps:


### PR DESCRIPTION
There is a new label for our macOS runners: "macos-m1-stable". All runners labeled "macos-m1-12" should be switched to "macos-m1-stable". There are no changes to the hardware or software configurations. The new label is solely to improve clarity and consistency. [Here](https://fb.workplace.com/groups/pytorch.dev.perf.infra.teams/permalink/7546708885348237/) you can find more detailed info.

