### PR TITLE
Use `Parallel.spawn_kwargs` as kwargs to the backend when appropriate

### DIFF
--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -242,8 +242,6 @@ class Parallel:
                 )
             else:
                 self._pg_init_kwargs = spawn_kwargs
-                if "init_method" in self._pg_init_kwargs:
-                    raise ValueError("Argument 'init_method' should not be specified in 'spawn_kwargs'")
 
 
         # The logger will be setup after the idist.initialize() call

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -232,6 +232,7 @@ class Parallel:
 
         self.backend = backend
         self._spawn_params = None
+        self._pg_init_kwargs = None
         self.init_method = init_method
 
         if self.backend is not None:
@@ -239,6 +240,11 @@ class Parallel:
                 self._spawn_params = self._setup_spawn_params(
                     nproc_per_node, nnodes, node_rank, master_addr, master_port, init_method, **spawn_kwargs
                 )
+            else:
+                self._pg_init_kwargs = spawn_kwargs
+                if "init_method" in self._pg_init_kwargs:
+                    raise ValueError("Argument 'init_method' should not be specified in 'spawn_kwargs'")
+
 
         # The logger will be setup after the idist.initialize() call
         self._logger = None
@@ -319,7 +325,7 @@ class Parallel:
 
     def __enter__(self) -> "Parallel":
         if self.backend is not None and self._spawn_params is None:
-            idist.initialize(self.backend, init_method=self.init_method)
+            idist.initialize(self.backend, init_method=self.init_method, **(self._pg_init_kwargs or dict()))
 
         # The logger can be setup from now since idist.initialize() has been called (if needed)
         self._logger = setup_logger(__name__ + "." + self.__class__.__name__)


### PR DESCRIPTION
Fixes #{issue number}
None.

Description:

Allow passing extra arguments to the distributed backend, this enables the following usage pattern:

```
torchrun ... main.py ...

# Note that nproc_per_node is not specified.
with idist.Prallel(backend=foo, timeout=bar) as par:
    ....
```
Which is not previously possible.

Note that `kwargs` in `_NativeDistModel._create_from_backend` is unused, so there is still a chance that the args passed via spawn_args is still unused, but it works for explicitly listed arguments like timeout

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
