### PR TITLE
Fix Optional and Union typing hints in ignite/handlers/ema_handler.py

### DIFF
--- a/ignite/handlers/ema_handler.py
+++ b/ignite/handlers/ema_handler.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 
 import torch.nn as nn
 
-
 from ignite.engine import CallableEventWithFilter, Engine, Events, EventsList
 from ignite.handlers.param_scheduler import BaseParamScheduler
 from ignite.handlers.state_param_scheduler import LambdaStateScheduler


### PR DESCRIPTION
Replaces `Optional[X]` with `X | None` and `Union[X, Y]` with `X | Y`
for modern Python 3.10+ typing style.

Part of #3481
