### PR TITLE
refactor: update type hints to use Python 3.10+ syntax in utils and …

### DIFF
--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Callable, cast, Mapping, Optional, Literal
+from typing import Callable, cast, Mapping, Literal
 
 from ignite.base import Serializable
 from ignite.engine import Engine
@@ -96,7 +96,7 @@ class EarlyStopping(Serializable):
         self.cumulative_delta = cumulative_delta
         self.trainer = trainer
         self.counter = 0
-        self.best_score: Optional[float] = None
+        self.best_score: float | None = None
         self.logger = setup_logger(__name__ + "." + self.__class__.__name__)
         self.min_delta_mode = min_delta_mode
         self.mode = mode


### PR DESCRIPTION
This pull request makes minor improvements to type annotations in the `ignite/handlers/early_stopping.py` file, updating the syntax to use modern Python features.

Type annotation updates:

* Replaced use of `Optional[float]` with the more modern `float | None` syntax for the `best_score` attribute in the `EarlyStopping` handler.
* Removed the unused import of `Optional` from the `typing` module.…clearml_logger

part of #3481 
