### PR TITLE
adds argument name for device in test_mean_squared_error #3335

### DIFF
--- a/tests/ignite/metrics/test_mean_squared_error.py
+++ b/tests/ignite/metrics/test_mean_squared_error.py
@@ -30,7 +30,7 @@ def test_case(request):
 
 @pytest.mark.parametrize("n_times", range(5))
 def test_compute(n_times, available_device, test_case):
-    mse = MeanSquaredError(available_device)
+    mse = MeanSquaredError(device=available_device)
 
     y_pred, y, batch_size = test_case
 

--- a/tests/ignite/metrics/test_mean_squared_error.py
+++ b/tests/ignite/metrics/test_mean_squared_error.py
@@ -48,6 +48,7 @@ def test_compute(n_times, available_device, test_case):
 
     np_res = np.power((np_y - np_y_pred), 2.0).sum() / np_y.shape[0]
 
+    assert mse._device == torch.device(available_device)
     assert isinstance(mse.compute(), float)
     assert mse.compute() == np_res
 

--- a/tests/ignite/metrics/test_mean_squared_error.py
+++ b/tests/ignite/metrics/test_mean_squared_error.py
@@ -31,6 +31,7 @@ def test_case(request):
 @pytest.mark.parametrize("n_times", range(5))
 def test_compute(n_times, available_device, test_case):
     mse = MeanSquaredError(device=available_device)
+    assert mse._device == torch.device(available_device)
 
     y_pred, y, batch_size = test_case
 
@@ -48,7 +49,6 @@ def test_compute(n_times, available_device, test_case):
 
     np_res = np.power((np_y - np_y_pred), 2.0).sum() / np_y.shape[0]
 
-    assert mse._device == torch.device(available_device)
     assert isinstance(mse.compute(), float)
     assert mse.compute() == np_res
 


### PR DESCRIPTION
missing argument name for device when instantiating MeanSquaredError 
