### PR TITLE
Added support for logging dicts/iterables of metrics

### DIFF
--- a/ignite/handlers/clearml_logger.py
+++ b/ignite/handlers/clearml_logger.py
@@ -109,6 +109,13 @@ class ClearMLLogger(BaseLogger):
                 log_handler=WeightsScalarHandler(model)
             )
 
+    Note:
+        :class:`~ignite.handlers.clearml_logger.OutputHandler` can handle
+        metrics, state attributes and engine output values of the following format:
+        - scalar values (i.e. int, float)
+        - 0d and 1d pytorch tensors
+        - dicts and list/tuples of previous types
+
     """
 
     def __init__(self, **kwargs: Any):
@@ -342,9 +349,10 @@ class OutputHandler(BaseOutputHandler):
         for key, value in metrics.items():
             if len(key) == 2:
                 logger.clearml_logger.report_scalar(title=key[0], series=key[1], iteration=global_step, value=value)
-            elif len(key) == 3:
+            elif len(key) >= 3:
+                series = "/".join(key[2:])
                 logger.clearml_logger.report_scalar(
-                    title=f"{key[0]}/{key[1]}", series=key[2], iteration=global_step, value=value
+                    title=f"{key[0]}/{key[1]}", series=series, iteration=global_step, value=value
                 )
 
 

--- a/ignite/handlers/mlflow_logger.py
+++ b/ignite/handlers/mlflow_logger.py
@@ -84,6 +84,49 @@ class MLflowLogger(BaseLogger):
                 optimizer=optimizer,
                 param_name='lr'  # optional
             )
+
+    Note:
+        :class:`~ignite.handlers.mlflow_logger.OutputHandler` can handle
+        metrics, state attributes and engine output values of the following format:
+        - scalar values (i.e. int, float)
+        - 0d and 1d pytorch tensors
+        - dicts and list/tuples of previous types
+
+        .. code-block:: python
+
+            # !!! This is not a runnable code !!!
+            evalutator.state.metrics = {
+                "a": 0,
+                "dict_value": {
+                    "a": 111,
+                    "c": {"d": 23, "e": [123, 234]},
+                },
+                "list_value": [12, 13, {"aa": 33, "bb": 44}],
+                "tuple_value": (112, 113, {"aaa": 33, "bbb": 44}),
+            }
+
+            handler = OutputHandler(
+                tag="tag",
+                metric_names="all",
+            )
+
+            handler(evaluator, mlflow_logger, event_name=Events.EPOCH_COMPLETED)
+            # Behind it would call `mlflow_logger.log_metrics` on
+            # {
+            #     "tag/a": 0,
+            #     "tag/dict_value/a": 111,
+            #     "tag/dict_value/c/d": 23,
+            #     "tag/dict_value/c/e/0": 123,
+            #     "tag/dict_value/c/e/1": 234,
+            #     "tag/list_value/0": 12,
+            #     "tag/list_value/1": 13,
+            #     "tag/list_value/2/aa": 33,
+            #     "tag/list_value/2/bb": 44,
+            #     "tag/tuple_value/0": 112,
+            #     "tag/tuple_value/1": 113,
+            #     "tag/tuple_value/2/aaa": 33,
+            #     "tag/tuple_value/2/bbb": 44,
+            # }
     """
 
     def __init__(self, tracking_uri: Optional[str] = None):

--- a/ignite/handlers/neptune_logger.py
+++ b/ignite/handlers/neptune_logger.py
@@ -153,6 +153,13 @@ class NeptuneLogger(BaseLogger):
                     output_transform=lambda loss: {"loss": loss},
                 )
 
+    Note:
+        :class:`~ignite.handlers.neptune_logger.OutputHandler` can handle
+        metrics, state attributes and engine output values of the following format:
+        - scalar values (i.e. int, float)
+        - 0d and 1d pytorch tensors
+        - dicts and list/tuples of previous types
+
     """
 
     def __getattr__(self, attr: Any) -> Any:

--- a/ignite/handlers/polyaxon_logger.py
+++ b/ignite/handlers/polyaxon_logger.py
@@ -92,6 +92,13 @@ class PolyaxonLogger(BaseLogger):
             )
             # to manually end a run
             plx_logger.close()
+
+    Note:
+        :class:`~ignite.handlers.polyaxon_logger.OutputHandler` can handle
+        metrics, state attributes and engine output values of the following format:
+        - scalar values (i.e. int, float)
+        - 0d and 1d pytorch tensors
+        - dicts and list/tuples of previous types
     """
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/ignite/handlers/tensorboard_logger.py
+++ b/ignite/handlers/tensorboard_logger.py
@@ -145,6 +145,49 @@ class TensorboardLogger(BaseLogger):
                     output_transform=lambda loss: {"loss": loss}
                 )
 
+    Note:
+        :class:`~ignite.handlers.tensorboard_logger.OutputHandler` can handle
+        metrics, state attributes and engine output values of the following format:
+        - scalar values (i.e. int, float)
+        - 0d and 1d pytorch tensors
+        - dicts and list/tuples of previous types
+
+        .. code-block:: python
+
+            # !!! This is not a runnable code !!!
+            evalutator.state.metrics = {
+                "a": 0,
+                "dict_value": {
+                    "a": 111,
+                    "c": {"d": 23, "e": [123, 234]},
+                },
+                "list_value": [12, 13, {"aa": 33, "bb": 44}],
+                "tuple_value": (112, 113, {"aaa": 33, "bbb": 44}),
+            }
+
+            handler = OutputHandler(
+                tag="tag",
+                metric_names="all",
+            )
+
+            handler(evaluator, tb_logger, event_name=Events.EPOCH_COMPLETED)
+            # Behind it would call `tb_logger.writer.add_scalar` on
+            # {
+            #     "tag/a": 0,
+            #     "tag/dict_value/a": 111,
+            #     "tag/dict_value/c/d": 23,
+            #     "tag/dict_value/c/e/0": 123,
+            #     "tag/dict_value/c/e/1": 234,
+            #     "tag/list_value/0": 12,
+            #     "tag/list_value/1": 13,
+            #     "tag/list_value/2/aa": 33,
+            #     "tag/list_value/2/bb": 44,
+            #     "tag/tuple_value/0": 112,
+            #     "tag/tuple_value/1": 113,
+            #     "tag/tuple_value/2/aaa": 33,
+            #     "tag/tuple_value/2/bbb": 44,
+            # }
+
     """
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/ignite/handlers/tqdm_logger.py
+++ b/ignite/handlers/tqdm_logger.py
@@ -298,8 +298,7 @@ class _OutputHandler(BaseOutputHandler):
         rendered_metrics = self._setup_output_metrics_state_attrs(engine, log_text=True)
         metrics = OrderedDict()
         for key, value in rendered_metrics.items():
-            key = "_".join(key[1:])  # tqdm has tag as description
-
+            key = "_".join(key[1:])  # skip tag as tqdm has tag as description
             metrics[key] = value
 
         if metrics:

--- a/ignite/handlers/visdom_logger.py
+++ b/ignite/handlers/visdom_logger.py
@@ -137,6 +137,13 @@ class VisdomLogger(BaseLogger):
                     output_transform=lambda loss: {"loss": loss}
                 )
 
+    Note:
+        :class:`~ignite.handlers.visdom_logger.OutputHandler` can handle
+        metrics, state attributes and engine output values of the following format:
+        - scalar values (i.e. int, float)
+        - 0d and 1d pytorch tensors
+        - dicts and list/tuples of previous types
+
     .. versionchanged:: 0.4.7
         accepts an optional list of `state_attributes`
     """

--- a/ignite/handlers/wandb_logger.py
+++ b/ignite/handlers/wandb_logger.py
@@ -120,6 +120,12 @@ class WandBLogger(BaseLogger):
             )
             evaluator.add_event_handler(Events.COMPLETED, model_checkpoint, {'model': model})
 
+    Note:
+        :class:`~ignite.handlers.wandb_logger.OutputHandler` can handle
+        metrics, state attributes and engine output values of the following format:
+        - scalar values (i.e. int, float)
+        - 0d and 1d pytorch tensors
+        - dicts and list/tuples of previous types
 
     """
 

--- a/tests/ignite/handlers/test_base_logger.py
+++ b/tests/ignite/handlers/test_base_logger.py
@@ -103,6 +103,44 @@ def test_base_output_handler_setup_output_metrics():
     metrics = handler._setup_output_metrics_state_attrs(engine=engine, key_tuple=False)
     assert metrics == {"tag/a": 0, "tag/b": 1}
 
+    # metrics with mappings, iterables
+    true_metrics = {
+        "a": 0,
+        "b": "1",
+        "dict_value": {
+            "a": 111,
+            "b": "222",
+            "c": {"d": 23, "e": [123, 234]},
+            "f": [{"g": 11, "h": (321, 432)}, 778],
+        },
+        "list_value": [12, "13", {"aa": 33, "bb": 44}],
+        "tuple_value": (112, "113", {"aaa": 33, "bbb": 44}),
+    }
+    engine.state = State(metrics=true_metrics)
+    handler = DummyOutputHandler("tag", metric_names="all", output_transform=None)
+    metrics = handler._setup_output_metrics_state_attrs(engine=engine, key_tuple=False, log_text=True)
+    assert metrics == {
+        "tag/a": 0,
+        "tag/b": "1",
+        "tag/dict_value/a": 111,
+        "tag/dict_value/b": "222",
+        "tag/dict_value/c/d": 23,
+        "tag/dict_value/c/e/0": 123,
+        "tag/dict_value/c/e/1": 234,
+        "tag/dict_value/f/0/g": 11,
+        "tag/dict_value/f/0/h/0": 321,
+        "tag/dict_value/f/0/h/1": 432,
+        "tag/dict_value/f/1": 778,
+        "tag/list_value/0": 12,
+        "tag/list_value/1": "13",
+        "tag/list_value/2/aa": 33,
+        "tag/list_value/2/bb": 44,
+        "tag/tuple_value/0": 112,
+        "tag/tuple_value/1": "113",
+        "tag/tuple_value/2/aaa": 33,
+        "tag/tuple_value/2/bbb": 44,
+    }
+
 
 def test_base_output_handler_setup_output_state_attrs():
     engine = Engine(lambda engine, batch: None)


### PR DESCRIPTION
Fixes #3294
Closes #3295 

Description:
- Added support for logging dicts/iterables

For example:
```python
evalutator.state.metrics = {
    "a": 0,
    "dict_value": {
        "a": 111,
        "c": {"d": 23, "e": [123, 234]},
    },
    "list_value": [12, "13", {"aa": 33, "bb": 44}],
    "tuple_value": (112, "113", {"aaa": 33, "bbb": 44}),
}

handler = OutputHandler(
  tag="tag",
  metric_names="all",
)

handler(evaluator, tb_logger, event_name=Events.EPOCH_COMPLETED)
# Behind it would call `tb_logger.writer.add_scalar` on 
# {
#     "tag/a": 0,
#     "tag/dict_value/a": 111,
#     "tag/dict_value/c/d": 23,
#     "tag/dict_value/c/e/0": 123,
#     "tag/dict_value/c/e/1": 234,
#     "tag/list_value/0": 12,
#     "tag/list_value/1": "13",
#     "tag/list_value/2/aa": 33,
#     "tag/list_value/2/bb": 44,
#     "tag/tuple_value/0": 112,
#     "tag/tuple_value/1": "113",
#     "tag/tuple_value/2/aaa": 33,
#     "tag/tuple_value/2/bbb": 44,
# }
```

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
