### PR TITLE
Introduce `ResettableHandler` interface and `attach()` method

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -34,6 +34,17 @@ Complete list of generic handlers
     param_scheduler.ParamScheduler
     state_param_scheduler.StateParamScheduler
 
+Interfaces
+----------
+
+.. currentmodule:: ignite.base.mixins
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    ResettableHandler
+
 
 Loggers
 --------

--- a/ignite/base/__init__.py
+++ b/ignite/base/__init__.py
@@ -1,1 +1,1 @@
-from ignite.base.mixins import Serializable
+from ignite.base.mixins import Serializable, ResettableHandler

--- a/ignite/base/mixins.py
+++ b/ignite/base/mixins.py
@@ -1,5 +1,30 @@
+from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from collections.abc import Mapping
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ignite.engine import Engine
+
+
+class ResettableHandler(metaclass=ABCMeta):
+    """Interface for handlers whose internal state can be reset.
+
+    Subclasses must implement the :meth:`reset` method to clear any accumulated
+    state, typically at the beginning of a training run.
+
+    .. versionadded:: 0.6.0
+    """
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset the handler's internal state."""
+        pass
+
+    @abstractmethod
+    def attach(self, engine: "Engine", *args: Any, **kwargs: Any) -> None:
+        """Attach the handler to an engine."""
+        pass
 
 
 class Serializable:

--- a/ignite/handlers/early_stopping.py
+++ b/ignite/handlers/early_stopping.py
@@ -1,14 +1,14 @@
 from collections import OrderedDict
-from typing import Callable, cast, Mapping, Literal
+from typing import Any, Callable, cast, Mapping, Literal
 
-from ignite.base import Serializable
-from ignite.engine import Engine
+from ignite.base import Serializable, ResettableHandler
+from ignite.engine import Engine, Events
 from ignite.utils import setup_logger
 
 __all__ = ["EarlyStopping"]
 
 
-class EarlyStopping(Serializable):
+class EarlyStopping(Serializable, ResettableHandler):
     """EarlyStopping handler can be used to stop the training if no improvement after a given number of events.
 
     Args:
@@ -127,6 +127,45 @@ class EarlyStopping(Serializable):
         else:
             self.best_score = score
             self.counter = 0
+
+    def reset(self) -> None:
+        """Reset the early stopping state, including the counter and best score.
+
+        .. versionadded:: 0.6.0
+        """
+        self.counter = 0
+        self.best_score = None
+
+    def attach(  # type: ignore[override]
+        self,
+        engine: Engine,
+        event: Any = Events.COMPLETED,
+        reset_engine: Engine | None = None,
+        reset_event: Any = Events.STARTED,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Attaches the early stopping handler to an engine and registers its reset callback.
+
+        This method will:
+        1. Add the early stopping evaluation logic (``self``) to ``engine`` on the given ``event``.
+        2. Add the ``reset`` method to ``reset_engine`` (or ``engine`` if not provided) on the given ``reset_event``.
+
+        Args:
+            engine: The engine to attach the early stopping evaluation to (typically an evaluator).
+            event: The event on ``engine`` that triggers the early stopping check. Default is
+                :attr:`~ignite.engine.events.Events.COMPLETED`.
+            reset_engine: The engine to attach the reset callback to (typically the trainer).
+                If ``None``, defaults to ``engine``.
+            reset_event: The event on ``reset_engine`` that triggers the handler state reset.
+                Default is :attr:`~ignite.engine.events.Events.STARTED`.
+
+        .. versionadded:: 0.6.0
+        """
+        engine.add_event_handler(event, self)
+
+        target_reset_engine = reset_engine or engine
+        target_reset_engine.add_event_handler(reset_event, self.reset)
 
     def state_dict(self) -> "OrderedDict[str, float]":
         """Method returns state dict with ``counter`` and ``best_score``.


### PR DESCRIPTION
Partially Addresses #3535 

**Description:**
Introduces a `ResettableHandler` abstract base class to establish a formalized interface for stateful handlers. `EarlyStopping` is the first adopter of this pattern, implementing both `reset()` and `attach()` methods. 

This mirrors the existing `Metric.attach()` lifecycle pattern, avoiding any Engine-level modifications while providing a clean, self-contained way to manage handler state across runs.

**API**

```python
from ignite.engine import Engine, Events
from ignite.handlers import EarlyStopping

trainer = Engine(train_fn)
evaluator = Engine(eval_fn)

handler = EarlyStopping(patience=5, score_function=score_fn, trainer=trainer)

# Attaches the handler's check to the evaluator (Events.EPOCH_COMPLETED)
# AND automatically attaches the handler's `reset()` to the trainer (Events.STARTED)
handler.attach(
    engine=evaluator, 
    event=Events.EPOCH_COMPLETED, 
    reset_engine=trainer, 
    reset_event=Events.STARTED
)
```

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
