### PR TITLE
Allow to terminate an epoch without firing `Events.EPOCH_COMPLETED`

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -998,7 +998,10 @@ class Engine(Serializable):
                         # update time wrt handlers
                         self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
 
-                    self.should_terminate_single_epoch = False
+                    if self.should_terminate_single_epoch:
+                        # We skip raising _EngineTerminateSingleEpochException exception on Events.EPOCH_COMPLETED
+                        # as epoch is already completed and nothing to terminate 
+                        self.should_terminate_single_epoch = False
                     yield from self._maybe_terminate_or_interrupt()
 
                     hours, mins, secs = _to_hours_mins_secs(epoch_time_taken)
@@ -1192,7 +1195,10 @@ class Engine(Serializable):
                         # update time wrt handlers
                         self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
 
-                    self.should_terminate_single_epoch = False
+                    if self.should_terminate_single_epoch:
+                        # We skip raising _EngineTerminateSingleEpochException exception on Events.EPOCH_COMPLETED
+                        # as epoch is already completed and nothing to terminate 
+                        self.should_terminate_single_epoch = False
                     self._maybe_terminate_legacy()
 
                     hours, mins, secs = _to_hours_mins_secs(epoch_time_taken)

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -1000,7 +1000,7 @@ class Engine(Serializable):
 
                     if self.should_terminate_single_epoch:
                         # We skip raising _EngineTerminateSingleEpochException exception on Events.EPOCH_COMPLETED
-                        # as epoch is already completed and nothing to terminate 
+                        # as epoch is already completed and nothing to terminate
                         self.should_terminate_single_epoch = False
                     yield from self._maybe_terminate_or_interrupt()
 
@@ -1197,7 +1197,7 @@ class Engine(Serializable):
 
                     if self.should_terminate_single_epoch:
                         # We skip raising _EngineTerminateSingleEpochException exception on Events.EPOCH_COMPLETED
-                        # as epoch is already completed and nothing to terminate 
+                        # as epoch is already completed and nothing to terminate
                         self.should_terminate_single_epoch = False
                     self._maybe_terminate_legacy()
 

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -991,7 +991,7 @@ class Engine(Serializable):
                     # time is available for handlers but must be updated after fire
                     self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
 
-                    if self.should_terminate_single_epoch != "skip_epoch_completed":
+                    if self.should_terminate_single_epoch != "skip_epoch_completed":  # type: ignore[comparison-overlap]
                         handlers_start_time = time.time()
                         self._fire_event(Events.EPOCH_COMPLETED)
                         epoch_time_taken += time.time() - handlers_start_time
@@ -1021,7 +1021,7 @@ class Engine(Serializable):
             self.state.times[Events.COMPLETED.name] = time_taken
 
             # do not fire Events.COMPLETED if we terminated the run with flag `skip_completed=True`
-            if self.should_terminate != "skip_completed":
+            if self.should_terminate != "skip_completed":  # type: ignore[comparison-overlap]
                 handlers_start_time = time.time()
                 self._fire_event(Events.COMPLETED)
                 time_taken += time.time() - handlers_start_time
@@ -1185,7 +1185,7 @@ class Engine(Serializable):
                     # time is available for handlers but must be updated after fire
                     self.state.times[Events.EPOCH_COMPLETED.name] = epoch_time_taken
 
-                    if self.should_terminate_single_epoch != "skip_epoch_completed":
+                    if self.should_terminate_single_epoch != "skip_epoch_completed":  # type: ignore[comparison-overlap]
                         handlers_start_time = time.time()
                         self._fire_event(Events.EPOCH_COMPLETED)
                         epoch_time_taken += time.time() - handlers_start_time
@@ -1215,7 +1215,7 @@ class Engine(Serializable):
             self.state.times[Events.COMPLETED.name] = time_taken
 
             # do not fire Events.COMPLETED if we terminated the run with flag `skip_completed=True`
-            if self.should_terminate != "skip_completed":
+            if self.should_terminate != "skip_completed":  # type: ignore[comparison-overlap]
                 handlers_start_time = time.time()
                 self._fire_event(Events.COMPLETED)
                 time_taken += time.time() - handlers_start_time

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -547,7 +547,7 @@ class Engine(Serializable):
         - ...
         - Terminating event
         - :attr:`~ignite.engine.events.Events.TERMINATE`
-        - :attr:`~ignite.engine.events.Events.COMPLETED`
+        - :attr:`~ignite.engine.events.Events.COMPLETED` (unless `skip_completed=True`)
 
         Args:
             skip_completed: if True, the event :attr:`~ignite.engine.events.Events.COMPLETED` is not fired after
@@ -636,13 +636,16 @@ class Engine(Serializable):
         - ...
         - Event on which ``terminate_epoch`` method is called
         - :attr:`~ignite.engine.events.Events.TERMINATE_SINGLE_EPOCH`
-        - :attr:`~ignite.engine.events.Events.EPOCH_COMPLETED`
+        - :attr:`~ignite.engine.events.Events.EPOCH_COMPLETED` (unless `skip_epoch_completed=True`)
         - :attr:`~ignite.engine.events.Events.EPOCH_STARTED`
         - ...
 
         Args:
             skip_epoch_completed: if True, the event :attr:`~ignite.engine.events.Events.EPOCH_COMPLETED`
                 is not fired after :attr:`~ignite.engine.events.Events.TERMINATE_SINGLE_EPOCH`. Default is False.
+
+        .. versionchanged:: 0.5.2
+            Added `skip_epoch_completed` flag
         """
         self.logger.info(
             "Terminate current epoch is signaled. "

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -141,10 +141,10 @@ class Engine(Serializable):
         self.last_event_name: Optional[Events] = None
         # should_terminate flag: False - don't terminate, True - terminate,
         # "skip_completed" - terminate and skip the event "COMPLETED"
-        self.should_terminate: bool | str = False
+        self.should_terminate: Union[bool, str] = False
         # should_terminate_single_epoch flag: False - don't terminate, True - terminate,
         # "skip_epoch_completed" - terminate and skip the event "EPOCH_COMPLETED"
-        self.should_terminate_single_epoch: bool | str = False
+        self.should_terminate_single_epoch: Union[bool, str] = False
         self.should_interrupt = False
         self.state = State()
         self._state_dict_user_keys: List[str] = []

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -1009,6 +1009,13 @@ class Engine(Serializable):
             except _EngineTerminateException:
                 self._fire_event(Events.TERMINATE)
 
+            except _EngineTerminateSingleEpochException:
+                raise RuntimeError(
+                    "The method terminate_epoch() should not be called on Event.STARTED or Event.EPOCH_STARTED."
+                    "If this is a desired behaviour, please open a feature request on"
+                    "https://github.com/pytorch/ignite/issues/new/choose"
+                )
+
             time_taken = time.time() - start_time
             # time is available for handlers but must be updated after fire
             self.state.times[Events.COMPLETED.name] = time_taken
@@ -1195,6 +1202,13 @@ class Engine(Serializable):
 
             except _EngineTerminateException:
                 self._fire_event(Events.TERMINATE)
+
+            except _EngineTerminateSingleEpochException:
+                raise RuntimeError(
+                    "The method terminate_epoch() should not be called on Event.STARTED or Event.EPOCH_STARTED."
+                    "If this is a desired behaviour, please open a feature request on"
+                    "https://github.com/pytorch/ignite/issues/new/choose"
+                )
 
             time_taken = time.time() - start_time
             # time is available for handlers but must be updated after fire

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -140,7 +140,7 @@ class Engine(Serializable):
         self._process_function = process_function
         self.last_event_name: Optional[Events] = None
         self.should_terminate = False
-        self.skip_completed_after_termination = False
+        self._skip_completed_after_termination = False
         self.should_terminate_single_epoch = False
         self._skip_epoch_completed_after_termination = False
         self.should_interrupt = False
@@ -627,7 +627,7 @@ class Engine(Serializable):
         """
         self.logger.info("Terminate signaled. Engine will stop after current iteration is finished.")
         self.should_terminate = True
-        self.skip_completed_after_termination = skip_completed
+        self._skip_completed_after_termination = skip_completed
 
     def terminate_epoch(self, skip_epoch_completed: bool = False) -> None:
         """Sends terminate signal to the engine, so that it terminates the current epoch. The run
@@ -1015,7 +1015,7 @@ class Engine(Serializable):
             self.state.times[Events.COMPLETED.name] = time_taken
 
             # do not fire Events.COMPLETED if we terminated the run with flag `skip_completed=True`
-            if not (self.should_terminate and self.skip_completed_after_termination):
+            if not (self.should_terminate and self._skip_completed_after_termination):
                 handlers_start_time = time.time()
                 self._fire_event(Events.COMPLETED)
                 time_taken += time.time() - handlers_start_time
@@ -1204,7 +1204,7 @@ class Engine(Serializable):
             self.state.times[Events.COMPLETED.name] = time_taken
 
             # do not fire Events.COMPLETED if we terminated the run with flag `skip_completed=True`
-            if not (self.should_terminate and self.skip_completed_after_termination):
+            if not (self.should_terminate and self._skip_completed_after_termination):
                 handlers_start_time = time.time()
                 self._fire_event(Events.COMPLETED)
                 time_taken += time.time() - handlers_start_time

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -259,8 +259,9 @@ class Events(EventEnum):
     - TERMINATE_SINGLE_EPOCH : triggered when the run is about to end the current epoch,
       after receiving a :meth:`~ignite.engine.engine.Engine.terminate_epoch()` or
       :meth:`~ignite.engine.engine.Engine.terminate()` call.
-    - EPOCH_COMPLETED : triggered when the epoch is ended. Note that this is triggered even
-      when :meth:`~ignite.engine.engine.Engine.terminate_epoch()` is called.
+    - EPOCH_COMPLETED : triggered when the epoch is ended. This is triggered even
+      when :meth:`~ignite.engine.engine.Engine.terminate_epoch()` is called,
+      unless the flag `skip_epoch_completed` is set to True.
 
     - TERMINATE : triggered when the run is about to end completely,
       after receiving :meth:`~ignite.engine.engine.Engine.terminate()` call.
@@ -272,7 +273,7 @@ class Events(EventEnum):
     The table below illustrates which events are triggered when various termination methods are called.
 
     .. list-table::
-       :widths: 35 38 28 20 20
+       :widths: 38 38 28 20 20
        :header-rows: 1
 
        * - Method
@@ -288,6 +289,11 @@ class Events(EventEnum):
        * - :meth:`~ignite.engine.engine.Engine.terminate_epoch()`
          - ✔
          - ✔
+         - ✗
+         - ✔
+       * - :meth:`~ignite.engine.engine.Engine.terminate_epoch()` with `skip_epoch_completed=True`
+         - ✔
+         - ✗
          - ✗
          - ✔
        * - :meth:`~ignite.engine.engine.Engine.terminate()`

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -44,10 +44,10 @@ class TestEngine:
     def test_terminate(self, skip_completed):
         engine = Engine(lambda e, b: 1)
         assert not engine.should_terminate
-        assert not engine.skip_completed_after_termination
+        assert not engine._skip_completed_after_termination
         engine.terminate(skip_completed)
         assert engine.should_terminate
-        assert engine.skip_completed_after_termination == skip_completed
+        assert engine._skip_completed_after_termination == skip_completed
 
     def test_invalid_process_raises_with_invalid_signature(self):
         with pytest.raises(ValueError, match=r"Engine must be given a processing function in order to run"):

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -292,8 +292,11 @@ class TestEngine:
         assert engine.called_events[0] == (0, 0, Events.STARTED)
         assert engine._dataloader_iter is None
 
-    @pytest.mark.parametrize("data, epoch_length", [(None, 10), (range(10), None)])
-    def test_terminate_epoch_stops_mid_epoch(self, data, epoch_length):
+    @pytest.mark.parametrize(
+        "data, epoch_length, skip_epoch_completed",
+        [(None, 10, False), (range(10), None, False), (None, 10, True), (range(10), None, True)],
+    )
+    def test_terminate_epoch_stops_mid_epoch(self, data, epoch_length, skip_epoch_completed):
         real_epoch_length = epoch_length if data is None else len(data)
         iteration_to_stop = real_epoch_length + 4
 
@@ -301,7 +304,7 @@ class TestEngine:
 
         def start_of_iteration_handler(engine):
             if engine.state.iteration == iteration_to_stop:
-                engine.terminate_epoch()
+                engine.terminate_epoch(skip_epoch_completed)
 
         max_epochs = 3
         engine.add_event_handler(Events.ITERATION_STARTED, start_of_iteration_handler)
@@ -312,15 +315,19 @@ class TestEngine:
         assert state.epoch == max_epochs
 
     @pytest.mark.parametrize(
-        "terminate_epoch_event, i",
+        "terminate_epoch_event, i, skip_epoch_completed",
         [
-            (Events.GET_BATCH_STARTED(once=12), 12),
-            (Events.GET_BATCH_COMPLETED(once=12), 12),
-            (Events.ITERATION_STARTED(once=14), 14),
-            (Events.ITERATION_COMPLETED(once=14), 14),
+            (Events.GET_BATCH_STARTED(once=12), 12, False),
+            (Events.GET_BATCH_COMPLETED(once=12), 12, False),
+            (Events.ITERATION_STARTED(once=14), 14, False),
+            (Events.ITERATION_COMPLETED(once=14), 14, False),
+            (Events.GET_BATCH_STARTED(once=12), 12, True),
+            (Events.GET_BATCH_COMPLETED(once=12), 12, True),
+            (Events.ITERATION_STARTED(once=14), 14, True),
+            (Events.ITERATION_COMPLETED(once=14), 14, True),
         ],
     )
-    def test_terminate_epoch_events_sequence(self, terminate_epoch_event, i):
+    def test_terminate_epoch_events_sequence(self, terminate_epoch_event, i, skip_epoch_completed):
         engine = RecordedEngine(MagicMock(return_value=1))
         data = range(10)
         max_epochs = 3
@@ -331,23 +338,27 @@ class TestEngine:
 
         @engine.on(terminate_epoch_event)
         def call_terminate_epoch():
+            assert not engine._skip_epoch_completed_after_termination
             nonlocal call_count
             if call_count < 1:
-                engine.terminate_epoch()
+                engine.terminate_epoch(skip_epoch_completed)
+                assert engine._skip_epoch_completed_after_termination == skip_epoch_completed
+
             call_count += 1
 
         @engine.on(Events.TERMINATE_SINGLE_EPOCH)
         def check_previous_events(iter_counter):
             e = i // len(data) + 1
-
             assert engine.called_events[0] == (0, 0, Events.STARTED)
             assert engine.called_events[-2] == (e, i, terminate_epoch_event)
             assert engine.called_events[-1] == (e, i, Events.TERMINATE_SINGLE_EPOCH)
+            assert engine._skip_epoch_completed_after_termination == skip_epoch_completed
 
         @engine.on(Events.EPOCH_COMPLETED)
         def check_previous_events2():
             e = i // len(data) + 1
             if e == engine.state.epoch and i == engine.state.iteration:
+                assert not skip_epoch_completed
                 assert engine.called_events[-3] == (e, i, terminate_epoch_event)
                 assert engine.called_events[-2] == (e, i, Events.TERMINATE_SINGLE_EPOCH)
                 assert engine.called_events[-1] == (e, i, Events.EPOCH_COMPLETED)
@@ -356,6 +367,9 @@ class TestEngine:
 
         assert engine.state.epoch == max_epochs
         assert (max_epochs - 1) * len(data) < engine.state.iteration < max_epochs * len(data)
+
+        epoch_completed_events = [e for e in engine.called_events if e[2] == Events.EPOCH_COMPLETED.name]
+        assert len(epoch_completed_events) == max_epochs - skip_epoch_completed
 
     @pytest.mark.parametrize("data", [None, "mock_data_loader"])
     def test_iteration_events_are_fired(self, data):


### PR DESCRIPTION
This pull request addresses #3312 

### Description
`Engine.terminate_epoch()` can now be called with the flag `skip_epoch_completed=True`, which allows to prevent `Events.EPOCH_COMPLETED` to be fired after the termination of the epoch.

### TODOs

- [x] Adapt existing tests 
- [ ] Add new tests to ensure that handlers behave as expected when an epoch is terminated with the flag `skip_epoch_completed=True`.
- [x] Documentation is updated (if required)

### Other minor changes
- Engine's attribute `skip_completed_after_termination` introduced in #3309 has been made renamed to `_skip_completed_after_termination` to make it private, for consistency with [adb2a01](https://github.com/pytorch/ignite/commit/adb2a01f20e5dd2ceb97f1142808a45bef9f60ac)