### PR TITLE
Fixed mypy failure on the CI

### DIFF
--- a/ignite/handlers/wandb_logger.py
+++ b/ignite/handlers/wandb_logger.py
@@ -135,13 +135,13 @@ class WandBLogger(BaseLogger):
             )
         if kwargs.get("init", True):
             kwargs.pop("init", None)
-            wandb.init(*args, **kwargs)
+            self._wandb.init(*args, **kwargs)
 
     def __getattr__(self, attr: Any) -> Any:
         return getattr(self._wandb, attr)
 
     def close(self) -> None:
-        self._wandb.finish()
+        self._wandb.finish()  # type: ignore[attr-defined]
 
     def _create_output_handler(self, *args: Any, **kwargs: Any) -> "OutputHandler":
         return OutputHandler(*args, **kwargs)


### PR DESCRIPTION
Description:
- Fixed mypy failure on the CI

```
Run bash ./tests/run_code_style.sh mypy
+ '[' mypy = lint ']'
+ '[' mypy = fmt ']'
+ '[' mypy = mypy ']'
+ mypy --config-file mypy.ini
ignite/handlers/wandb_logger.py:144: error: Module has no attribute "finish" 
[attr-defined]
            self._wandb.finish()
            ^~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 145 source files)
```