### PR TITLE
fixes #3352

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ coverage.xml
 /docs/source/generated/
 
 # Virtualenv
+venv/
 .venv/
 .python-version

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -361,6 +361,9 @@ class Metric(Serializable, metaclass=ABCMeta):
         device: Union[str, torch.device] = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
+        if not callable(output_transform):
+            raise TypeError("Argument output_transform should be callable, " f"got {type(output_transform)}")
+
         self._output_transform = output_transform
 
         # Some metrics have a large performance regression when run on XLA devices, so for now, we disallow it.

--- a/tests/ignite/metrics/test_metric.py
+++ b/tests/ignite/metrics/test_metric.py
@@ -1468,3 +1468,20 @@ def test_access_to_metric_dunder_attributes():
 
     # `inspect.signature` accesses `__signature__` attribute of the metric.
     assert "value" in inspect.signature(metric).parameters.keys()
+
+class DummyMetric7(Metric):
+    def reset(self):
+        pass
+
+    def compute(self):
+        pass
+
+    def update(self, output):
+        pass
+
+    def __call__(self, value):
+        pass
+
+def test_output_transform():
+    with pytest.raises(TypeError, match="Argument output_transform should be callable"):
+        DummyMetric7(output_transform=1)


### PR DESCRIPTION
Fixes #3352

**Description:**
Validation to ensure that output_transform is callable, raising a TypeError.

**
![metric.py](https://github.com/user-attachments/assets/b3237d1d-ec48-47ef-bec7-54df18423807)
![test_metric.py](https://github.com/user-attachments/assets/2bfcd12b-208e-4e93-9bb6-ba25e839a76e)**

- [x] Added the above mentioned code
- [x]Added output_transform type check in Metric class

