### PR TITLE
fix scheduled tests

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           max_attempts: 5
           timeout_minutes: 15
-          shell: bash
+          shell: bash -l {0}
           command: bash tests/run_cpu_tests.sh "not test_time_profilers"
           new_command_on_retry: USE_LAST_FAILED=1 bash tests/run_cpu_tests.sh "not test_time_profilers"
 

--- a/tests/common-test-functionality.sh
+++ b/tests/common-test-functionality.sh
@@ -70,6 +70,14 @@ run_tests() {
         esac
     done
 
+    if ! command -v pytest &> /dev/null
+    then
+        echo "pytest could not be found"
+        echo "The path is: ${PATH}"
+        exit 1
+    fi
+
+
     if [ "${skip_distrib_tests}" -eq "1" ]; then
         # can be overwritten by core_args
         skip_distrib_opt="-m 'not distributed and not tpu and not multinode_distributed'"


### PR DESCRIPTION
This should fix the failing scheduled tests. Pytest isn't found for them. These tests use the setup-miniconda action for python env installation. The action needs a bash login shell in subsequent steps for the env to be active.

Here's a description of the problem: https://stackoverflow.com/questions/72703363/how-to-activate-conda-environment-in-github-actions

Also torch.backends.mps does not exist for older pytorch versions and "filelock" should be listed explicitly as a dependency.