### PR TITLE
Add test timeouts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ numpy
 pytest
 pytest-cov
 pytest-xdist
+pytest-timeout
 dill
 setuptools
 # Test contrib dependencies

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -195,7 +195,7 @@ def distributed_context_single_node_gloo(local_rank, world_size):
         "world_size": world_size,
         "rank": local_rank,
         "init_method": init_method,
-        "timeout": timedelta(seconds=60),
+        "timeout": timedelta(seconds=30),
     }
     yield _create_dist_context(dist_info, local_rank)
     _destroy_dist_context()
@@ -423,7 +423,7 @@ def distributed(request, local_rank, world_size):
             dist_info["backend"] = "gloo"
             from datetime import timedelta
 
-            dist_info["timeout"] = timedelta(seconds=60)
+            dist_info["timeout"] = timedelta(seconds=30)
         yield _create_dist_context(dist_info, local_rank)
         _destroy_dist_context()
         if temp_file:

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -11,6 +11,8 @@ if not has_native_dist_support:
 else:
     from ignite.distributed.comp_models.native import _expand_hostlist, _NativeDistModel, _setup_ddp_vars_from_slurm_env
 
+pytestmark = pytest.mark.timeout(60)
+
 
 # tests from https://github.com/LLNL/py-hostlist/blob/master/hostlist/unittest_hostlist.py
 @pytest.mark.parametrize(

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -10,6 +10,8 @@ from packaging.version import Version
 import ignite.distributed as idist
 from ignite.distributed.utils import has_hvd_support, has_native_dist_support, has_xla_support
 
+pytestmark = pytest.mark.timeout(60)
+
 
 def test_parallel_wrong_inputs():
     with pytest.raises(ValueError, match=r"Unknown backend 'abc'. Available backends:"):


### PR DESCRIPTION
Speeds up failure for hanging tests. I've marked the tests by module but they can be marked individually too.
