### PR TITLE
Fix mypy issue with wandb.finish()

### DIFF
--- a/ignite/handlers/wandb_logger.py
+++ b/ignite/handlers/wandb_logger.py
@@ -141,7 +141,7 @@ class WandBLogger(BaseLogger):
         return getattr(self._wandb, attr)
 
     def close(self) -> None:
-        self._wandb.finish()  # type: ignore[attr-defined]
+        self._wandb.finish()
 
     def _create_output_handler(self, *args: Any, **kwargs: Any) -> "OutputHandler":
         return OutputHandler(*args, **kwargs)


### PR DESCRIPTION
Fixes CI issue with mypy:
```
Run bash ./tests/run_code_style.sh mypy
+ '[' mypy = lint ']'
+ '[' mypy = fmt ']'
+ '[' mypy = mypy ']'
+ mypy --config-file mypy.ini
ignite/handlers/wandb_logger.py:144: error: Unused "type: ignore" comment 
[unused-ignore]
            self._wandb.finish()  # type: ignore[attr-defined]
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 148 source files)
```
https://github.com/pytorch/ignite/actions/runs/10728076043/job/29751849022?pr=2901