### PR TITLE
Retry tests

### DIFF
--- a/.github/workflows/gpu-hvd-tests.yml
+++ b/.github/workflows/gpu-hvd-tests.yml
@@ -22,7 +22,7 @@ jobs:
   gpu-hvd-tests:
     strategy:
       matrix:
-        pytorch-channel: [pytorch, ]
+        pytorch-channel: [pytorch]
       fail-fast: false
     env:
       DOCKER_IMAGE: "pytorch/conda-builder:cuda12.1"
@@ -128,8 +128,8 @@ jobs:
           # Can't build Horovod with recent pytorch due to pytorch required C++17 standard
           # and horovod is still using C++14
           # HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_PYTORCH=1 pip install horovod[pytorch]
-          # Using a similar hack as described here: 
-          # https://github.com/horovod/horovod/issues/3941#issuecomment-1732505345 
+          # Using a similar hack as described here:
+          # https://github.com/horovod/horovod/issues/3941#issuecomment-1732505345
           git clone --recursive https://github.com/horovod/horovod.git /horovod
           cd /horovod
           sed -i "s/CMAKE_CXX_STANDARD 14/CMAKE_CXX_STANDARD 17/g" CMakeLists.txt
@@ -152,7 +152,7 @@ jobs:
           set -xe
 
           bash tests/run_gpu_tests.sh 2 hvd
-          CUDA_VISIBLE_DEVICES="" pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml -vvv tests/ -m distributed -k hvd
+          CUDA_VISIBLE_DEVICES="" pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml -vvv tests/ignite/ignite/ -m distributed -k hvd
 
           EOF
           )

--- a/.github/workflows/gpu-hvd-tests.yml
+++ b/.github/workflows/gpu-hvd-tests.yml
@@ -152,7 +152,7 @@ jobs:
           set -xe
 
           bash tests/run_gpu_tests.sh 2 hvd
-          CUDA_VISIBLE_DEVICES="" pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml -vvv tests/ignite/ignite/ -m distributed -k hvd
+          CUDA_VISIBLE_DEVICES="" pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml -vvv tests/ignite -m distributed -k hvd
 
           EOF
           )

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -121,18 +121,13 @@ jobs:
 
       - name: Run GPU Unit Tests
         continue-on-error: false
-        run: |
-
-          script=$(cat << EOF
-
-          set -xe
-
-          bash tests/run_gpu_tests.sh 2
-
-          EOF
-          )
-
-          docker exec -t pthd /bin/bash -c "${script}"
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 30
+          shell: bash
+          command: docker exec -t pthd /bin/bash -xec 'tests/run_gpu_tests.sh 2'
+          new_command_on_retry: docker exec -e USE_LAST_FAILED=1 -t pthd /bin/bash -xec 'tests/run_gpu_tests.sh 2'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -29,7 +29,7 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     runs-on: linux.8xlarge.nvidia.gpu
-    timeout-minutes: 45
+    timeout-minutes: 85
 
     steps:
       - name: Clean workspace
@@ -124,7 +124,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           max_attempts: 5
-          timeout_minutes: 30
+          timeout_minutes: 25
           shell: bash
           command: docker exec -t pthd /bin/bash -xec 'tests/run_gpu_tests.sh 2'
           new_command_on_retry: docker exec -e USE_LAST_FAILED=1 -t pthd /bin/bash -xec 'tests/run_gpu_tests.sh 2'

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -75,9 +75,12 @@ jobs:
           target_dir: /tmp
 
       - name: Run Tests
-        shell: bash -l {0}
-        run: |
-          bash tests/run_cpu_tests.sh
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 25
+          shell: bash
+          command: bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -81,6 +81,7 @@ jobs:
           timeout_minutes: 25
           shell: bash
           command: bash tests/run_cpu_tests.sh
+          new_command_on_retry: USE_LAST_FAILED=1   bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -78,7 +78,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           max_attempts: 5
-          timeout_minutes: 25
+          timeout_minutes: 15
           shell: bash
           command: bash tests/run_cpu_tests.sh
           new_command_on_retry: USE_LAST_FAILED=1   bash tests/run_cpu_tests.sh

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -81,7 +81,7 @@ jobs:
           timeout_minutes: 15
           shell: bash
           command: bash tests/run_cpu_tests.sh
-          new_command_on_retry: USE_LAST_FAILED=1   bash tests/run_cpu_tests.sh
+          new_command_on_retry: USE_LAST_FAILED=1 bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -98,6 +98,7 @@ jobs:
           timeout_minutes: 25
           shell: bash
           command: bash tests/run_cpu_tests.sh "not test_time_profilers"
+          new_command_on_retry: USE_LAST_FAILED=1  bash tests/run_cpu_tests.sh "not test_time_profilers"
 
   # create-issue:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 85
     strategy:
       max-parallel: 5
       fail-fast: false
@@ -95,7 +95,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           max_attempts: 5
-          timeout_minutes: 25
+          timeout_minutes: 15
           shell: bash
           command: bash tests/run_cpu_tests.sh "not test_time_profilers"
           new_command_on_retry: USE_LAST_FAILED=1  bash tests/run_cpu_tests.sh "not test_time_profilers"

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -98,7 +98,7 @@ jobs:
           timeout_minutes: 15
           shell: bash
           command: bash tests/run_cpu_tests.sh "not test_time_profilers"
-          new_command_on_retry: USE_LAST_FAILED=1  bash tests/run_cpu_tests.sh "not test_time_profilers"
+          new_command_on_retry: USE_LAST_FAILED=1 bash tests/run_cpu_tests.sh "not test_time_profilers"
 
   # create-issue:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
         pytorch-version:
           [2.1.2, 2.0.1, 1.13.1, 1.12.1, 1.11.0, 1.10.0, 1.9.1, 1.8.1, 1.5.1]
-        exclude:            
+        exclude:
           - pytorch-version: 1.5.1
             python-version: 3.9
           - pytorch-version: 1.5.1
@@ -78,7 +78,7 @@ jobs:
           pip install -r requirements-dev.txt
           python setup.py install
 
-          # pytorch>=1.9.0,<1.11.0 is using "from setuptools import distutils; distutils.version.LooseVersion" anti-pattern 
+          # pytorch>=1.9.0,<1.11.0 is using "from setuptools import distutils; distutils.version.LooseVersion" anti-pattern
           # which raises the error: AttributeError: module 'distutils' has no attribute 'version' for setuptools>59
           bad_pth_version=$(python -c "import torch; print('.'.join(torch.__version__.split('.')[:2]) in ['1.9', '1.10'])")
           if [ "${bad_pth_version}" == "True" ]; then
@@ -92,9 +92,12 @@ jobs:
           target_dir: /tmp
 
       - name: Run Tests
-        shell: bash -l {0}
-        run: |
-          bash tests/run_cpu_tests.sh "not test_time_profilers"
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 25
+          shell: bash
+          command: bash tests/run_cpu_tests.sh "not test_time_profilers"
 
   # create-issue:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -97,6 +97,7 @@ jobs:
           command: |
             python -c "import torch_xla; print('torch xla version:', torch_xla.__version__)"
             bash tests/run_tpu_tests.sh
+          new_command_on_retry: USE_LAST_FAILED=1  bash tests/run_tpu_tests.sh
         env:
           LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}:${{ env.Python_ROOT_DIR }}/lib
           XRT_DEVICE_MAP: "CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -89,13 +89,18 @@ jobs:
           target_dir: /tmp
 
       - name: Run Tests
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${Python_ROOT_DIR}/lib
-          export XRT_DEVICE_MAP="CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
-          export XRT_WORKERS="localservice:0;grpc://localhost:40934"
-
-          python -c "import torch_xla; print('torch xla version:', torch_xla.__version__)"
-          bash tests/run_tpu_tests.sh
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 25
+          shell: bash
+          command: |
+            python -c "import torch_xla; print('torch xla version:', torch_xla.__version__)"
+            bash tests/run_tpu_tests.sh
+        env:
+          LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}:${{ env.Python_ROOT_DIR }}/lib
+          XRT_DEVICE_MAP: "CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"
+          XRT_WORKERS: "localservice:0;grpc://localhost:40934"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -97,7 +97,7 @@ jobs:
           command: |
             python -c "import torch_xla; print('torch xla version:', torch_xla.__version__)"
             bash tests/run_tpu_tests.sh
-          new_command_on_retry: USE_LAST_FAILED=1  bash tests/run_tpu_tests.sh
+          new_command_on_retry: USE_LAST_FAILED=1 bash tests/run_tpu_tests.sh
         env:
           LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}:${{ env.Python_ROOT_DIR }}/lib
           XRT_DEVICE_MAP: "CPU:0;/job:localservice/replica:0/task:0/device:XLA_CPU:0"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   cpu-tests:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 85
     defaults:
       run:
         shell: bash
@@ -123,7 +123,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           max_attempts: 5
-          timeout_minutes: 25
+          timeout_minutes: 15
           shell: bash
           command: SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
           new_command_on_retry: USE_LAST_FAILED=1  SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -126,6 +126,7 @@ jobs:
           timeout_minutes: 25
           shell: bash
           command: SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
+          new_command_on_retry: USE_LAST_FAILED=1  SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11","3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         pytorch-channel: [pytorch, pytorch-nightly]
         include:
           # includes a single build on windows
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run Mypy
         # https://github.com/pytorch/ignite/pull/2780
-        # 
+        #
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.pytorch-channel == 'pytorch-nightly'}}
         run: |
           bash ./tests/run_code_style.sh mypy
@@ -120,8 +120,12 @@ jobs:
           cp -R /tmp/MNIST .
 
       - name: Run Tests
-        run: |
-          SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 25
+          shell: bash
+          command: SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -126,7 +126,7 @@ jobs:
           timeout_minutes: 15
           shell: bash
           command: SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
-          new_command_on_retry: USE_LAST_FAILED=1  SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
+          new_command_on_retry: USE_LAST_FAILED=1 SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/tests/common-test-functionality.sh
+++ b/tests/common-test-functionality.sh
@@ -7,7 +7,7 @@ last_failed_no_failures_code=5
 #  functions shared across test files
 run_tests() {
     # Set defaults
-    local core_args="-vvv tests"
+    local core_args="-vvv tests/ignite"
     local cache_dir=".unknown-cache"
     local skip_distrib_tests=1
     local match_tests_expression=""

--- a/tests/common-test-functionality.sh
+++ b/tests/common-test-functionality.sh
@@ -81,7 +81,7 @@ run_tests() {
     echo [pytest] > pytest.ini ; echo "cache_dir=${cache_dir}" >> pytest.ini
 
     # Assemble options for the pytest command
-    pytest_args="${skip_distrib_opt} ${core_args} -k '${match_tests_expression}'"
+    pytest_args="${skip_distrib_opt} ${core_args} --treat-unrun-as-failed -k '${match_tests_expression}'"
     if [ "${use_last_failed:-0}" -eq "1" ] && [ -d "${cache_dir}" ]; then
         pytest_args="--last-failed --last-failed-no-failures none ${pytest_args}"
     fi

--- a/tests/common-test-functionality.sh
+++ b/tests/common-test-functionality.sh
@@ -57,6 +57,8 @@ run_tests() {
             shift
             ;;
             *)
+            echo "Error: Unknown argument $key"
+            exit 1
             shift
             ;;
         esac
@@ -73,7 +75,7 @@ run_tests() {
     echo [pytest] > pytest.ini ; echo "cache_dir=${cache_dir}" >> pytest.ini
 
     # Assemble options for the pytest command
-    pytest_args="${skip_distrib_opt} ${core_args} -k '${match_tests_expression}' tests"
+    pytest_args="${skip_distrib_opt} ${core_args} -k '${match_tests_expression}'"
     if [ "${use_last_failed:-0}" -eq "1" ] && [ -d "${cache_dir}" ]; then
         pytest_args="--last-failed --last-failed-no-failures none ${pytest_args}"
     fi

--- a/tests/common-test-functionality.sh
+++ b/tests/common-test-functionality.sh
@@ -14,6 +14,7 @@ run_tests() {
     local trap_deselected_exit_code=1
     local use_last_failed=0
     local use_coverage=0
+    local world_size=0
     # Always clean up pytest.ini
     trap 'rm -f pytest.ini' RETURN
     # Parse arguments
@@ -56,6 +57,11 @@ run_tests() {
             shift
             shift
             ;;
+            --world_size)
+            world_size="$2"
+            shift
+            shift
+            ;;
             *)
             echo "Error: Unknown argument $key"
             exit 1
@@ -81,6 +87,10 @@ run_tests() {
     fi
     if [ "${use_coverage}" -eq "1" ]; then
         pytest_args="--cov ignite --cov-append --cov-report term-missing --cov-report xml ${pytest_args}"
+    fi
+    if [ ! "${world_size}" -eq "0" ]; then
+        export WORLD_SIZE="${world_size}"
+        pytest_args="--dist=each --tx ${WORLD_SIZE}*popen//python=python ${pytest_args}"
     fi
 
     # Run the command

--- a/tests/run_cpu_tests.sh
+++ b/tests/run_cpu_tests.sh
@@ -5,12 +5,21 @@ set -xeu
 if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
     skip_distrib_opt=(-m "not distributed and not tpu and not multinode_distributed")
 else
-    skip_distrib_opt=(-m "")
+    skip_distrib_opt=()
 fi
 
 MATCH_TESTS_EXPRESSION=${1:-""}
 
-CUDA_VISIBLE_DEVICES="" pytest --tx 4*popen//python=python --cov ignite --cov-report term-missing --cov-report xml -vvv tests "${skip_distrib_opt[@]}" -k "$MATCH_TESTS_EXPRESSION"
+# Will catch exit code 5 when tests are deselected from previous passing run
+EXIT_CODE_ALL_TESTS_DESELECTED=5
+
+CACHE_DIR=.cpu-not-distrib
+echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
+PYTEST_ARGS="--tx 4*popen//python=python --cov ignite --cov-report term-missing --cov-report xml -vvv tests ${skip_distrib_opt[@]} ${MATCH_TESTS_EXPRESSION}"
+if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
+    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+fi
+CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}"  || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
 
 # https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02
 if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
@@ -18,5 +27,13 @@ if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
 fi
 
 export WORLD_SIZE=2
-CUDA_VISIBLE_DEVICES="" pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx $WORLD_SIZE*popen//python=python tests -m distributed -vvv -k "$MATCH_TESTS_EXPRESSION"
+CACHE_DIR=.cpu-distrib
+echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
+PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx ${WORLD_SIZE}*popen//python=python tests -m distributed -vvv ${MATCH_TESTS_EXPRESSION}"
+if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
+    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+fi
+CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}"
 unset WORLD_SIZE
+
+rm -f pytest.ini

--- a/tests/run_cpu_tests.sh
+++ b/tests/run_cpu_tests.sh
@@ -8,7 +8,7 @@ match_tests_expression=${1:-""}
 
 
 run_tests \
-    --core_args "--tx 4*popen//python=python -vvv tests" \
+    --core_args "--tx 4*popen//python=python -vvv tests/ignite" \
     --cache_dir ".cpu-not-distrib" \
     --skip_distrib_tests "${skip_distrib_tests}" \
     --use_coverage 1 \
@@ -22,7 +22,7 @@ fi
 
 # Run 2 processes with --dist=each
 run_tests \
-    --core_args "-m distributed -vvv tests" \
+    --core_args "-m distributed -vvv tests/ignite" \
     --world_size 2 \
     --cache_dir ".cpu-distrib" \
     --skip_distrib_tests 0 \

--- a/tests/run_cpu_tests.sh
+++ b/tests/run_cpu_tests.sh
@@ -8,7 +8,7 @@ match_tests_expression=${1:-""}
 
 
 run_tests \
-    --core-args "--tx 4*popen//python=python -vvv tests" \
+    --core_args "--tx 4*popen//python=python -vvv tests" \
     --cache_dir ".cpu-not-distrib" \
     --skip_distrib_tests "${skip_distrib_tests}" \
     --use_coverage 1 \
@@ -22,7 +22,7 @@ fi
 
 # Run 2 processes with --dist=each
 run_tests \
-    --core-args "--dist=each --tx 2*popen//python=python -m distributed -vvv tests" \
+    --core_args "--dist=each --tx 2*popen//python=python -m distributed -vvv tests" \
     --cache_dir ".cpu-distrib" \
     --skip_distrib_tests 0 \
     --use_coverage 1 \

--- a/tests/run_cpu_tests.sh
+++ b/tests/run_cpu_tests.sh
@@ -1,39 +1,30 @@
 #!/bin/bash
-
+source "$(dirname "$0")/common-test-functionality.sh"
 set -xeu
 
-if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
-    skip_distrib_opt="not distributed and not tpu and not multinode_distributed"
-else
-    skip_distrib_opt=""
-fi
+skip_distrib_tests=${SKIP_DISTRIB_TESTS:-0}
+use_last_failed=${USE_LAST_FAILED:-0}
+match_tests_expression=${1:-""}
 
-MATCH_TESTS_EXPRESSION=${1:-""}
 
-# Will catch exit code 5 when tests are deselected from previous passing run
-EXIT_CODE_ALL_TESTS_DESELECTED=5
-
-CACHE_DIR=.cpu-not-distrib
-echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-PYTEST_ARGS="--tx 4*popen//python=python --cov ignite --cov-report term-missing --cov-report xml -vvv tests -m '${skip_distrib_opt}' -k '${MATCH_TESTS_EXPRESSION}'"
-if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
-    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
-fi
-CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}"  || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
+run_tests \
+    --core-args "--tx 4*popen//python=python -vvv tests" \
+    --cache_dir ".cpu-not-distrib" \
+    --skip_distrib_tests "${skip_distrib_tests}" \
+    --use_coverage 1 \
+    --match_tests_expression "${match_tests_expression}" \
+    --use_last_failed ${use_last_failed}
 
 # https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02
-if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
+if [ "${skip_distrib_tests}" -eq "1" ]; then
     exit 0
 fi
 
-export WORLD_SIZE=2
-CACHE_DIR=.cpu-distrib
-echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx ${WORLD_SIZE}*popen//python=python tests -m distributed -vvv -k '${MATCH_TESTS_EXPRESSION}'"
-if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
-    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
-fi
-CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}"
-unset WORLD_SIZE
-
-rm -f pytest.ini
+# Run 2 processes with --dist=each
+run_tests \
+    --core-args "--dist=each --tx 2*popen//python=python -m distributed -vvv tests" \
+    --cache_dir ".cpu-distrib" \
+    --skip_distrib_tests 0 \
+    --use_coverage 1 \
+    --match_tests_expression "${match_tests_expression}" \
+    --use_last_failed ${use_last_failed}

--- a/tests/run_cpu_tests.sh
+++ b/tests/run_cpu_tests.sh
@@ -3,9 +3,9 @@
 set -xeu
 
 if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
-    skip_distrib_opt=(-m "not distributed and not tpu and not multinode_distributed")
+    skip_distrib_opt="not distributed and not tpu and not multinode_distributed"
 else
-    skip_distrib_opt=()
+    skip_distrib_opt=""
 fi
 
 MATCH_TESTS_EXPRESSION=${1:-""}
@@ -15,7 +15,7 @@ EXIT_CODE_ALL_TESTS_DESELECTED=5
 
 CACHE_DIR=.cpu-not-distrib
 echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-PYTEST_ARGS="--tx 4*popen//python=python --cov ignite --cov-report term-missing --cov-report xml -vvv tests ${skip_distrib_opt[@]} ${MATCH_TESTS_EXPRESSION}"
+PYTEST_ARGS="--tx 4*popen//python=python --cov ignite --cov-report term-missing --cov-report xml -vvv tests -m '${skip_distrib_opt}' -k '${MATCH_TESTS_EXPRESSION}'"
 if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
     PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
 fi
@@ -29,7 +29,7 @@ fi
 export WORLD_SIZE=2
 CACHE_DIR=.cpu-distrib
 echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx ${WORLD_SIZE}*popen//python=python tests -m distributed -vvv ${MATCH_TESTS_EXPRESSION}"
+PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx ${WORLD_SIZE}*popen//python=python tests -m distributed -vvv -k '${MATCH_TESTS_EXPRESSION}'"
 if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
     PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
 fi

--- a/tests/run_cpu_tests.sh
+++ b/tests/run_cpu_tests.sh
@@ -22,7 +22,8 @@ fi
 
 # Run 2 processes with --dist=each
 run_tests \
-    --core_args "--dist=each --tx 2*popen//python=python -m distributed -vvv tests" \
+    --core_args "-m distributed -vvv tests" \
+    --world_size 2 \
     --cache_dir ".cpu-distrib" \
     --skip_distrib_tests 0 \
     --use_coverage 1 \

--- a/tests/run_gpu_tests.sh
+++ b/tests/run_gpu_tests.sh
@@ -27,7 +27,7 @@ if [ "${skip_distrib_tests}" -eq "1" ]; then
 fi
 
 run_tests \
-    --core_args "-vvv -m distributed tests" \
+    --core_args "-vvv -m distributed tests/ignite" \
     --cache_dir ".gpu-distrib" \
     --skip_distrib_tests 0 \
     --use_coverage 1 \
@@ -37,7 +37,7 @@ run_tests \
 
 if [ ${ngpus} -gt 1 ]; then
     run_tests \
-        --core_args "-vvv -m distributed tests" \
+        --core_args "-vvv -m distributed tests/ignite" \
         --world_size "${ngpus}" \
         --cache_dir ".gpu-distrib-multi" \
         --skip_distrib_tests 0 \

--- a/tests/run_gpu_tests.sh
+++ b/tests/run_gpu_tests.sh
@@ -37,7 +37,8 @@ run_tests \
 
 if [ ${ngpus} -gt 1 ]; then
     run_tests \
-        --core_args "--tx ${ngpus}*popen//python=python --dist=each -vvv -m distributed tests" \
+        --core_args "-vvv -m distributed tests" \
+        --world_size "${ngpus}" \
         --cache_dir ".gpu-distrib-multi" \
         --skip_distrib_tests 0 \
         --use_coverage 1 \

--- a/tests/run_gpu_tests.sh
+++ b/tests/run_gpu_tests.sh
@@ -14,7 +14,7 @@ else
 fi
 
 run_tests \
-    --core-args "-vvv tests" \
+    --core_args "-vvv tests" \
     --cache_dir ".gpu-cuda" \
     --skip_distrib_tests "${skip_distrib_tests}" \
     --use_coverage 1 \
@@ -27,7 +27,7 @@ if [ "${skip_distrib_tests}" -eq "1" ]; then
 fi
 
 run_tests \
-    --core-args "-vvv -m distributed tests" \
+    --core_args "-vvv -m distributed tests" \
     --cache_dir ".gpu-distrib" \
     --skip_distrib_tests 0 \
     --use_coverage 1 \
@@ -37,7 +37,7 @@ run_tests \
 
 if [ ${ngpus} -gt 1 ]; then
     run_tests \
-        --core-args "--tx ${ngpus}*popen//python=python --dist=each -vvv -m distributed tests" \
+        --core_args "--tx ${ngpus}*popen//python=python --dist=each -vvv -m distributed tests" \
         --cache_dir ".gpu-distrib-multi" \
         --skip_distrib_tests 0 \
         --use_coverage 1 \

--- a/tests/run_gpu_tests.sh
+++ b/tests/run_gpu_tests.sh
@@ -14,7 +14,7 @@ else
 fi
 
 run_tests \
-    --core_args "-vvv tests" \
+    --core_args "-vvv tests/ignite" \
     --cache_dir ".gpu-cuda" \
     --skip_distrib_tests "${skip_distrib_tests}" \
     --use_coverage 1 \

--- a/tests/run_gpu_tests.sh
+++ b/tests/run_gpu_tests.sh
@@ -14,22 +14,45 @@ else
     cuda_pattern="cuda and $MATCH_TESTS_EXPRESSION"
 fi
 
+# Will catch exit code 5 when tests are deselected from previous passing run
+EXIT_CODE_ALL_TESTS_DESELECTED=5
+
 set -xeu
 
-pytest --cov ignite --cov-report term-missing --cov-report xml -vvv tests/ -k "$cuda_pattern"
+CACHE_DIR=.gpu-cuda
+echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
+PYTEST_ARGS="--cov ignite --cov-report term-missing --cov-report xml -vvv tests/ -k '${cuda_pattern}'"
+if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
+    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+fi
+CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
+
+
 
 # https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02
 if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
     exit 0
 fi
 
-pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml -vvv tests/ -m distributed -k "$MATCH_TESTS_EXPRESSION"
-
+CACHE_DIR=.gpu-distrib
+echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
+PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml -vvv tests/ -m distributed -k '${MATCH_TESTS_EXPRESSION}'"
+if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
+    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+fi
+CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
 
 if [ ${ngpus} -gt 1 ]; then
 
     export WORLD_SIZE=${ngpus}
-    pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx ${WORLD_SIZE}*popen//python=python tests -m distributed -vvv -k "$MATCH_TESTS_EXPRESSION"
+    CACHE_DIR=.gpu-distrib-multi
+    echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
+    PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx ${WORLD_SIZE}*popen//python=python tests -m distributed -vvv -k '${MATCH_TESTS_EXPRESSION}'"
+    if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
+        PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+    fi
+    CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}"
     unset WORLD_SIZE
 
 fi
+rm -f pytest.ini

--- a/tests/run_gpu_tests.sh
+++ b/tests/run_gpu_tests.sh
@@ -1,58 +1,46 @@
 #!/bin/bash
-
-if [ -z "$1" ]; then
-    ngpus=1
-else
-    ngpus=$1
-fi
-
-MATCH_TESTS_EXPRESSION=${2:-""}
-
-if [ -z "$MATCH_TESTS_EXPRESSION" ]; then
-    cuda_pattern="cuda"
-else
-    cuda_pattern="cuda and $MATCH_TESTS_EXPRESSION"
-fi
-
-# Will catch exit code 5 when tests are deselected from previous passing run
-EXIT_CODE_ALL_TESTS_DESELECTED=5
-
+source "$(dirname "$0")/common-test-functionality.sh"
 set -xeu
 
-CACHE_DIR=.gpu-cuda
-echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-PYTEST_ARGS="--cov ignite --cov-report term-missing --cov-report xml -vvv tests/ -k '${cuda_pattern}'"
-if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
-    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+skip_distrib_tests=${SKIP_DISTRIB_TESTS:-1}
+use_last_failed=${USE_LAST_FAILED:-0}
+ngpus=${1:-1}
+
+match_tests_expression=${2:-""}
+if [ -z "$match_tests_expression" ]; then
+    cuda_pattern="cuda"
+else
+    cuda_pattern="cuda and $match_tests_expression"
 fi
-CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
 
-
+run_tests \
+    --core-args "-vvv tests" \
+    --cache_dir ".gpu-cuda" \
+    --skip_distrib_tests "${skip_distrib_tests}" \
+    --use_coverage 1 \
+    --match_tests_expression "${cuda_pattern}" \
+    --use_last_failed ${use_last_failed}
 
 # https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02
-if [ "${SKIP_DISTRIB_TESTS:-0}" -eq "1" ]; then
+if [ "${skip_distrib_tests}" -eq "1" ]; then
     exit 0
 fi
 
-CACHE_DIR=.gpu-distrib
-echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml -vvv tests/ -m distributed -k '${MATCH_TESTS_EXPRESSION}'"
-if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
-    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
-fi
-CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
+run_tests \
+    --core-args "-vvv -m distributed tests" \
+    --cache_dir ".gpu-distrib" \
+    --skip_distrib_tests 0 \
+    --use_coverage 1 \
+    --match_tests_expression "${match_tests_expression}" \
+    --use_last_failed ${use_last_failed}
+
 
 if [ ${ngpus} -gt 1 ]; then
-
-    export WORLD_SIZE=${ngpus}
-    CACHE_DIR=.gpu-distrib-multi
-    echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-    PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml --dist=each --tx ${WORLD_SIZE}*popen//python=python tests -m distributed -vvv -k '${MATCH_TESTS_EXPRESSION}'"
-    if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
-        PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
-    fi
-    CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}"
-    unset WORLD_SIZE
-
+    run_tests \
+        --core-args "--tx ${ngpus}*popen//python=python --dist=each -vvv -m distributed tests" \
+        --cache_dir ".gpu-distrib-multi" \
+        --skip_distrib_tests 0 \
+        --use_coverage 1 \
+        --match_tests_expression "${match_tests_expression}" \
+        --use_last_failed ${use_last_failed}
 fi
-rm -f pytest.ini

--- a/tests/run_multinode_tests_in_docker.sh
+++ b/tests/run_multinode_tests_in_docker.sh
@@ -36,7 +36,7 @@ RUN pip install --no-cache-dir mock pytest pytest-xdist scikit-learn scikit-imag
 EOF
 
 docker_python_version=`docker run --rm -i $docker_image python -c "import sys; print(str(sys.version_info[0]) + \".\" + str(sys.version_info[1]), end=\"\")"`
-cmd="pytest --dist=each --tx $nproc_per_node*popen//python${docker_python_version} -m multinode_distributed -vvv tests"
+cmd="pytest --dist=each --tx $nproc_per_node*popen//python${docker_python_version} -m multinode_distributed -vvv tests/ignite"
 
 export MASTER_ADDR=node0
 export MASTER_PORT=9999

--- a/tests/run_tpu_tests.sh
+++ b/tests/run_tpu_tests.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
+# Will catch exit code 5 when tests are deselected from previous passing run
+EXIT_CODE_ALL_TESTS_DESELECTED=5
 
 set -xeu
 
-pytest --cov ignite --cov-report term-missing --cov-report xml tests/ -vvv -m tpu
+CACHE_DIR=.tpu
+echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
+PYTEST_ARGS="--cov ignite --cov-report term-missing --cov-report xml tests/ -vvv -m tpu"
+if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
+    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+fi
+CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
+
 
 if [ -z ${NUM_TPU_WORKERS+x} ]; then
     export NUM_TPU_WORKERS=1
-    pytest --cov ignite --cov-append --cov-report term-missing --cov-report xml tests/ -vvv -m tpu
+    CACHE_DIR=.tpu-multi
+    echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
+    PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml tests/ -vvv -m tpu"
+    if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
+        PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
+    fi
+    CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
 fi
+rm -f pytest.ini

--- a/tests/run_tpu_tests.sh
+++ b/tests/run_tpu_tests.sh
@@ -1,26 +1,20 @@
 #!/bin/bash
-# Will catch exit code 5 when tests are deselected from previous passing run
-EXIT_CODE_ALL_TESTS_DESELECTED=5
-
+source "$(dirname "$0")/common-test-functionality.sh"
 set -xeu
+use_last_failed=${USE_LAST_FAILED:-0}
 
-CACHE_DIR=.tpu
-echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-PYTEST_ARGS="--cov ignite --cov-report term-missing --cov-report xml tests/ -vvv -m tpu"
-if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
-    PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
-fi
-CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
+run_tests \
+    --core-args "-vvv -m tpu tests" \
+    --cache_dir ".tpu" \
+    --use_coverage 1 \
+    --use_last_failed ${use_last_failed}
 
 
 if [ -z ${NUM_TPU_WORKERS+x} ]; then
     export NUM_TPU_WORKERS=1
-    CACHE_DIR=.tpu-multi
-    echo [pytest] > pytest.ini ; echo "cache_dir=${CACHE_DIR}" >> pytest.ini
-    PYTEST_ARGS="--cov ignite --cov-append --cov-report term-missing --cov-report xml tests/ -vvv -m tpu"
-    if [ "${USE_LAST_FAILED:-0}" -eq "1" ] && [ -d "${CACHE_DIR}" ]; then
-        PYTEST_ARGS="--last-failed --last-failed-no-failures none ${PYTEST_ARGS}"
-    fi
-    CUDA_VISIBLE_DEVICES="" eval "pytest ${PYTEST_ARGS}" || { exit_code=$?; if [ "$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit $exit_code; fi;}
+    run_tests \
+        --core-args "-vvv -m tpu tests" \
+        --cache_dir ".tpu-multi" \
+        --use_coverage 1 \
+        --use_last_failed ${use_last_failed}
 fi
-rm -f pytest.ini

--- a/tests/run_tpu_tests.sh
+++ b/tests/run_tpu_tests.sh
@@ -4,7 +4,7 @@ set -xeu
 use_last_failed=${USE_LAST_FAILED:-0}
 
 run_tests \
-    --core_args "-vvv -m tpu tests" \
+    --core_args "-vvv -m tpu tests/ignite" \
     --cache_dir ".tpu" \
     --use_coverage 1 \
     --use_last_failed ${use_last_failed}
@@ -13,7 +13,7 @@ run_tests \
 if [ -z ${NUM_TPU_WORKERS+x} ]; then
     export NUM_TPU_WORKERS=1
     run_tests \
-        --core_args "-vvv -m tpu tests" \
+        --core_args "-vvv -m tpu tests/ignite" \
         --cache_dir ".tpu-multi" \
         --use_coverage 1 \
         --use_last_failed ${use_last_failed}

--- a/tests/run_tpu_tests.sh
+++ b/tests/run_tpu_tests.sh
@@ -4,7 +4,7 @@ set -xeu
 use_last_failed=${USE_LAST_FAILED:-0}
 
 run_tests \
-    --core-args "-vvv -m tpu tests" \
+    --core_args "-vvv -m tpu tests" \
     --cache_dir ".tpu" \
     --use_coverage 1 \
     --use_last_failed ${use_last_failed}
@@ -13,7 +13,7 @@ run_tests \
 if [ -z ${NUM_TPU_WORKERS+x} ]; then
     export NUM_TPU_WORKERS=1
     run_tests \
-        --core-args "-vvv -m tpu tests" \
+        --core_args "-vvv -m tpu tests" \
         --cache_dir ".tpu-multi" \
         --use_coverage 1 \
         --use_last_failed ${use_last_failed}


### PR DESCRIPTION
@vfdev-5 



This is an attempt to rerun some of the CI tests using the retry github action from nick-fields. The objective is to rerun  steps in the GitHub workflows that have failed due to flaky tests or tests that hang. Using the pytest argument --last-failed is helpful as passed tests are not re-executed across reruns.

An edge-case that is trickier to handle is when the first pytest invocation passes and the subsequent one fails. In some circumstances this will lead to all tests being executed for the first invocation. The pytest argument "--last-failed-no-failures none" can help here though I have observed undesirable behaviour in some cases using this argument (see reproducer below). Sometimes it skips all tests when I would expect it (or at least hope) to run some tests. Additionally, if all tests are deselected it emits an exit code of 5 in bash. For now I catch and ignore this for the first invocation.

<details>
<summary>Bash script to set up reproducer</summary>
<br>

```
#!/bin/bash

# Create the directory if it doesn't exist
pytest --cache-clear || true
rm -rf lf-behaviour
mkdir -p lf-behaviour

# Create the Python test file
cat << EOF > lf-behaviour/test_example.py
#!/usr/bin/env python3
import pytest

@pytest.fixture
def cache(pytestconfig):
    return pytestconfig.cache

def test_common_pass():
    assert True

def test_common_flaky_fail(cache):
    retrieved_cache = cache.get("common_flaky_fail",0)
    if not retrieved_cache > 2:
        cache.set("common_flaky_fail", retrieved_cache +1)
        assert False
    # Passes after the first failure
    assert True

def test_unique1_pass(cache):
    assert True

def test_unique1_flaky_fail(cache):
    retrieved_cache = cache.get("unique1_flaky_fail",0)
    if not retrieved_cache > 2:
        cache.set("unique1_flaky_fail", retrieved_cache +1)
        assert False
    # Passes after the first failure
    assert True

def test_unique2_pass():
    assert True

def test_unique2_fail():
    assert False

EOF

# Create the Python test file unique to the first run
cat << EOF > lf-behaviour/test_example_unique3.py
#!/usr/bin/env python3
import pytest

@pytest.fixture
def cache(pytestconfig):
    return pytestconfig.cache

def test_separately_unique3_pass(cache):
    assert True

def test_separately_unique3_fail(cache):
    retrieved_cache = cache.get("unique3_flaky_fail",0)
    if not retrieved_cache > 2:
        cache.set("unique3_flaky_fail", retrieved_cache +1)
        assert False
    # Passes after the first failure
    assert True


EOF

# Create the Python test file unique to the second run
cat << EOF > lf-behaviour/test_example_unique4.py
#!/usr/bin/env python3
import pytest
def test_separately_unique4_pass():
    assert True

def test_separately_unique4_fail():
    assert False

EOF

# Create the shell script
cat << EOF > lf-behaviour/run_unique_individually.sh
#!/bin/bash
set -ex

pytest \${EXTRA_PYTEST_ARGS} -k "unique1" test_example.py || { exit_code=\$?; if [ "\$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit \$exit_code; fi;}
pytest \${EXTRA_PYTEST_ARGS} test_example_unique3.py || { exit_code=\$?; if [ "\$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit \$exit_code; fi;}
pytest \${EXTRA_PYTEST_ARGS} -k "unique2" test_example.py || { exit_code=\$?; if [ "\$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit \$exit_code; fi;}
pytest \${EXTRA_PYTEST_ARGS} test_example_unique4.py || { exit_code=\$?; if [ "\$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit \$exit_code; fi;}
EOF

# Create the shell script
cat << EOF > lf-behaviour/run_tests.sh
#!/bin/bash
set -ex

pytest \${EXTRA_PYTEST_ARGS} -k "test_common or unique1 or unique3" . || { exit_code=\$?; if [ "\$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit \$exit_code; fi;}
pytest \${EXTRA_PYTEST_ARGS} -k "test_common or unique2 or unique4" . || { exit_code=\$?; if [ "\$exit_code" -eq 5 ]; then echo "All tests deselected"; else exit \$exit_code; fi;}
EOF


cd lf-behaviour
bash run_unique_individually.sh

# Echo the command to run the tests
echo "To run the tests, use the following command (you can also add pytest args --cache-clear and --last-failed-no-failures [all/none]):"
echo cd lf-behaviour
echo EXTRA_PYTEST_ARGS="--last-failed --last-failed-no-failures none" bash run_unique_individually.sh
```


</details>

That leaves one remaining problem for this approach to be usable (i.e. this PR could be merged): currently some of the pytest invocations hang. When this happens the tests that were not executed are automatically determined to have passed which can result in most of the test-suite being skipped completely. I haven't thought of a way to address this.

The simpler solution of removing these extra pytest arguments would work but the timeout for the full job needs to be increased a good bit more than what it is currently (45 mins).

EDIT: opting for the simpler solution for now. Perhaps using pytest-timeout could help with test hanging. Previous work [here](https://github.com/leej3/ignite/tree/retry-with-lf)
EDIT 2: using separate pytest cache directories for different runs/executions of pytest on a particular CI machine allows the --last-failed functionality to be used effectively.