### PR TITLE
Fix cocotools change for missing info key

### DIFF
--- a/tests/ignite/metrics/vision/test_object_detection_map.py
+++ b/tests/ignite/metrics/vision/test_object_detection_map.py
@@ -508,6 +508,7 @@ def create_coco_api(
             dataset["annotations"].append(ann)
             ann_id += 1
     dataset["categories"] = [{"id": i} for i in range(0, 91)]
+    dataset["info"] = {}
     coco_gt.dataset = dataset
     coco_gt.createIndex()
 


### PR DESCRIPTION
It seems `Coco` now expects the annotations file, since it is copying `info` key, so I added that to the dataset in the meantime.

Requires https://github.com/pytorch/ignite/pull/3414 to get fixes for nightly

```
2025-06-11T17:39:05.3129969Z =========================== short test summary info ============================
2025-06-11T17:39:05.3130730Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_empty_data[cpu] - KeyError: 'info'
2025-06-11T17:39:05.3131593Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample0-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3132669Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample1-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3133503Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample2-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3134307Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample3-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3135138Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample4-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3136343Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample5-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3137185Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample6-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3138004Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_iou[sample7-cpu] - KeyError: 'info'
2025-06-11T17:39:05.3138810Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample0] - KeyError: 'info'
2025-06-11T17:39:05.3139601Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample1] - KeyError: 'info'
2025-06-11T17:39:05.3140246Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample2] - KeyError: 'info'
2025-06-11T17:39:05.3140888Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample3] - KeyError: 'info'
2025-06-11T17:39:05.3141533Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample4] - KeyError: 'info'
2025-06-11T17:39:05.3142159Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample5] - KeyError: 'info'
2025-06-11T17:39:05.3142794Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample6] - KeyError: 'info'
2025-06-11T17:39:05.3143448Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample7] - KeyError: 'info'
2025-06-11T17:39:05.3144100Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample0] - KeyError: 'info'
2025-06-11T17:39:05.3144765Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample1] - KeyError: 'info'
2025-06-11T17:39:05.3145426Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample2] - KeyError: 'info'
2025-06-11T17:39:05.3146199Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample3] - KeyError: 'info'
2025-06-11T17:39:05.3146975Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample4] - KeyError: 'info'
2025-06-11T17:39:05.3147671Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample5] - KeyError: 'info'
2025-06-11T17:39:05.3148347Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample6] - KeyError: 'info'
2025-06-11T17:39:05.3149014Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample7] - KeyError: 'info'
2025-06-11T17:39:05.3149766Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample0] - KeyError: 'info'
2025-06-11T17:39:05.3150550Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample1] - KeyError: 'info'
2025-06-11T17:39:05.3151417Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample2] - KeyError: 'info'
2025-06-11T17:39:05.3152273Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample3] - KeyError: 'info'
2025-06-11T17:39:05.3153043Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample4] - KeyError: 'info'
2025-06-11T17:39:05.3153816Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample5] - KeyError: 'info'
2025-06-11T17:39:05.3154651Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample6] - KeyError: 'info'
2025-06-11T17:39:05.3155429Z ERROR tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample7] - KeyError: 'info'
```