### PR TITLE
Skip unrolling follow up

### DIFF
--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -14,11 +14,14 @@ class _BaseClassification(Metric):
         output_transform: Callable = lambda x: x,
         is_multilabel: bool = False,
         device: Union[str, torch.device] = torch.device("cpu"),
+        skip_unrolling: bool = False,
     ):
         self._is_multilabel = is_multilabel
         self._type: Optional[str] = None
         self._num_classes: Optional[int] = None
-        super(_BaseClassification, self).__init__(output_transform=output_transform, device=device)
+        super(_BaseClassification, self).__init__(
+            output_transform=output_transform, device=device, skip_unrolling=skip_unrolling
+        )
 
     def reset(self) -> None:
         self._type = None
@@ -114,6 +117,9 @@ class Accuracy(_BaseClassification):
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
             default, CPU.
+        skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
+            true for multi-output model, for example, if ``y_pred`` contains multi-ouput as ``(y_pred_a, y_pred_b)``
+            Alternatively, ``output_transform`` can be used to handle this.
 
     Examples:
 
@@ -206,6 +212,9 @@ class Accuracy(_BaseClassification):
         .. testoutput:: 4
 
             0.6666...
+
+    .. versionchanged:: 0.5.1
+        ``skip_unrolling`` argument is added.
     """
 
     _state_dict_all_req_keys = ("_num_correct", "_num_examples")
@@ -215,8 +224,11 @@ class Accuracy(_BaseClassification):
         output_transform: Callable = lambda x: x,
         is_multilabel: bool = False,
         device: Union[str, torch.device] = torch.device("cpu"),
+        skip_unrolling: bool = False,
     ):
-        super(Accuracy, self).__init__(output_transform=output_transform, is_multilabel=is_multilabel, device=device)
+        super(Accuracy, self).__init__(
+            output_transform=output_transform, is_multilabel=is_multilabel, device=device, skip_unrolling=skip_unrolling
+        )
 
     @reinit__is_reduced
     def reset(self) -> None:

--- a/ignite/metrics/average_precision.py
+++ b/ignite/metrics/average_precision.py
@@ -60,6 +60,8 @@ class AveragePrecision(EpochMetric):
 
             0.9166...
 
+    .. versionchanged:: 0.5.1
+        ``skip_unrolling`` argument is added.
     """
 
     def __init__(
@@ -67,6 +69,7 @@ class AveragePrecision(EpochMetric):
         output_transform: Callable = lambda x: x,
         check_compute_fn: bool = False,
         device: Union[str, torch.device] = torch.device("cpu"),
+        skip_unrolling: bool = False,
     ):
         try:
             from sklearn.metrics import average_precision_score  # noqa: F401
@@ -78,4 +81,5 @@ class AveragePrecision(EpochMetric):
             output_transform=output_transform,
             check_compute_fn=check_compute_fn,
             device=device,
+            skip_unrolling=skip_unrolling,
         )

--- a/ignite/metrics/epoch_metric.py
+++ b/ignite/metrics/epoch_metric.py
@@ -65,6 +65,9 @@ class EpochMetric(Metric):
     Warnings:
         EpochMetricWarning: User is warned that there are issues with ``compute_fn`` on a batch of data processed.
         To disable the warning, set ``check_compute_fn=False``.
+
+    .. versionchanged:: 0.5.1
+        ``skip_unrolling`` argument is added.
     """
 
     _state_dict_all_req_keys = ("_predictions", "_targets")
@@ -75,6 +78,7 @@ class EpochMetric(Metric):
         output_transform: Callable = lambda x: x,
         check_compute_fn: bool = True,
         device: Union[str, torch.device] = torch.device("cpu"),
+        skip_unrolling: bool = False,
     ) -> None:
         if not callable(compute_fn):
             raise TypeError("Argument compute_fn should be callable.")
@@ -82,7 +86,9 @@ class EpochMetric(Metric):
         self.compute_fn = compute_fn
         self._check_compute_fn = check_compute_fn
 
-        super(EpochMetric, self).__init__(output_transform=output_transform, device=device)
+        super(EpochMetric, self).__init__(
+            output_transform=output_transform, device=device, skip_unrolling=skip_unrolling
+        )
 
     @reinit__is_reduced
     def reset(self) -> None:

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -658,7 +658,7 @@ def test_skip_unrolling():
             self.true_output = true_output
 
         def update(self, output):
-            assert torch.all(output == self.true_output)
+            assert output == self.true_output
 
     a_pred = torch.randint(0, 2, size=(8, 1))
     b_pred = torch.randint(0, 2, size=(8, 1))

--- a/tests/ignite/metrics/test_average_precision.py
+++ b/tests/ignite/metrics/test_average_precision.py
@@ -331,3 +331,11 @@ def _test_distrib_xla_nprocs(index):
 def test_distrib_xla_nprocs(xmp_executor):
     n = int(os.environ["NUM_TPU_WORKERS"])
     xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)
+
+
+def test_skip_unrolling():
+    ap = AveragePrecision(skip_unrolling=True)
+    ap.reset()
+    output1 = (torch.rand(4, 2), torch.randint(0, 2, size=(4, 2), dtype=torch.long))
+    ap.update(output1)
+    res = ap.compute()


### PR DESCRIPTION
Description: Follow up PR for adding argument skip_unrolling in Metric Class. #3258 
Following classes need to be updated:
- [x] Accuracy
- [x] AveragePrecision
- [ ] CohenKappa
- [ ] ConfusionMatrix
- [ ] CosineSimilarity
- [ ] Entropy
- [x] EpochMetric
- [ ] Frequency
- [ ] GpuInfo
- [ ] JSDivergence
- [ ] KSDivergence
- [ ] MaximumMeanDiscrepancy
- [ ] MeanAbsoluteError
- [ ] MeanPairwiseDistance
- [ ] MeanSquaredError
- [ ] MetricsLamda
- [ ] MultiLabelConfusionMatrix
- [ ] MutualInformation
- [ ] PrecisionRecallCurve
- [ ] Precision
- [ ] PSNR
- [ ] Recall
- [ ] ROC_AUC
- [ ] RootMeanSquaredError
- [ ] RunningAverage
- [ ] SSIM
- [ ] TopKCategoricalAccuracy

Modification might also be required to related classes. 


Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
