### PR TITLE
Replace Union with | syntax in root_mean_squared_error.py

### DIFF
--- a/ignite/metrics/root_mean_squared_error.py
+++ b/ignite/metrics/root_mean_squared_error.py
@@ -1,5 +1,4 @@
 import math
-from typing import Union
 
 import torch
 
@@ -65,6 +64,6 @@ class RootMeanSquaredError(MeanSquaredError):
         ``skip_unrolling`` argument is added.
     """
 
-    def compute(self) -> Union[torch.Tensor, float]:
+    def compute(self) -> torch.Tensor | float:
         mse = super(RootMeanSquaredError, self).compute()
         return math.sqrt(mse)


### PR DESCRIPTION
## Summary
  - Replace `Union[torch.Tensor, float]` with `torch.Tensor | float`
  - Remove unused `from typing import Union` import

  Part of #3481

  ## Test plan
  - [x] Existing tests pass (25 passed)
  - [x] Import check verified