### PR TITLE
Update type hints to Python 3.10+ in ignite/metrics/roc_auc.py

### DIFF
--- a/ignite/metrics/roc_auc.py
+++ b/ignite/metrics/roc_auc.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, cast, Tuple, Union
+from typing import Any, Callable, cast
 
 import torch
 
@@ -15,7 +15,7 @@ def roc_auc_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> float:
     return roc_auc_score(y_true, y_pred)
 
 
-def roc_auc_curve_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> Tuple[Any, Any, Any]:
+def roc_auc_curve_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> tuple[Any, Any, Any]:
     from sklearn.metrics import roc_curve
 
     y_true = y_targets.cpu().numpy()
@@ -83,7 +83,7 @@ class ROC_AUC(EpochMetric):
         self,
         output_transform: Callable = lambda x: x,
         check_compute_fn: bool = False,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
         try:
@@ -166,7 +166,7 @@ class RocCurve(EpochMetric):
         self,
         output_transform: Callable = lambda x: x,
         check_compute_fn: bool = False,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ) -> None:
         try:
@@ -182,7 +182,7 @@ class RocCurve(EpochMetric):
             skip_unrolling=skip_unrolling,
         )
 
-    def compute(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
+    def compute(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
         if len(self._predictions) < 1 or len(self._targets) < 1:
             raise NotComputableError("RocCurve must have at least one example before it can be computed.")
 
@@ -197,7 +197,7 @@ class RocCurve(EpochMetric):
 
         if idist.get_rank() == 0:
             # Run compute_fn on zero rank only
-            fpr, tpr, thresholds = cast(Tuple, self.compute_fn(_prediction_tensor, _target_tensor))
+            fpr, tpr, thresholds = cast(tuple, self.compute_fn(_prediction_tensor, _target_tensor))
             fpr = torch.tensor(fpr, dtype=self._double_dtype, device=_prediction_tensor.device)
             tpr = torch.tensor(tpr, dtype=self._double_dtype, device=_prediction_tensor.device)
             thresholds = torch.tensor(thresholds, dtype=self._double_dtype, device=_prediction_tensor.device)


### PR DESCRIPTION
Fixes part of #3481.

Updated type hints in `ignite/metrics/roc_auc.py` to use Python 3.10+ syntax (e.g., "|" instead of "Union").