### PR TITLE
Drop python 3.8 in the CI

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
       - run: |
           bash ./tests/run_code_style.sh install
           bash ./tests/run_code_style.sh fmt

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
         pytorch-channel: [pytorch]
 
     steps:

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -33,8 +33,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: Get year & week number
         id: get-date
@@ -59,6 +57,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
   
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -35,7 +35,7 @@ jobs:
         # Extension horovod.torch has not been built: /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/horovod/torch/mpi_lib_v2.cpython-311-x86_64-linux-gnu.so not found
         # If this is not expected, reinstall Horovod with HOROVOD_WITH_PYTORCH=1 to debug the build error.
         # Warning! MPI libs are missing, but python applications are still available.
-        python-version: [3.10]
+        python-version: ["3.10"]
         pytorch-channel: [pytorch]
 
     steps:

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -28,14 +28,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        # Horovod installed on python 3.11, 3.10 fails with error: 
-        # ignite/distributed/comp_models/horovod.py:159: in _HorovodDistModel
-        #     "SUM": hvd.mpi_ops.Sum,
-        # E   AttributeError: module 'horovod.torch' has no attribute 'mpi_ops'
-        # Extension horovod.torch has not been built: /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/horovod/torch/mpi_lib_v2.cpython-311-x86_64-linux-gnu.so not found
-        # If this is not expected, reinstall Horovod with HOROVOD_WITH_PYTORCH=1 to debug the build error.
-        # Warning! MPI libs are missing, but python applications are still available.
-        python-version: ["3.9"]
+        python-version: ["3.11"]
         pytorch-channel: [pytorch]
 
     steps:
@@ -71,7 +64,7 @@ jobs:
           #install other dependencies
           pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements-dev.txt
-          pip install horovod
+          pip install git+https://github.com/horovod/horovod.git
           python setup.py install
 
       # Download MNIST: https://github.com/pytorch/ignite/issues/1737

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -28,7 +28,14 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.11]
+        # Horovod installed on python 3.11 fails with error: 
+        # ignite/distributed/comp_models/horovod.py:159: in _HorovodDistModel
+        #     "SUM": hvd.mpi_ops.Sum,
+        # E   AttributeError: module 'horovod.torch' has no attribute 'mpi_ops'
+        # Extension horovod.torch has not been built: /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/horovod/torch/mpi_lib_v2.cpython-311-x86_64-linux-gnu.so not found
+        # If this is not expected, reinstall Horovod with HOROVOD_WITH_PYTORCH=1 to debug the build error.
+        # Warning! MPI libs are missing, but python applications are still available.
+        python-version: [3.10]
         pytorch-channel: [pytorch]
 
     steps:

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -56,9 +56,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-  
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: Install dependencies
         shell: bash -l {0}
@@ -67,7 +64,20 @@ jobs:
           #install other dependencies
           pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements-dev.txt
-          pip install git+https://github.com/horovod/horovod.git
+          
+          # Install Horovod from source and apply a patch to build with recent pytorch
+          # We can't use pip install <whatever> as build-env can't find pytorch and 
+          # `--no-build-isolation` does not work with horovod setup.py
+          git clone --recursive https://github.com/horovod/horovod.git /tmp/horovod
+          cd /tmp/horovod
+          sed -i "s/CMAKE_CXX_STANDARD 14/CMAKE_CXX_STANDARD 17/g" CMakeLists.txt
+          sed -i "s/CMAKE_CXX_STANDARD 14/CMAKE_CXX_STANDARD 17/g" horovod/torch/CMakeLists.txt          
+          HOROVOD_WITH_PYTORCH=1 python setup.py install                
+          cd -
+          # test the installation:
+          python -c "import horovod.torch as hvd; hvd.mpi_ops.Sum"
+
+          # Install ignite
           python setup.py install
 
       # Download MNIST: https://github.com/pytorch/ignite/issues/1737

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -28,14 +28,14 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        # Horovod installed on python 3.11 fails with error: 
+        # Horovod installed on python 3.11, 3.10 fails with error: 
         # ignite/distributed/comp_models/horovod.py:159: in _HorovodDistModel
         #     "SUM": hvd.mpi_ops.Sum,
         # E   AttributeError: module 'horovod.torch' has no attribute 'mpi_ops'
         # Extension horovod.torch has not been built: /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/horovod/torch/mpi_lib_v2.cpython-311-x86_64-linux-gnu.so not found
         # If this is not expected, reinstall Horovod with HOROVOD_WITH_PYTORCH=1 to debug the build error.
         # Warning! MPI libs are missing, but python applications are still available.
-        python-version: ["3.10"]
+        python-version: ["3.9"]
         pytorch-channel: [pytorch]
 
     steps:

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: Get year & week number
         id: get-date
@@ -56,7 +58,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
+  
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/mps-tests.yml
+++ b/.github/workflows/mps-tests.yml
@@ -34,7 +34,7 @@ jobs:
   mps-tests:
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
         pytorch-channel: ["pytorch"]
         skip-distrib-tests: [1]
       fail-fast: false

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -15,6 +15,8 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
+        # Here we keep python 3.8 tests until the end of the 2024 and 
+        # will drop python version and related pytorch versions
         python-version: [3.8, 3.9, "3.10"]
         pytorch-version:
           [2.3.1, 2.2.2, 2.1.2, 2.0.1, 1.13.1, 1.12.1, 1.10.0, 1.8.1, 1.5.1]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,18 +40,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         pytorch-channel: [pytorch, pytorch-nightly]
         include:
           # includes a single build on windows
           - os: windows-latest
             pytorch-channel: pytorch
-            python-version: 3.9
+            python-version: 3.11
             skip-distrib-tests: 1
           # includes a single build on macosx
           - os: macos-latest
             pytorch-channel: pytorch
-            python-version: 3.9
+            python-version: 3.11
             skip-distrib-tests: 1
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ into the following categories:
 - Create an isolated conda environment for pytorch-ignite:
 
 ```bash
-conda create -n pytorch-ignite-dev python=3.8
+conda create -n pytorch-ignite-dev python=3.11
 ```
 
 - Activate the newly created environment:

--- a/ignite/handlers/neptune_logger.py
+++ b/ignite/handlers/neptune_logger.py
@@ -166,15 +166,7 @@ class NeptuneLogger(BaseLogger):
 
     def __init__(self, api_token: Optional[str] = None, project: Optional[str] = None, **kwargs: Any) -> None:
         try:
-            try:
-                # neptune-client<1.0.0 package structure
-                with warnings.catch_warnings():
-                    # ignore the deprecation warnings
-                    warnings.simplefilter("ignore")
-                    import neptune.new as neptune
-            except ImportError:
-                # neptune>=1.0.0 package structure
-                import neptune
+            import neptune
         except ImportError:
             raise ModuleNotFoundError(
                 "This contrib module requires the Neptune client library to be installed. "


### PR DESCRIPTION
Description:
- Drop python 3.8 in the CI
- EOL of python 3.8 is 2024-10, https://devguide.python.org/versions/


FIXED:
Problem with Horovod CPU CI for py3.10 and py3.11
```
 ignite/distributed/comp_models/horovod.py:159: in _HorovodDistModel
    "SUM": hvd.mpi_ops.Sum,
E   AttributeError: module 'horovod.torch' has no attribute 'mpi_ops'
Extension horovod.torch has not been built: /opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/horovod/torch/mpi_lib_v2.cpython-310-x86_64-linux-gnu.so not found
If this is not expected, reinstall Horovod with HOROVOD_WITH_PYTORCH=1 to debug the build error.
Warning! MPI libs are missing, but python applications are still available.
```
