### PR TITLE
Refactor: switch GradScaler import from torch.cuda.amp to torch.amp

### DIFF
--- a/examples/cifar10/main.py
+++ b/examples/cifar10/main.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.optim as optim
 import utils
 from torch.amp import autocast
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler
 
 import ignite
 import ignite.distributed as idist

--- a/examples/cifar100_amp_benchmark/benchmark_torch_cuda_amp.py
+++ b/examples/cifar100_amp_benchmark/benchmark_torch_cuda_amp.py
@@ -1,7 +1,7 @@
 import fire
 import torch
 from torch.amp import autocast
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler
 from torch.nn import CrossEntropyLoss
 from torch.optim import SGD
 from torchvision.models import wide_resnet50_2

--- a/examples/cifar10_qat/main.py
+++ b/examples/cifar10_qat/main.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import torch.optim as optim
 import utils
 from torch.amp import autocast
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler
 
 import ignite
 import ignite.distributed as idist

--- a/examples/transformers/main.py
+++ b/examples/transformers/main.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.optim as optim
 import utils
 from torch.amp import autocast
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler
 
 import ignite
 import ignite.distributed as idist

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -48,7 +48,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "distributed: run distributed")
     config.addinivalue_line("markers", "multinode_distributed: distributed")
     config.addinivalue_line("markers", "tpu: run on tpu")
-    if config.option.treat_unrun_as_failed:
+    if getattr(config.option, "treat_unrun_as_failed", False):
         unrun_tracker = UnrunTracker()
         config.pluginmanager.register(unrun_tracker, "unrun_tracker_plugin")
 
@@ -611,6 +611,6 @@ def pytest_sessionfinish(session, exitstatus):
     run finished, right before returning the exit status to the system.
     """
     # If requested by the user, track all unrun tests and add them to the lastfailed cache
-    if session.config.option.treat_unrun_as_failed:
+    if getattr(session.config.option, "treat_unrun_as_failed", False):
         unrun_tracker = session.config.pluginmanager.get_plugin("unrun_tracker_plugin")
         unrun_tracker.record_unrun_as_failed(session, exitstatus)

--- a/tests/ignite/engine/test_create_supervised.py
+++ b/tests/ignite/engine/test_create_supervised.py
@@ -48,7 +48,7 @@ def _default_create_supervised_trainer(
     trainer_device: Optional[str] = None,
     trace: bool = False,
     amp_mode: str = None,
-    scaler: Union[bool, "torch.cuda.amp.GradScaler"] = False,
+    scaler: Union[bool, "torch.amp.GradScaler"] = False,
     with_model_transform: bool = False,
     with_model_fn: bool = False,
 ):
@@ -104,7 +104,7 @@ def _test_create_supervised_trainer(
     trainer_device: Optional[str] = None,
     trace: bool = False,
     amp_mode: str = None,
-    scaler: Union[bool, "torch.cuda.amp.GradScaler"] = False,
+    scaler: Union[bool, "torch.amp.GradScaler"] = False,
     with_model_transform: bool = False,
     with_model_fn: bool = False,
 ):
@@ -170,10 +170,10 @@ def _test_create_supervised_trainer(
 @pytest.mark.skipif(Version(torch.__version__) < Version("1.12.0"), reason="Skip if < 1.12.0")
 def test_create_supervised_training_scalar_assignment():
     with mock.patch("ignite.engine._check_arg") as check_arg_mock:
-        check_arg_mock.return_value = None, torch.cuda.amp.GradScaler(enabled=False)
+        check_arg_mock.return_value = None, torch.amp.GradScaler(enabled=False)
         trainer, _ = _default_create_supervised_trainer(model_device="cpu", trainer_device="cpu", scaler=True)
         assert hasattr(trainer.state, "scaler")
-        assert isinstance(trainer.state.scaler, torch.cuda.amp.GradScaler)
+        assert isinstance(trainer.state.scaler, torch.amp.GradScaler)
 
 
 def _test_create_mocked_supervised_trainer(
@@ -181,7 +181,7 @@ def _test_create_mocked_supervised_trainer(
     trainer_device: Optional[str] = None,
     trace: bool = False,
     amp_mode: str = None,
-    scaler: Union[bool, "torch.cuda.amp.GradScaler"] = False,
+    scaler: Union[bool, "torch.amp.GradScaler"] = False,
 ):
     with mock.patch("ignite.engine.supervised_training_step_amp") as training_step_amp_mock:
         with mock.patch("ignite.engine.supervised_training_step_apex") as training_step_apex_mock:
@@ -462,7 +462,7 @@ def test_create_supervised_trainer_amp_error(mock_torch_cuda_amp_module):
 
 @pytest.mark.skipif(Version(torch.__version__) < Version("1.12.0"), reason="Skip if < 1.12.0")
 def test_create_supervised_trainer_scaler_not_amp():
-    scaler = torch.cuda.amp.GradScaler(enabled=torch.cuda.is_available())
+    scaler = torch.amp.GradScaler(enabled=torch.cuda.is_available())
 
     with pytest.raises(ValueError, match=f"scaler argument is {scaler}, but amp_mode is None."):
         _test_create_supervised_trainer(amp_mode=None, scaler=scaler)
@@ -540,7 +540,7 @@ def test_create_supervised_trainer_on_cuda_amp_scaler():
     _test_create_mocked_supervised_trainer(
         model_device=model_device, trainer_device=trainer_device, amp_mode="amp", scaler=True
     )
-    scaler = torch.cuda.amp.GradScaler(enabled=torch.cuda.is_available())
+    scaler = torch.amp.GradScaler(enabled=torch.cuda.is_available())
     _test_create_supervised_trainer(
         gradient_accumulation_steps=1,
         model_device=model_device,


### PR DESCRIPTION
Fixes #3435

Description:
I have made change in code from torch.cuda.amp import GradScaler to from torch.amp import GradScaler.
	•	torch.amp provides a unified AMP interface across devices.
	•	Using torch.cuda.amp restricts AMP usage to CUDA-only environments.
	•	This change helps Ignite better support PyTorch’s full AMP ecosystem in a clean and future-proof way.

No new functionality added — this is a safe refactor with no effect on runtime behavior.

