### PR TITLE
Fixed failing tests on pytorch nightly using torch.load

### DIFF
--- a/tests/ignite/engine/test_deterministic.py
+++ b/tests/ignite/engine/test_deterministic.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 import torch
 import torch.nn as nn
+from packaging.version import Version
 from torch.optim import SGD
 from torch.utils.data import BatchSampler, DataLoader, RandomSampler
 
@@ -737,7 +738,11 @@ def _test_gradients_on_resume(
             grad_norms.append([i, total[1]] + out2)
 
         if sd is not None:
-            sd = torch.load(sd)
+            if Version(torch.__version__) >= Version("1.13.0"):
+                kwargs = {"weights_only": False}
+            else:
+                kwargs = {}
+            sd = torch.load(sd, **kwargs)
             model.load_state_dict(sd[0])
             opt.load_state_dict(sd[1])
             from ignite.engine.deterministic import _repr_rng_state

--- a/tests/ignite/handlers/test_state_param_scheduler.py
+++ b/tests/ignite/handlers/test_state_param_scheduler.py
@@ -295,7 +295,11 @@ def test_torch_save_load(dirname):
 
     filepath = Path(dirname) / "dummy_lambda_state_parameter_scheduler.pt"
     torch.save(lambda_state_parameter_scheduler, filepath)
-    loaded_lambda_state_parameter_scheduler = torch.load(filepath)
+    if Version(torch.__version__) >= Version("1.13.0"):
+        kwargs = {"weights_only": False}
+    else:
+        kwargs = {}
+    loaded_lambda_state_parameter_scheduler = torch.load(filepath, **kwargs)
 
     engine1 = Engine(lambda e, b: None)
     lambda_state_parameter_scheduler.attach(engine1, Events.EPOCH_COMPLETED)


### PR DESCRIPTION
Description:
- Fixed failing tests on pytorch nightly using torch.load

Ref: https://github.com/pytorch/ignite/actions/runs/11437373312/job/32648411373
```
=========================== short test summary info ============================
FAILED tests/ignite/engine/test_deterministic.py::test_gradients_on_resume_cpu - _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray._reconstruct was not an allowed global by default. Please use `torch.serialization.add_safe_globals([_reconstruct])` or the `torch.serialization.safe_globals([_reconstruct])` context manager to allowlist this global if you trust this class/function.

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
FAILED tests/ignite/handlers/test_state_param_scheduler.py::test_torch_save_load - _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL ignite.handlers.state_param_scheduler.LambdaStateScheduler was not an allowed global by default. Please use `torch.serialization.add_safe_globals([LambdaStateScheduler])` or the `torch.serialization.safe_globals([LambdaStateScheduler])` context manager to allowlist this global if you trust this class/function.

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.

```