### PR TITLE
Temporary fixing mpmath issue

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,3 +28,5 @@ nltk
 pandas
 gymnasium
 mkl;platform_machine=="x86_64"
+# temporary fix: E   AttributeError: module 'mpmath' has no attribute 'rational'
+mpmath<1.4


### PR DESCRIPTION
Description:
- Temporary fixing mpmath issue

```
 /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/sympy/__init__.py:30: in <module>
    from sympy.core.cache import lazy_function
/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/sympy/core/__init__.py:9: in <module>
    from .expr import Expr, AtomicExpr, UnevaluatedExpr
/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/sympy/core/expr.py:4159: in <module>
    from .mul import Mul
/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/sympy/core/mul.py:2193: in <module>
    from .numbers import Rational
/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/sympy/core/numbers.py:4567: in <module>
    _sympy_converter[type(mpmath.rational.mpq(1, 2))] = sympify_mpmath_mpq
E   AttributeError: module 'mpmath' has no attribute 'rational'
```