### PR TITLE
Refactor type hints in median_absolute_error.py

### DIFF
--- a/ignite/metrics/regression/median_absolute_error.py
+++ b/ignite/metrics/regression/median_absolute_error.py
@@ -64,9 +64,7 @@ class MedianAbsoluteError(EpochMetric):
             0.625
     """
 
-    def __init__(
-        self, output_transform: Callable = lambda x: x, device: str | torch.device = torch.device("cpu")
-    ):
+    def __init__(self, output_transform: Callable = lambda x: x, device: str | torch.device = torch.device("cpu")):
         super(MedianAbsoluteError, self).__init__(
             median_absolute_error_compute_fn, output_transform=output_transform, device=device
         )


### PR DESCRIPTION
This PR refractors type hints in 
'ignite/metrics/regression/median_absolute_error.py'
to use Python 3.10+ syntax.

Related to #3481 