### PR TITLE
Use the default runner type

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       REPOSITORY: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-    runs-on: amz2023.linux.4xlarge
+    runs-on: linux.4xlarge
     steps:
       - name: Clean workspace
         run: |
@@ -116,7 +116,7 @@ jobs:
     env:
       REPOSITORY: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-    runs-on: amz2023.linux.12xlarge
+    runs-on: linux.12xlarge
     steps:
       - name: Clean workspace
         run: |
@@ -176,7 +176,7 @@ jobs:
     env:
       REPOSITORY: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-    runs-on: amz2023.linux.4xlarge
+    runs-on: linux.4xlarge
     steps:
       - name: Clean workspace
         run: |
@@ -236,7 +236,7 @@ jobs:
     env:
       REPOSITORY: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-    runs-on: amz2023.linux.12xlarge
+    runs-on: linux.12xlarge
     steps:
       - name: Clean workspace
         run: |

--- a/.github/workflows/gpu-hvd-tests.yml
+++ b/.github/workflows/gpu-hvd-tests.yml
@@ -28,7 +28,7 @@ jobs:
       DOCKER_IMAGE: "pytorch/conda-builder:cuda12.1"
       REPOSITORY: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-    runs-on: amz2023.linux.8xlarge.nvidia.gpu
+    runs-on: linux.8xlarge.nvidia.gpu
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -28,7 +28,7 @@ jobs:
       DOCKER_IMAGE: "pytorch/conda-builder:cuda12.1"
       REPOSITORY: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-    runs-on: amz2023.linux.8xlarge.nvidia.gpu
+    runs-on: linux.8xlarge.nvidia.gpu
     timeout-minutes: 85
 
     steps:


### PR DESCRIPTION
During the Linux Amazon 2023 AMI (base OS) migration these jobs had been temporarily shifted to use the new experimental AMI (see https://github.com/pytorch/ignite/pull/3265)

Now that the new AMI has become the base AMI, shifting these back to use the default runners

