### PR TITLE
Fixed iteration visual value in fbresearch_logger

### DIFF
--- a/ignite/handlers/fbresearch_logger.py
+++ b/ignite/handlers/fbresearch_logger.py
@@ -154,7 +154,7 @@ class FBResearchLogger:
         if torch.cuda.is_available():
             cuda_max_mem = f"GPU Max Mem: {torch.cuda.max_memory_allocated() / MB:.0f} MB"
 
-        current_iter = engine.state.iteration % (engine.state.epoch_length + 1)
+        current_iter = ((engine.state.iteration - 1) % engine.state.epoch_length) + 1
         iter_avg_time = self.iter_timer.value()
 
         eta_seconds = iter_avg_time * (engine.state.epoch_length - current_iter)


### PR DESCRIPTION
Description:
- Fixed iteration visual value in fbresearch_logger

Before this PR (10 -> 9 -> 8 -> 7 but should be always 10):
```
Training: start epoch [1/15]                                                                                                                                                                       
Epoch [1/15]  [10/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Epoch [1/15]  [20/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s  
Training: Epoch [1/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [2/15]                                                                                                                                                                       
Epoch [2/15]  [9/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                    
Epoch [2/15]  [19/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s  
Training: Epoch [2/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [3/15]                                                                                                                                                                       
Epoch [3/15]  [8/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                    
Epoch [3/15]  [18/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s  
Training: Epoch [3/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [4/15]                                                                                                                                                                       
Epoch [4/15]  [7/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                    
Epoch [4/15]  [17/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s  
Training: Epoch [4/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [5/15]                                                                                                                                                                       
Epoch [5/15]  [6/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                    
Epoch [5/15]  [16/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s 
```
with the PR:
```
Training: start epoch [1/15]                                                                                                                                                                       
Epoch [1/15]  [10/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Epoch [1/15]  [20/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Training: Epoch [1/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [2/15]                                                                                                                                                                       
Epoch [2/15]  [10/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Epoch [2/15]  [20/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Training: Epoch [2/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [3/15]                                                                                                                                                                       
Epoch [3/15]  [10/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Epoch [3/15]  [20/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Training: Epoch [3/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [4/15]                                                                                                                                                                       
Epoch [4/15]  [10/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Epoch [4/15]  [20/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Training: Epoch [4/15]  Total time: 0:00:00  (0.0000 s / it)                                                                                                                                       
Training: start epoch [5/15]                                                                                                                                                                       
Epoch [5/15]  [10/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s                                                                                                   
Epoch [5/15]  [20/20]:  ETA: 0:00:00    42.0000    Iter time: 0.0000 s  Data prep time: 0.0000 s  
```


Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
