### PR TITLE
Fix codecov deprecation warning

### DIFF
--- a/.github/workflows/gpu-hvd-tests.yml
+++ b/.github/workflows/gpu-hvd-tests.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ${{ github.repository }}/coverage.xml
+          files: ${{ github.repository }}/coverage.xml
           flags: gpu-2
           fail_ci_if_error: false
 

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ${{ github.repository }}/coverage.xml
+          files: ${{ github.repository }}/coverage.xml
           flags: gpu-2
           fail_ci_if_error: false
 

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -94,6 +94,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: hvd-cpu
           fail_ci_if_error: false

--- a/.github/workflows/mps-tests.yml
+++ b/.github/workflows/mps-tests.yml
@@ -75,6 +75,12 @@ jobs:
           conda activate $CONDA_ENV
           pip install uv
 
+      - name: Install GPG for Codecov
+        shell: bash -l {0}
+        run: |
+          # Install GPG which is required by codecov-action@v5
+          brew install gnupg
+
       - name: Install PyTorch
         if: ${{ matrix.pytorch-channel == 'pytorch' }}
         shell: bash -l {0}
@@ -130,7 +136,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ${{ github.repository }}/coverage.xml
+          files: ${{ github.repository }}/coverage.xml
           flags: mps
           fail_ci_if_error: false
 

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -103,6 +103,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: tpu
           fail_ci_if_error: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: cpu
           fail_ci_if_error: false
 


### PR DESCRIPTION
Fix codecov deprecation warning

Replace `file` with `files` in the action inpurt parameter