### PR TITLE
Added available_device in metric tests (#3335)

### DIFF
--- a/tests/ignite/metrics/test_mean_absolute_error.py
+++ b/tests/ignite/metrics/test_mean_absolute_error.py
@@ -32,7 +32,7 @@ def test_case(request):
 def test_compute(n_times, test_case, available_device):
     mae = MeanAbsoluteError(device=available_device)
     assert mae._device == torch.device(available_device)
-    
+
     y_pred, y, batch_size = test_case
 
     mae.reset()

--- a/tests/ignite/metrics/test_mean_absolute_error.py
+++ b/tests/ignite/metrics/test_mean_absolute_error.py
@@ -29,9 +29,10 @@ def test_case(request):
 
 
 @pytest.mark.parametrize("n_times", range(5))
-def test_compute(n_times, test_case):
-    mae = MeanAbsoluteError()
-
+def test_compute(n_times, test_case, available_device):
+    mae = MeanAbsoluteError(device=available_device)
+    assert mae._device == torch.device(available_device)
+    
     y_pred, y, batch_size = test_case
 
     mae.reset()

--- a/tests/ignite/metrics/test_mean_pairwise_distance.py
+++ b/tests/ignite/metrics/test_mean_pairwise_distance.py
@@ -29,8 +29,9 @@ def test_case(request):
 
 
 @pytest.mark.parametrize("n_times", range(5))
-def test_compute(n_times, test_case):
-    mpd = MeanPairwiseDistance()
+def test_compute(n_times, test_case, available_device):
+    mpd = MeanPairwiseDistance(device=available_device)
+    assert mpd._device == torch.device(available_device)
 
     y_pred, y, batch_size = test_case
 


### PR DESCRIPTION
Related #3335 

Description:

* Added available_device fixture in test_mean_absolute_error.py

* Added available_device fixture in test_mean_mean_pairwise_distance.py
