### PR TITLE
Fix group as list of ints in torch dist collective ops

### DIFF
--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -408,6 +408,15 @@ if has_native_dist_support:
                 **spawn_kwargs,
             )
 
+        def _setup_group(self, group: Optional[Any]) -> dist.ProcessGroup:
+            if isinstance(group, list) and all(isinstance(item, int) for item in group):
+                group = self._do_new_group(group)
+            if not (isinstance(group, dist.ProcessGroup) or group == dist.GroupMember.NON_GROUP_MEMBER):
+                raise ValueError(
+                    f"Argument group should be list of int or ProcessGroup, got {type(group)}, group={group}"
+                )
+            return group
+
         _reduce_op_map = {
             "SUM": dist.ReduceOp.SUM,
             "PRODUCT": dist.ReduceOp.PRODUCT,
@@ -420,8 +429,8 @@ if has_native_dist_support:
         def _do_all_reduce(self, tensor: torch.Tensor, op: str = "SUM", group: Optional[Any] = None) -> torch.Tensor:
             if op not in self._reduce_op_map:
                 raise ValueError(f"Unsupported reduction operation: '{op}'")
-            if group is not None and not isinstance(group, dist.ProcessGroup):
-                raise ValueError("Argument group should be list of int or ProcessGroup")
+            if group is not None:
+                group = self._setup_group(group)
             reduce_op = self._reduce_op_map[op]
             # We do if/else here for compatibility with older pytorch versions
             if group is not None:
@@ -431,15 +440,14 @@ if has_native_dist_support:
             return tensor
 
         def _do_all_gather(self, tensor: torch.Tensor, group: Optional[Any] = None) -> torch.Tensor:
+            if group is not None:
+                group = self._setup_group(group)
             if group == dist.GroupMember.NON_GROUP_MEMBER:
                 return tensor
-
             if group is None:
                 group_size = self.get_world_size()
-            elif isinstance(group, dist.ProcessGroup):
-                group_size = group.size()
             else:
-                raise ValueError("Argument group should be list of int or ProcessGroup")
+                group_size = group.size()
             if tensor.ndimension() == 0:
                 tensor = tensor.unsqueeze(0)
             output = [torch.zeros_like(tensor) for _ in range(group_size)]
@@ -456,16 +464,14 @@ if has_native_dist_support:
                     "Current torch version does not implement dist.all_gather_object. "
                     "Required version should be >=1.7.0"
                 )
-
+            if group is not None:
+                group = self._setup_group(group)
             if group == dist.GroupMember.NON_GROUP_MEMBER:
                 return tensor
-
             if group is None:
                 group_size = self.get_world_size()
-            elif isinstance(group, dist.ProcessGroup):
-                group_size = group.size()
             else:
-                raise ValueError("Argument group should be list of int or ProcessGroup")
+                group_size = group.size()
             output = [None for _ in range(group_size)]
             # We do if/else here for compatibility with older pytorch versions
             if group is not None:

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -347,9 +347,6 @@ def all_reduce(
     if _need_to_sync and isinstance(_model, _SerialModel):
         sync(temporary=True)
 
-    if isinstance(group, list) and all(isinstance(item, int) for item in group):
-        group = _model.new_group(group)
-
     return _model.all_reduce(tensor, op, group=group)
 
 
@@ -428,9 +425,6 @@ def all_gather(
     """
     if _need_to_sync and isinstance(_model, _SerialModel):
         sync(temporary=True)
-
-    if isinstance(group, list) and all(isinstance(item, int) for item in group):
-        group = _model.new_group(group)
 
     return _model.all_gather(tensor, group=group)
 

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -225,7 +225,8 @@ def test_idist__model_methods_gloo(distributed_context_single_node_gloo):
 def test_idist_all_reduce_nccl(distributed_context_single_node_nccl):
     device = idist.device()
     _test_distrib_all_reduce(device)
-    _test_distrib_all_reduce_group(device)
+    if idist.get_world_size() > 1:
+        _test_distrib_all_reduce_group(device)
 
 
 @pytest.mark.distributed
@@ -233,7 +234,8 @@ def test_idist_all_reduce_nccl(distributed_context_single_node_nccl):
 def test_idist_all_reduce_gloo(distributed_context_single_node_gloo):
     device = idist.device()
     _test_distrib_all_reduce(device)
-    _test_distrib_all_reduce_group(device)
+    if idist.get_world_size() > 1:
+        _test_distrib_all_reduce_group(device)
 
 
 @pytest.mark.distributed
@@ -243,7 +245,8 @@ def test_idist_all_reduce_gloo(distributed_context_single_node_gloo):
 def test_idist_all_gather_nccl(distributed_context_single_node_nccl):
     device = idist.device()
     _test_distrib_all_gather(device)
-    _test_distrib_all_gather_group(device)
+    if idist.get_world_size() > 1:
+        _test_distrib_all_gather_group(device)
 
 
 @pytest.mark.distributed
@@ -252,7 +255,8 @@ def test_idist_all_gather_nccl(distributed_context_single_node_nccl):
 def test_idist_all_gather_gloo(distributed_context_single_node_gloo):
     device = idist.device()
     _test_distrib_all_gather(device)
-    _test_distrib_all_gather_group(device)
+    if idist.get_world_size() > 1:
+        _test_distrib_all_gather_group(device)
 
 
 @pytest.mark.distributed
@@ -261,7 +265,8 @@ def test_idist_all_gather_gloo(distributed_context_single_node_gloo):
 def test_idist_all_gather_tensors_with_shapes_nccl(distributed_context_single_node_nccl):
     device = idist.device()
     _test_idist_all_gather_tensors_with_shapes(device)
-    _test_idist_all_gather_tensors_with_shapes_group(device)
+    if idist.get_world_size() > 1:
+        _test_idist_all_gather_tensors_with_shapes_group(device)
 
 
 @pytest.mark.distributed
@@ -269,7 +274,8 @@ def test_idist_all_gather_tensors_with_shapes_nccl(distributed_context_single_no
 def test_idist_all_gather_tensors_with_shapes_gloo(distributed_context_single_node_gloo):
     device = idist.device()
     _test_idist_all_gather_tensors_with_shapes(device)
-    _test_idist_all_gather_tensors_with_shapes_group(device)
+    if idist.get_world_size() > 1:
+        _test_idist_all_gather_tensors_with_shapes_group(device)
 
 
 @pytest.mark.distributed

--- a/tests/run_cpu_tests.sh
+++ b/tests/run_cpu_tests.sh
@@ -22,7 +22,7 @@ fi
 # Run 2 processes with --dist=each
 CUDA_VISIBLE_DEVICES="" run_tests \
     --core_args "-m distributed -vvv tests/ignite" \
-    --world_size 2 \
+    --world_size 4 \
     --cache_dir ".cpu-distrib" \
     --skip_distrib_tests 0 \
     --use_coverage 1 \


### PR DESCRIPTION
Description:
- update world_size to 4 in the cpu distributed tests to reveal failures in all_reduce/all_gather tests
- fix the issue when group is given as `list[int]`