### PR TITLE
fix: Prevent in-place mutation in collective ops and simplify metric sync

### DIFF
--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -346,6 +346,11 @@ def all_reduce(
     if _need_to_sync and isinstance(_model, _SerialModel):
         sync(temporary=True)
 
+    # Clone tensor only for operations that modify the input tensor in-place like all_reduce to avoid unexpected side effects.
+    # This is required for native distributed and XLA distributed models, but not for Horovod since it does not modify the input tensor in-place.
+    if model_name() in ("native-dist", "xla-dist") and isinstance(tensor, torch.Tensor):
+        tensor = tensor.clone()
+
     return _model.all_reduce(tensor, op, group=group)
 
 

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -855,11 +855,7 @@ def sync_all_reduce(*attrs: Any) -> Callable:
                             f"number or tensor but `{attr}` has type {type(t)}"
                         )
                     unreduced_attrs[attr] = t
-                    # Here `clone` is necessary since `idist.all_reduce` modifies `t` inplace in the case
-                    # `t` is a tensor and its `device` is same as that of the process.
-                    # TODO: Remove this dual behavior of `all_reduce` to always either return a new tensor or
-                    #       modify it in-place.
-                    t_reduced = idist.all_reduce(cast(float, t) if isinstance(t, Number) else t.clone(), **op_kwargs)
+                    t_reduced = idist.all_reduce(cast(float, t) if isinstance(t, Number) else t, **op_kwargs)
                     setattr(self, attr, t_reduced)
 
             result = func(self, *args, **kwargs)


### PR DESCRIPTION
This pull request improves the handling of tensors in distributed operations to ensure that backend implementations do not inadvertently modify the original tensors passed by callers. The changes focus on preventing in-place mutations and standardizing the behavior across distributed backends.

Distributed tensor mutation prevention:

* In `ignite/distributed/comp_models/base.py`, the tensor is now cloned before applying backend operations, ensuring that any in-place modifications by backend implementations do not affect the original tensor.

Standardization of distributed reduction behavior:

* In `ignite/metrics/metric.py`, the wrapper no longer clones tensors before passing them to `idist.all_reduce`, relying on the distributed layer to avoid in-place mutations and always return the reduced value. This change aligns the behavior across backends and simplifies the code.…tric sync_all_reduce


