### PR TITLE
Fix scipy sqrtm return change causing doctest failure in FID metric

### DIFF
--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -37,7 +37,7 @@ def fid_score(
     diff = mu1 - mu2
 
     # Product might be almost singular
-    covmean, _ = scipy.linalg.sqrtm(sigma1.mm(sigma2).numpy(), disp=False)
+    covmean = scipy.linalg.sqrtm(sigma1.mm(sigma2).numpy())
     # Numerical error might give slight imaginary component
     if np.iscomplexobj(covmean):
         if not np.allclose(np.diagonal(covmean).imag, 0, atol=1e-3):


### PR DESCRIPTION
Fixes #3611

Description:
SciPy >= 1.12 changed the return value of scipy.linalg.sqrtm.
The function may return a tuple instead of a single matrix.

This caused doctest failures in FID metric implementation.

This patch ensures compatibility with newer SciPy versions
by correctly handling the return value of sqrtm.

Checklist:
- [x] Tests pass locally
- [x] No new warnings introduced
- [x] Code formatted with black