### PR TITLE
docs: add MAPE description to MARE [skip ci]

### DIFF
--- a/ignite/contrib/metrics/regression/mean_absolute_relative_error.py
+++ b/ignite/contrib/metrics/regression/mean_absolute_relative_error.py
@@ -8,7 +8,7 @@ from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce
 
 
 class MeanAbsoluteRelativeError(_BaseRegression):
-    r"""Calculate Mean Absolute Relative Error.
+    r"""Calculate Mean Absolute Relative Error (MARE), also known as Mean Absolute Percentage Error (MAPE).
 
     .. math::
         \text{MARE} = \frac{1}{n}\sum_{j=1}^n\frac{\left|A_j-P_j\right|}{\left|A_j\right|}


### PR DESCRIPTION
Fixes #3198

Description: Small adjustment to the Docstring of `ignite/contrib/metrics/regression/mean_absolute_relative_error.py`

Check list:

- [x] Added alias "MAPE" to docstring
