### PR TITLE
[Feature] Implement TopK wrapper

### DIFF
--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -88,10 +88,6 @@ class _BasePrecisionRecall(_BaseClassification):
 
         return y_pred, y, correct
 
-    @classmethod
-    def _topk_transform(cls, output: Sequence[torch.tensor], top_k: int) -> Sequence[torch.tensor]:
-        return output
-
     @reinit__is_reduced
     def reset(self) -> None:
         """

--- a/ignite/metrics/precision.py
+++ b/ignite/metrics/precision.py
@@ -88,6 +88,10 @@ class _BasePrecisionRecall(_BaseClassification):
 
         return y_pred, y, correct
 
+    @classmethod
+    def _topk_transform(cls, output: Sequence[torch.tensor], top_k: int) -> Sequence[torch.tensor]:
+        return output
+
     @reinit__is_reduced
     def reset(self) -> None:
         """
@@ -410,8 +414,9 @@ class Precision(_BasePrecisionRecall):
                 For binary and multilabel data, both y and y_pred should consist of 0's and 1's, but for multiclass
                 data, y_pred and y should consist of probabilities and integers respectively.
         """
-        self._check_shape(output)
-        self._check_type(output)
+        if not getattr(self, "_skip_checks", False):
+            self._check_shape(output)
+            self._check_type(output)
         y_pred, y, correct = self._prepare_output(output)
 
         if self._average == "samples":

--- a/ignite/metrics/top_k.py
+++ b/ignite/metrics/top_k.py
@@ -9,7 +9,8 @@ class TopK(Metric):
     """https://github.com/open-mmlab/mmengine/blob/main/mmengine/registry/registry.py
         https://github.com/open-mmlab/mmdetection/tree/main
 
-    the idea is to maintain tok_k transforms here for metrics.
+    the idea is to maintain top_k transforms here for metrics.
+    each topk_transform will be registered in TopK class.
     and user will have to pass output_transform to TopK instead of base_metric
     and the output transform must only unpack output into y_pred, y, and do no other transformations like binarisation
     """
@@ -46,8 +47,11 @@ class TopK(Metric):
         self._states = {k: self._base_metric.state_dict() for k in self._ks}
 
     def update(self, output):
-        self._base_metric._check_shape(output)
-        self._base_metric._check_type(output)
+        """run checks on output only once for highest `k` value and then skip checks
+        in base metric's update for each `k`"""
+        _output = self._transform(output, self._ks[-1])
+        self._base_metric._check_shape(_output)
+        self._base_metric._check_type(_output)
         self._base_metric._skip_checks = True
 
         for k in self._ks:
@@ -71,6 +75,7 @@ class TopK(Metric):
 
 
 def _precision_recall_topk_transform(output: Sequence[torch.Tensor], k: int):
+    """top_k transform for precision and recall"""
     y_pred, y = output[0], output[1]
     _, top_indices = torch.topk(y_pred, k=k, dim=-1)
     masked = torch.zeros_like(y_pred)

--- a/ignite/metrics/top_k.py
+++ b/ignite/metrics/top_k.py
@@ -1,0 +1,81 @@
+import torch
+from typing import Sequence
+
+from ignite.metrics import Metric
+from ignite.metrics.precision import _BasePrecisionRecall
+
+
+class TopK(Metric):
+    """https://github.com/open-mmlab/mmengine/blob/main/mmengine/registry/registry.py
+        https://github.com/open-mmlab/mmdetection/tree/main
+
+    the idea is to maintain tok_k transforms here for metrics.
+    and user will have to pass output_transform to TopK instead of base_metric
+    and the output transform must only unpack output into y_pred, y, and do no other transformations like binarisation
+    """
+
+    _output_transform_registry = {}
+
+    @classmethod
+    def register(cls, metric_type, k_transform):
+        cls._output_transform_registry[metric_type] = k_transform
+
+    def __init__(
+        self,
+        base_metric: Metric,
+        top_k: int | list[int],
+        output_transform=lambda x: x,
+        device: str | torch.device = torch.device("cpu"),
+        skip_unrolling: bool = False,
+    ):
+        transform = None
+        for metric_type, k_transform in self._output_transform_registry.items():
+            if isinstance(base_metric, metric_type):
+                transform = k_transform
+
+        if transform is None:
+            raise ValueError(f"{type(base_metric).__name__} does not support TopK.")
+
+        self._transform = transform
+        self._base_metric = base_metric
+        self._ks = sorted(top_k) if isinstance(top_k, list) else [top_k]
+        super().__init__(output_transform=output_transform, device=device, skip_unrolling=skip_unrolling)
+
+    def reset(self):
+        self._base_metric.reset()
+        self._states = {k: self._base_metric.state_dict() for k in self._ks}
+
+    def update(self, output):
+        self._base_metric._check_shape(output)
+        self._base_metric._check_type(output)
+        self._base_metric._skip_checks = True
+
+        for k in self._ks:
+            # restore state for this k
+            self._base_metric.load_state_dict(self._states[k])
+
+            k_output = self._transform(output, k)
+            self._base_metric.update(k_output)
+
+            # save state for this k
+            self._states[k] = self._base_metric.state_dict()
+
+        self._base_metric._skip_checks = False
+
+    def compute(self) -> list:
+        results = []
+        for k in self._ks:
+            self._base_metric.load_state_dict(self._states[k])
+            results.append(self._base_metric.compute())
+        return results
+
+
+def _precision_recall_topk_transform(output: Sequence[torch.Tensor], k: int):
+    y_pred, y = output[0], output[1]
+    _, top_indices = torch.topk(y_pred, k=k, dim=-1)
+    masked = torch.zeros_like(y_pred)
+    masked.scatter_(-1, top_indices, 1.0)
+    return (masked, y)
+
+
+TopK.register(_BasePrecisionRecall, _precision_recall_topk_transform)

--- a/tests/ignite/metrics/test_precision.py
+++ b/tests/ignite/metrics/test_precision.py
@@ -503,3 +503,34 @@ class TestDistributed:
             if average == "weighted":
                 assert pr._weight.device == metric_device, f"{type(pr._weight.device)}:{pr._weight.device} vs "
                 f"{type(metric_device)}:{metric_device}"
+
+
+def test_top_k_precision_multilabel_samples():
+    """dummy test for checking workflow of TopK wrapper and registry idea"""
+    import torch
+    from ignite.metrics import Precision
+    from ignite.metrics.top_k import TopK
+
+    y_pred = torch.tensor(
+        [
+            [0.9, 0.3, 0.8, 0.1],
+            [0.5, 0.8, 0.2, 0.9],
+            [0.3, 0.6, 0.9, 0.1],
+        ]
+    )
+    y_true = torch.tensor(
+        [
+            [1, 0, 1, 0],
+            [0, 1, 0, 1],
+            [0, 1, 1, 0],
+        ]
+    )
+
+    metric = TopK(Precision(average="samples", is_multilabel=True), top_k=[1, 2, 3])
+    metric.update((y_pred, y_true))
+    result = metric.compute()
+
+    assert len(result) == 3
+    assert pytest.approx(result[0], abs=1e-4) == 1.0
+    assert pytest.approx(result[1], abs=1e-4) == 1.0
+    assert pytest.approx(result[2], abs=1e-4) == 2 / 3


### PR DESCRIPTION
Fixes #3568 

Description:

As discussed in the issue thread, this is a **draft PR** for implementing a base structure for the `TopK` wrapper class.
the idea is to skip redundant checks on input data by skipping `_check_shape` and `_check_type` `k` times.

the wrapper only instantiates a single object of the base class and maintains states for each `k` using a `dict`.

for each batch, we check the data shape and type only once before updating the metric for each `k` individually. for this we use `_skip_checks` flag that can only be set from the `TopK` itself so it ensures metric function as usual when called without wrapper.

`TopK` class provides `_wrap_prepare_output` that handles top-k logic and transforms data accordingly. then metric can be calculated by base metric's update and compute as usual by the means of `state dict` and `_state_dict_all_req_keys`

I have currently only implemented the wrapper for recall and precision currently to get an idea how it would look when extended to other metrics in future
Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
