### PR TITLE
Updated pytorch-version-tests.yml

### DIFF
--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -33,50 +33,30 @@ jobs:
         run: echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
         shell: bash -l {0}
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          python3 -m pip install -U pip
-          echo "pip_cache=$(python3 -m pip cache dir)" >> $GITHUB_OUTPUT
-        shell: bash -l {0}
-
-      - uses: actions/cache@v4
+      - uses: astral-sh/setup-uv@v6
         with:
-          path: |
-            ~/conda_pkgs_dir
-            ${{ steps.pip-cache.outputs.pip_cache }}
-          key: ${{ steps.get-date.outputs.date }}-pytorch-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('requirements-dev.txt') }}
-          restore-keys: |
-            ${{ steps.get-date.outputs.date }}-pytorch-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-
-
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniconda-version: "latest"
+          version: "latest"
           python-version: ${{ matrix.python-version }}
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          activate-environment: true
+          enable-cache: true
+          cache-suffix: "${{ steps.get-date.outputs.date }}-pytorch-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pytorch-version }}"
+          cache-dependency-glob: |
+            **/requirements-dev.txt
+            **/pyproject.toml
 
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install pytorch=${{ matrix.pytorch-version }} torchvision cpuonly python=${{ matrix.python-version }} -c pytorch
+          uv pip install "torch==${{ matrix.pytorch-version }}" torchvision --index-url https://download.pytorch.org/whl/cpu
 
           # We should install numpy<2.0 for pytorch<2.3
           numpy_one_pth_version=$(python -c "import torch; print(float('.'.join(torch.__version__.split('.')[:2])) < 2.3)")
           if [ "${numpy_one_pth_version}" == "True" ]; then
-            pip install -U "numpy<2.0"
+            uv pip install -U "numpy<2.0"
           fi
 
-          pip install -r requirements-dev.txt
-          pip install .
-
-          # pytorch>=1.9.0,<1.11.0 is using "from setuptools import distutils; distutils.version.LooseVersion" anti-pattern
-          # which raises the error: AttributeError: module 'distutils' has no attribute 'version' for setuptools>59
-          bad_pth_version=$(python -c "import torch; print('.'.join(torch.__version__.split('.')[:2]) in ['1.9', '1.10'])")
-          if [ "${bad_pth_version}" == "True" ]; then
-            pip install --upgrade "setuptools<59"
-            python -c "from setuptools import distutils; distutils.version.LooseVersion"
-          fi
+          uv pip install -r requirements-dev.txt
+          uv pip install .
 
       - name: Download MNIST
         uses: pytorch-ignite/download-mnist-github-action@master


### PR DESCRIPTION
Failures with 1.13
```
2025-10-14T12:59:18.3797607Z =========================== short test summary info ============================
2025-10-14T12:59:18.3799199Z FAILED tests/ignite/contrib/engines/test_common.py::test_setup_clearml_logging - ValueError: ClearML configuration could not be found (missing `~/clearml.conf` or Environment CLEARML_API_HOST)
2025-10-14T12:59:18.3799722Z To get started with ClearML: setup your own `clearml-server`, or create a free account at https://app.community.clear.ml
2025-10-14T12:59:18.3800540Z FAILED tests/ignite/distributed/test_auto.py::test_dist_proxy_sampler - AssertionError: Regex pattern did not match.
2025-10-14T12:59:18.3800712Z  Regex: 'Argument sampler should have length'
2025-10-14T12:59:18.3801014Z  Input: "Sampler.__init__() missing 1 required positional argument: 'data_source'"
2025-10-14T12:59:18.3801756Z FAILED tests/ignite/engine/test_create_supervised.py::test_create_supervised_training_scalar_assignment - AttributeError: module 'torch.amp' has no attribute 'GradScaler'
2025-10-14T12:59:18.3802359Z FAILED tests/ignite/engine/test_create_supervised.py::test_create_supervised_trainer_scaler_not_amp - AttributeError: module 'torch.amp' has no attribute 'GradScaler'
2025-10-14T12:59:18.3803033Z FAILED tests/ignite/handlers/test_clearml_logger.py::test_integration - ValueError: ClearML configuration could not be found (missing `~/clearml.conf` or Environment CLEARML_API_HOST)
2025-10-14T12:59:18.3803419Z To get started with ClearML: setup your own `clearml-server`, or create a free account at https://app.community.clear.ml
2025-10-14T12:59:18.3804231Z FAILED tests/ignite/handlers/test_clearml_logger.py::test_integration_as_context_manager - ValueError: ClearML configuration could not be found (missing `~/clearml.conf` or Environment CLEARML_API_HOST)
2025-10-14T12:59:18.3804614Z To get started with ClearML: setup your own `clearml-server`, or create a free account at https://app.community.clear.ml
2025-10-14T12:59:18.3805346Z FAILED tests/ignite/handlers/test_clearml_logger.py::test_clearml_logger_getattr_method - ValueError: ClearML configuration could not be found (missing `~/clearml.conf` or Environment CLEARML_API_HOST)
2025-10-14T12:59:18.3805728Z To get started with ClearML: setup your own `clearml-server`, or create a free account at https://app.community.clear.ml
2025-10-14T12:59:18.3806466Z FAILED tests/ignite/handlers/test_clearml_logger.py::test_clearml_logger_get_task_bypass - ValueError: ClearML configuration could not be found (missing `~/clearml.conf` or Environment CLEARML_API_HOST)
2025-10-14T12:59:18.3806841Z To get started with ClearML: setup your own `clearml-server`, or create a free account at https://app.community.clear.ml
2025-10-14T12:59:18.3807407Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample0] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3807971Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample1] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3808524Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample2] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3809076Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample3] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3809635Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample4] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3810401Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample5] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3810967Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample6] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3811456Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_compute[sample7] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3811996Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample0] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3812473Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample1] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3812941Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample2] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3813451Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample3] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3813909Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample4] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3814371Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample5] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3814824Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample6] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3815340Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_integration[sample7] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3815870Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample0] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3816391Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample1] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3816913Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample2] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3817425Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample3] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3817950Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample4] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3818473Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample5] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3818987Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample6] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3819509Z FAILED tests/ignite/metrics/vision/test_object_detection_map.py::test_distrib_update_compute[gloo_cpu-sample7] - TypeError: where(): argument 'other' (position 2) must be Tensor, not int
2025-10-14T12:59:18.3819632Z ======================= 32 failed, 3 warnings in 32.37s ========================
```

- https://github.com/pytorch/ignite/actions/runs/18497027911/job/52703702677
