### PR TITLE
Exclude special attributes from causing `MetricsLambda` creation

### DIFF
--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -768,6 +768,9 @@ class Metric(Serializable, metaclass=ABCMeta):
     def __getattr__(self, attr: str) -> Callable:
         from ignite.metrics.metrics_lambda import MetricsLambda
 
+        if attr.startswith("__") and attr.endswith("__"):
+            return object.__getattribute__(self, attr)
+
         def fn(x: Metric, *args: Any, **kwargs: Any) -> Any:
             return getattr(x, attr)(*args, **kwargs)
 

--- a/tests/ignite/metrics/test_metric.py
+++ b/tests/ignite/metrics/test_metric.py
@@ -1446,3 +1446,25 @@ def test_skip_unrolling():
     state = State(output=(y_pred, y_true))
     engine = MagicMock(state=state)
     metric.iteration_completed(engine)
+
+
+class DummyMetric6(Metric):
+    def reset(self):
+        pass
+
+    def compute(self):
+        pass
+
+    def update(self, output):
+        pass
+
+    def __call__(self, value):
+        pass
+
+
+def test_access_to_metric_dunder_attributes():
+    metric = DummyMetric6()
+    import inspect
+
+    # `inspect.signature` accesses `__signature__` attribute of the metric.
+    assert "value" in inspect.signature(metric).parameters.keys()


### PR DESCRIPTION

Fixes #3262

Description:
To exclude special attributes from causing `MetricsLambda` creation when they're accessed.

Check list:

- [ ] New tests are added (if a new feature is added)
