### PR TITLE
Removed mkl from dev deps

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -65,14 +65,16 @@ jobs:
       - name: Install Torch XLA and others
         run: |
 
-          ## Install mkl
-          sudo apt-get update && sudo apt-get install -y libopenblas-dev libomp5
-          pip install mkl
+          ## Install mkl (alternative approach to https://github.com/pytorch/xla/blob/b0ba29f98a695671972d4a4cc07441014dba2892/.kokoro/common.sh#L31-L32)
+          pip install mkl==2021.4.0
 
           ## Install torch & xla and torchvision
           pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch-nightly-cp39-cp39-linux_x86_64.whl
           pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-nightly-cp39-cp39-linux_x86_64.whl
           pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torchvision-nightly-cp39-cp39-linux_x86_64.whl
+
+          # Check installation
+          python -c "import torch"
 
           ## Install test deps and Ignite
           pip install -r requirements-dev.txt

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
 
           ## Install mkl
-          # sudo apt-get update && sudo apt-get install -y libopenblas-dev libomp5
+          sudo apt-get update && sudo apt-get install -y libopenblas-dev libomp5
           pip install mkl
 
           ## Install torch & xla and torchvision

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -65,10 +65,9 @@ jobs:
       - name: Install Torch XLA and others
         run: |
 
-          ## Install openblas, mkl, gsutil
+          ## Install mkl
           # sudo apt-get update && sudo apt-get install -y libopenblas-dev libomp5
-          # mkl version fixed due to https://github.com/pytorch/ignite/issues/2350
-          # pip install mkl==2021.4.0 requests gsutil
+          pip install mkl
 
           ## Install torch & xla and torchvision
           pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch-nightly-cp39-cp39-linux_x86_64.whl

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -8,12 +8,16 @@ on:
       - "ignite/**"
       - "tests/ignite/**"
       - "tests/run_tpu_tests.sh"
+      - "tests/run_code_style.sh"
+      - "requirements-dev.txt"
       - ".github/workflows/tpu-tests.yml"
   pull_request:
     paths:
       - "ignite/**"
       - "tests/ignite/**"
       - "tests/run_tpu_tests.sh"
+      - "tests/run_code_style.sh"
+      - "requirements-dev.txt"
       - ".github/workflows/tpu-tests.yml"
   workflow_dispatch:
 
@@ -32,10 +36,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           architecture: "x64"
 
       - name: Get year & week number
@@ -62,14 +66,14 @@ jobs:
         run: |
 
           ## Install openblas, mkl, gsutil
-          sudo apt-get update && sudo apt-get install -y libopenblas-dev libomp5
+          # sudo apt-get update && sudo apt-get install -y libopenblas-dev libomp5
           # mkl version fixed due to https://github.com/pytorch/ignite/issues/2350
-          pip install mkl==2021.4.0 requests gsutil
+          # pip install mkl==2021.4.0 requests gsutil
 
           ## Install torch & xla and torchvision
-          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch-nightly-cp38-cp38-linux_x86_64.whl
-          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-nightly-cp38-cp38-linux_x86_64.whl
-          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torchvision-nightly-cp38-cp38-linux_x86_64.whl
+          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch-nightly-cp39-cp39-linux_x86_64.whl
+          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-nightly-cp39-cp39-linux_x86_64.whl
+          pip install --pre  https://storage.googleapis.com/tpu-pytorch/wheels/colab/torchvision-nightly-cp39-cp39-linux_x86_64.whl
 
           ## Install test deps and Ignite
           pip install -r requirements-dev.txt

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
 
           ## Install mkl (alternative approach to https://github.com/pytorch/xla/blob/b0ba29f98a695671972d4a4cc07441014dba2892/.kokoro/common.sh#L31-L32)
+          sudo apt-get update && sudo apt-get install -y libopenblas-dev libomp5
           pip install mkl==2021.4.0
 
           ## Install torch & xla and torchvision

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,5 @@ git+https://github.com/nltk/nltk
 # Examples dependencies
 pandas
 gymnasium
-mkl;platform_machine=="x86_64"
 # temporary fix: E   AttributeError: module 'mpmath' has no attribute 'rational'
 mpmath<1.4


### PR DESCRIPTION
Description:
- Removed mkl from dev deps
- Updated tpu yaml file for GHA
- pytorch version tests: https://github.com/pytorch/ignite/actions/runs/8506510996

Context: We have now failing tests for GHA pytorch version tests: https://github.com/pytorch/ignite/actions/runs/8444583767
```
 Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/share/miniconda3/envs/test/lib/python3.8/site-packages/torch/__init__.py", line 218, in <module>
    from torch._C import *  # noqa: F403
ImportError: /usr/share/miniconda3/envs/test/lib/python3.8/site-packages/torch/lib/libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent
```

The failure is due to mkl incompatibility between conda's installed version and the one installed by pip from `requirements-dev.txt` 

We added mkl in this PR: https://github.com/pytorch/ignite/pull/1971 due to failing CI on pytorch nightly at that time. 
