### PR TITLE
Add SAVED_CHECKPOINT event to Checkpoint handler

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -37,7 +37,6 @@ Complete list of generic handlers
 Checkpoint Events
 -----------------
 
-.. versionadded:: 0.5.0
 
 The Checkpoint handler provides a ``SAVED_CHECKPOINT`` event that fires after successful checkpoint saves.
 This allows users to attach custom handlers that react to checkpoint operations without manual event registration.

--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -34,6 +34,37 @@ Complete list of generic handlers
     state_param_scheduler.StateParamScheduler
 
 
+Checkpoint Events
+-----------------
+
+.. versionadded:: 0.5.0
+
+The Checkpoint handler provides a ``SAVED_CHECKPOINT`` event that fires after successful checkpoint saves.
+This allows users to attach custom handlers that react to checkpoint operations without manual event registration.
+
+**Usage:**
+
+.. code-block:: python
+
+    from ignite.handlers import Checkpoint
+    from ignite.engine import Engine, Events
+    
+    # Setup checkpoint handler
+    checkpoint_handler = Checkpoint(
+        {'model': model, 'optimizer': optimizer}, 
+        save_dir,
+        n_saved=2
+    )
+    
+    # Attach handler to checkpoint event (no manual registration needed)
+    @trainer.on(Checkpoint.SAVED_CHECKPOINT)
+    def on_checkpoint_saved(engine):
+        print(f"Checkpoint saved at epoch {engine.state.epoch}")
+        # Add custom logic: notifications, logging, etc.
+    
+    trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpoint_handler)
+
+
 Loggers
 --------
 

--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -11,6 +11,7 @@ Complete list of generic handlers
     :toctree: generated
 
     checkpoint.Checkpoint
+    checkpoint.CheckpointEvents
     DiskSaver
     checkpoint.ModelCheckpoint
     ema_handler.EMAHandler

--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -35,36 +35,6 @@ Complete list of generic handlers
     state_param_scheduler.StateParamScheduler
 
 
-Checkpoint Events
------------------
-
-
-The Checkpoint handler provides a ``SAVED_CHECKPOINT`` event that fires after successful checkpoint saves.
-This allows users to attach custom handlers that react to checkpoint operations without manual event registration.
-
-**Usage:**
-
-.. code-block:: python
-
-    from ignite.handlers import Checkpoint
-    from ignite.engine import Engine, Events
-    
-    # Setup checkpoint handler
-    checkpoint_handler = Checkpoint(
-        {'model': model, 'optimizer': optimizer}, 
-        save_dir,
-        n_saved=2
-    )
-    
-    # Attach handler to checkpoint event (no manual registration needed)
-    @trainer.on(Checkpoint.SAVED_CHECKPOINT)
-    def on_checkpoint_saved(engine):
-        print(f"Checkpoint saved at epoch {engine.state.epoch}")
-        # Add custom logic: notifications, logging, etc.
-    
-    trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpoint_handler)
-
-
 Loggers
 --------
 

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -28,8 +28,10 @@ __all__ = ["Checkpoint", "DiskSaver", "ModelCheckpoint", "BaseSaveHandler", "Che
 
 
 class CheckpointEvents(EventEnum):
-    """Events fired by Checkpoint handler
-
+    """Events fired by :class:`~ignite.handlers.checkpoint.Checkpoint`
+    
+    - SAVED_CHECKPOINT : triggered when checkpoint handler has saved objects
+    
     .. versionadded:: 0.5.3
     """
 

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -275,6 +275,29 @@ class Checkpoint(Serializable):
                 to_save, save_handler=DiskSaver('/tmp/models', create_dir=True, **kwargs), n_saved=2
             )
 
+        Respond to checkpoint events:
+
+        .. code-block:: python
+
+            from ignite.handlers import Checkpoint
+            from ignite.engine import Engine, Events
+
+            checkpoint_handler = Checkpoint(
+                {'model': model, 'optimizer': optimizer},
+                save_dir,
+                n_saved=2
+            )
+
+            @trainer.on(Checkpoint.SAVED_CHECKPOINT)
+            def on_checkpoint_saved(engine):
+                print(f"Checkpoint saved at epoch {engine.state.epoch}")
+
+            trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpoint_handler)
+
+    Attributes:
+        SAVED_CHECKPOINT: Alias of ``SAVED_CHECKPOINT`` from
+            :class:`~ignite.handlers.checkpoint.CheckpointEvents`.
+
     .. versionchanged:: 0.4.3
 
         - Checkpoint can save model with same filename.
@@ -286,7 +309,7 @@ class Checkpoint(Serializable):
         - `save_handler` automatically saves to disk if path to directory is provided.
         - `save_on_rank` saves objects on this rank in a distributed configuration.
 
-    .. 
+    ..
     """
 
     SAVED_CHECKPOINT = CheckpointEvents.SAVED_CHECKPOINT

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -28,7 +28,10 @@ __all__ = ["Checkpoint", "DiskSaver", "ModelCheckpoint", "BaseSaveHandler", "Che
 
 
 class CheckpointEvents(EventEnum):
-    """Events fired by Checkpoint handler"""
+    """Events fired by Checkpoint handler
+
+    .. versionadded:: 0.5.3
+    """
 
     SAVED_CHECKPOINT = "saved_checkpoint"
 

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -309,7 +309,9 @@ class Checkpoint(Serializable):
         - `save_handler` automatically saves to disk if path to directory is provided.
         - `save_on_rank` saves objects on this rank in a distributed configuration.
 
-    ..
+    .. versionchanged:: 0.5.3
+
+        - Added ``SAVED_CHECKPOINT`` class attribute.
     """
 
     SAVED_CHECKPOINT = CheckpointEvents.SAVED_CHECKPOINT

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -411,7 +411,7 @@ class Checkpoint(Serializable):
 
     def __call__(self, engine: Engine) -> None:
         if not engine.has_registered_events(CheckpointEvents.SAVED_CHECKPOINT):
-            engine.register_events(CheckpointEvents.SAVED_CHECKPOINT)
+            engine.register_events(*CheckpointEvents)
         global_step = None
         if self.global_step_transform is not None:
             global_step = self.global_step_transform(engine, engine.last_event_name)

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -29,9 +29,9 @@ __all__ = ["Checkpoint", "DiskSaver", "ModelCheckpoint", "BaseSaveHandler", "Che
 
 class CheckpointEvents(EventEnum):
     """Events fired by :class:`~ignite.handlers.checkpoint.Checkpoint`
-    
+
     - SAVED_CHECKPOINT : triggered when checkpoint handler has saved objects
-    
+
     .. versionadded:: 0.5.3
     """
 
@@ -285,6 +285,8 @@ class Checkpoint(Serializable):
         - `score_name` can be used to define `score_function` automatically without providing `score_function`.
         - `save_handler` automatically saves to disk if path to directory is provided.
         - `save_on_rank` saves objects on this rank in a distributed configuration.
+
+    .. 
     """
 
     SAVED_CHECKPOINT = CheckpointEvents.SAVED_CHECKPOINT


### PR DESCRIPTION
Fixes #934

This PR adds a "saved_checkpoint" event that fires after successful checkpoint saves.

**Usage:**
```python
# Users need to register the event first
engine.register_events("saved_checkpoint")

@trainer.on("saved_checkpoint")
def after_saving(engine):
    print("Checkpoint saved!")