### PR TITLE
[fix]: .gitignore to correctly ignore all __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Byte-compiled / optimized / DLL files
 *.pyc
-__pycache__/
+*/__pycache__/
 *.py[cod]
 *$py.class
 


### PR DESCRIPTION

Updated the .gitignore to stop tracking empty pycache directories.