### PR TITLE
Fixed test pearson metric issue with old pytorch versions

### DIFF
--- a/tests/ignite/metrics/regression/test_pearson_correlation.py
+++ b/tests/ignite/metrics/regression/test_pearson_correlation.py
@@ -120,8 +120,8 @@ def test_integration(n_times, test_case: Tuple[Tensor, Tensor, int]):
     m = PearsonCorrelation()
     m.attach(engine, "corr")
 
-    np_y = y.ravel().numpy()
-    np_y_pred = y_pred.ravel().numpy()
+    np_y = y.numpy().ravel()
+    np_y_pred = y_pred.numpy().ravel()
 
     data = list(range(y_pred.shape[0] // batch_size))
     corr = engine.run(data, max_epochs=1).metrics["corr"]


### PR DESCRIPTION
Description:
- Fixed test pearson metric issue with old pytorch version: 1.5.1, https://github.com/pytorch/ignite/actions/runs/8501889120/job/23285331993
```
         m = PearsonCorrelation()
        m.attach(engine, "corr")
    
>       np_y = y.ravel().numpy()
E       AttributeError: 'Tensor' object has no attribute 'ravel'

tests/ignite/metrics/regression/test_pearson_correlation.py:123: AttributeError
```

cc @kzkadc 


Restarted GHA PyTorch versions tests on this PR: https://github.com/pytorch/ignite/actions/runs/8505830753
- 1.5.1 is passing and others are failing due to https://github.com/pytorch/ignite/pull/3226

