### PR TITLE
setup_logger: add optional arg `encoding` for FileHandler

### DIFF
--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -230,6 +230,9 @@ def setup_logger(
 
     .. versionchanged:: 0.4.5
         Added ``reset`` parameter.
+
+    .. versionchanged:: 0.5.1
+        Argument ``encoding`` added to correctly handle special characters in the file, default "utf-8".
     """
     # check if the logger already exists
     existing = name is None or name in logging.root.manager.loggerDict

--- a/ignite/utils.py
+++ b/ignite/utils.py
@@ -163,6 +163,7 @@ def setup_logger(
     filepath: Optional[str] = None,
     distributed_rank: Optional[int] = None,
     reset: bool = False,
+    encoding: Optional[str] = "utf-8",
 ) -> logging.Logger:
     """Setups logger: name, level, format etc.
 
@@ -175,6 +176,7 @@ def setup_logger(
         distributed_rank: Optional, rank in distributed configuration to avoid logger setup for workers.
             If None, distributed_rank is initialized to the rank of process.
         reset: if True, reset an existing logger rather than keep format, handlers, and level.
+        encoding: open the file with the encoding. By default, 'utf-8'.
 
     Returns:
         logging.Logger
@@ -265,7 +267,7 @@ def setup_logger(
         logger.addHandler(ch)
 
         if filepath is not None:
-            fh = logging.FileHandler(filepath)
+            fh = logging.FileHandler(filepath, encoding=encoding)
             fh.setLevel(level)
             fh.setFormatter(formatter)
             logger.addHandler(fh)

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -174,6 +174,30 @@ def test_override_setup_logger(capsys):
     logging.shutdown()
 
 
+@pytest.mark.parametrize("encoding", [None, "utf-8"])
+def test_setup_logger_encoding(encoding, dirname):
+
+    fp = dirname / "log"
+    logger = setup_logger(name="logger", filepath=fp, encoding=encoding, reset=True)
+    test_words = ["hello", "你好", "привет"]
+    for w in test_words:
+        logger.info(w)
+    logging.shutdown()
+
+    with open(fp, "r") as h:
+        data = h.readlines()
+
+    if encoding == "utf-8":
+        assert len(data) == len(test_words)
+        for expected, output in zip(test_words, data):
+            assert expected in output
+    else:
+        # TODO: let's which OS will fail here
+        assert len(data) == len(test_words)
+        for expected, output in zip(test_words, data):
+            assert expected in output
+
+
 def test_deprecated():
     # Test on function without docs, @deprecated without reasons
     @deprecated("0.4.2", "0.6.0")

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import sys
 from collections import namedtuple
 
@@ -176,7 +177,8 @@ def test_override_setup_logger(capsys):
 
 @pytest.mark.parametrize("encoding", [None, "utf-8"])
 def test_setup_logger_encoding(encoding, dirname):
-
+    if platform.system() == "Windows" and encoding is None:
+        return
     fp = dirname / "log"
     logger = setup_logger(name="logger", filepath=fp, encoding=encoding, reset=True)
     test_words = ["hello", "你好", "こんにちわ", "안녕하세요", "привет"]

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -177,11 +177,9 @@ def test_override_setup_logger(capsys):
 
 @pytest.mark.parametrize("encoding", [None, "utf-8"])
 def test_setup_logger_encoding(encoding, dirname):
-    if platform.system() == "Windows" and encoding is None:
-        return
-    fp = dirname / "log"
+    fp = dirname / "log.txt"
     logger = setup_logger(name="logger", filepath=fp, encoding=encoding, reset=True)
-    test_words = ["hello", "你好", "こんにちわ", "안녕하세요", "привет"]
+    test_words = ["say hello", "say 你好", "say こんにちわ", "say 안녕하세요", "say привет"]
     for w in test_words:
         logger.info(w)
     logging.shutdown()
@@ -189,9 +187,15 @@ def test_setup_logger_encoding(encoding, dirname):
     with open(fp, "r", encoding=encoding) as h:
         data = h.readlines()
 
-    assert len(data) == len(test_words)
-    for expected, output in zip(test_words, data):
-        assert expected in output
+    if platform.system() == "Windows" and encoding is None:
+        flatten_data = "\n".join(data)
+        assert test_words[0] in flatten_data
+        for word in test_words[1:]:
+            assert word not in flatten_data
+    else:
+        assert len(data) == len(test_words)
+        for expected, output in zip(test_words, data):
+            assert expected in output
 
 
 def test_deprecated():

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -184,18 +184,12 @@ def test_setup_logger_encoding(encoding, dirname):
         logger.info(w)
     logging.shutdown()
 
-    with open(fp, "r") as h:
+    with open(fp, "r", encoding=encoding) as h:
         data = h.readlines()
 
-    if encoding == "utf-8":
-        assert len(data) == len(test_words)
-        for expected, output in zip(test_words, data):
-            assert expected in output
-    else:
-        # TODO: let's which OS will fail here
-        assert len(data) == len(test_words)
-        for expected, output in zip(test_words, data):
-            assert expected in output
+    assert len(data) == len(test_words)
+    for expected, output in zip(test_words, data):
+        assert expected in output
 
 
 def test_deprecated():

--- a/tests/ignite/test_utils.py
+++ b/tests/ignite/test_utils.py
@@ -179,7 +179,7 @@ def test_setup_logger_encoding(encoding, dirname):
 
     fp = dirname / "log"
     logger = setup_logger(name="logger", filepath=fp, encoding=encoding, reset=True)
-    test_words = ["hello", "你好", "привет"]
+    test_words = ["hello", "你好", "こんにちわ", "안녕하세요", "привет"]
     for w in test_words:
         logger.info(w)
     logging.shutdown()


### PR DESCRIPTION
By default, the encoding is `utf-8` for compatibility with CJK characters.

Fixes #3239

Description:

Add an optional arg `encoding` to `setup_logger()`. By default, the `encoding` is `utf-8` for compatibility with CJK characters.

Check list:

- [ ] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)

Test:

Can use the following script for test

```python
from ignite.utils import setup_logger

utf8logger = setup_logger(name='utf8 logger', filepath='utf8.log')
utf8logger.info('你好')

logger = setup_logger(name='encoding is None', filepath='defaultEncode.log', encoding=None)
logger.info('你好')
```

In `utf8.log`

```text
2024-04-23 17:53:23,792 utf8 logger INFO: 你好
```

while in `defaultEncode.log`

```text
2024-04-23 17:53:23,792 encoding is None INFO: ���
```