### PR TITLE
Fix mps ci

### DIFF
--- a/tests/ignite/engine/test_create_supervised.py
+++ b/tests/ignite/engine/test_create_supervised.py
@@ -316,7 +316,8 @@ def _test_create_supervised_evaluator(
             # This is broken in 1.6.0 but will be probably fixed with 1.7.0
             err_msg_1 = "Expected all tensors to be on the same device"
             err_msg_2 = "Placeholder storage has not been allocated on MPS device"
-            with pytest.raises(RuntimeError, match=f"({err_msg_1}|{err_msg_2})"):
+            err_msg_3 = "Tensor for argument weight is on cpu but expected on mps"
+            with pytest.raises(RuntimeError, match=f"({err_msg_1}|{err_msg_2}|{err_msg_3})"):
                 evaluator.run(data)
 
 


### PR DESCRIPTION
Description:
- Fix breaking mps ci:
```
 =========================== short test summary info ============================
FAILED tests/ignite/engine/test_create_supervised.py::test_create_supervised_evaluator_on_mps_with_model_on_cpu - AssertionError: Regex pattern did not match.
 Regex: '(Expected all tensors to be on the same device|Placeholder storage has not been allocated on MPS device)'
 Input: 'Tensor for argument weight is on cpu but expected on mps'
```

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
