### PR TITLE
Refactor type hints and imports in metrics

### DIFF
--- a/ignite/metrics/hsic.py
+++ b/ignite/metrics/hsic.py
@@ -1,4 +1,4 @@
-from typing import Callable, Sequence, Union
+from collections.abc import Callable, Sequence
 
 import torch
 from torch import Tensor
@@ -98,7 +98,7 @@ class HSIC(Metric):
         sigma_y: float = -1,
         ignore_invalid_batch: bool = True,
         output_transform: Callable = lambda x: x,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
         super().__init__(output_transform, device, skip_unrolling=skip_unrolling)
@@ -132,7 +132,7 @@ class HSIC(Metric):
         rx = xx.diag().unsqueeze(0).expand_as(xx)
         dxx = rx.T + rx - xx * 2
 
-        vx: Union[Tensor, float]
+        vx: Tensor | float
         if self.sigma_x < 0:
             # vx = torch.quantile(dxx, 0.5)
             vx = torch.quantile(dxx, 0.5)
@@ -144,7 +144,7 @@ class HSIC(Metric):
         ry = yy.diag().unsqueeze(0).expand_as(yy)
         dyy = ry.T + ry - yy * 2
 
-        vy: Union[Tensor, float]
+        vy: Tensor | float
         if self.sigma_y < 0:
             vy = torch.quantile(dyy, 0.5)
         else:

--- a/ignite/metrics/matthews_corrcoef.py
+++ b/ignite/metrics/matthews_corrcoef.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union
+from collections.abc import Callable
 
 import torch
 
@@ -80,7 +80,7 @@ class MatthewsCorrCoef(EpochMetric):
         self,
         output_transform: Callable = lambda x: x,
         check_compute_fn: bool = False,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
         try:

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -1,9 +1,9 @@
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from functools import wraps
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import torch
 
@@ -356,14 +356,14 @@ class Metric(Serializable, metaclass=ABCMeta):
     """
 
     # public class attribute
-    required_output_keys: Optional[Tuple] = ("y_pred", "y")
+    required_output_keys: tuple | None = ("y_pred", "y")
     # for backward compatibility
     _required_output_keys = required_output_keys
 
     def __init__(
         self,
         output_transform: Callable = lambda x: x,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
         metrics_result_mode: Literal["flatten", "named", "both"] = "both",
     ):
@@ -525,7 +525,7 @@ class Metric(Serializable, metaclass=ABCMeta):
 
             engine.state.metrics[name] = result
 
-    def _check_usage(self, usage: Union[str, MetricUsage]) -> MetricUsage:
+    def _check_usage(self, usage: str | MetricUsage) -> MetricUsage:
         if isinstance(usage, str):
             usages = [EpochWise, RunningEpochWise, BatchWise, RunningBatchWise, SingleEpochRunningBatchWise]
             for usage_cls in usages:
@@ -541,7 +541,7 @@ class Metric(Serializable, metaclass=ABCMeta):
             raise TypeError(f"Unhandled usage type {type(usage)}")
         return usage
 
-    def attach(self, engine: Engine, name: str, usage: Union[str, MetricUsage] = EpochWise()) -> None:
+    def attach(self, engine: Engine, name: str, usage: str | MetricUsage = EpochWise()) -> None:
         """
         Attaches current metric to provided engine. On the end of engine's run, `engine.state.metrics` dictionary will
         contain computed metric's value under provided name.
@@ -582,7 +582,7 @@ class Metric(Serializable, metaclass=ABCMeta):
             engine.add_event_handler(usage.ITERATION_COMPLETED, self.iteration_completed)
         engine.add_event_handler(usage.COMPLETED, self.completed, name)
 
-    def detach(self, engine: Engine, usage: Union[str, MetricUsage] = EpochWise()) -> None:
+    def detach(self, engine: Engine, usage: str | MetricUsage = EpochWise()) -> None:
         """
         Detaches current metric from the engine and no metric's computation is done during the run.
         This method in conjunction with :meth:`~ignite.metrics.metric.Metric.attach` can be useful if several
@@ -625,7 +625,7 @@ class Metric(Serializable, metaclass=ABCMeta):
         if engine.has_event_handler(self.iteration_completed, usage.ITERATION_COMPLETED):
             engine.remove_event_handler(self.iteration_completed, usage.ITERATION_COMPLETED)
 
-    def is_attached(self, engine: Engine, usage: Union[str, MetricUsage] = EpochWise()) -> bool:
+    def is_attached(self, engine: Engine, usage: str | MetricUsage = EpochWise()) -> bool:
         """
         Checks if current metric is attached to provided engine. If attached, metric's computed
         value is written to `engine.state.metrics` dictionary.
@@ -639,9 +639,7 @@ class Metric(Serializable, metaclass=ABCMeta):
         return engine.has_event_handler(self.completed, usage.COMPLETED)
 
     def _state_dict_per_rank(self) -> OrderedDict:
-        def func(
-            x: Union[torch.Tensor, Metric, None, float], **kwargs: Any
-        ) -> Union[torch.Tensor, float, OrderedDict, None]:
+        def func(x: torch.Tensor | Metric | None | float, **kwargs: Any) -> torch.Tensor | float | OrderedDict | None:
             if isinstance(x, Metric):
                 return x._state_dict_per_rank()
             if x is None or isinstance(x, (int, float, torch.Tensor)):
@@ -652,7 +650,7 @@ class Metric(Serializable, metaclass=ABCMeta):
                     " numeric types, tensor, Metric or sequence/mapping of metrics."
                 )
 
-        state: OrderedDict[str, Union[torch.Tensor, List, Dict, None]] = OrderedDict()
+        state: OrderedDict[str, torch.Tensor | list | dict | None] = OrderedDict()
         for attr_name in self._state_dict_all_req_keys:
             if attr_name not in self.__dict__:
                 raise ValueError(
@@ -808,10 +806,10 @@ class Metric(Serializable, metaclass=ABCMeta):
 
         return MetricsLambda(lambda x: x[index], self)
 
-    def __getstate__(self) -> Dict:
+    def __getstate__(self) -> dict:
         return self.__dict__
 
-    def __setstate__(self, d: Dict) -> None:
+    def __setstate__(self, d: dict) -> None:
         self.__dict__.update(d)
 
 
@@ -893,11 +891,11 @@ def reinit__is_reduced(func: Callable) -> Callable:
     return wrapper
 
 
-def _is_list_of_tensors_or_numbers(x: Sequence[Union[torch.Tensor, float]]) -> bool:
+def _is_list_of_tensors_or_numbers(x: Sequence[torch.Tensor | float]) -> bool:
     return isinstance(x, Sequence) and all([isinstance(t, (torch.Tensor, Number)) for t in x])
 
 
-def _to_batched_tensor(x: Union[torch.Tensor, Number], device: Optional[torch.device] = None) -> torch.Tensor:
+def _to_batched_tensor(x: torch.Tensor | Number, device: torch.device | None = None) -> torch.Tensor:
     if isinstance(x, torch.Tensor):
         return x.unsqueeze(dim=0)
     return torch.tensor([x], device=device)

--- a/ignite/metrics/precision_recall_curve.py
+++ b/ignite/metrics/precision_recall_curve.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, cast, Tuple, Union
+from collections.abc import Callable
+from typing import Any, cast
 
 import torch
 
@@ -7,7 +8,7 @@ from ignite.exceptions import NotComputableError
 from ignite.metrics.epoch_metric import EpochMetric
 
 
-def precision_recall_curve_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> Tuple[Any, Any, Any]:
+def precision_recall_curve_compute_fn(y_preds: torch.Tensor, y_targets: torch.Tensor) -> tuple[Any, Any, Any]:
     from sklearn.metrics import precision_recall_curve
 
     y_true = y_targets.cpu().numpy()
@@ -77,7 +78,7 @@ class PrecisionRecallCurve(EpochMetric):
         self,
         output_transform: Callable = lambda x: x,
         check_compute_fn: bool = False,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ) -> None:
         try:
@@ -93,7 +94,7 @@ class PrecisionRecallCurve(EpochMetric):
             skip_unrolling=skip_unrolling,
         )
 
-    def compute(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
+    def compute(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
         if len(self._predictions) < 1 or len(self._targets) < 1:
             raise NotComputableError("PrecisionRecallCurve must have at least one example before it can be computed.")
 
@@ -109,7 +110,7 @@ class PrecisionRecallCurve(EpochMetric):
 
             if idist.get_rank() == 0:
                 # Run compute_fn on zero rank only
-                precision, recall, thresholds = cast(Tuple, self.compute_fn(_prediction_tensor, _target_tensor))
+                precision, recall, thresholds = cast(tuple, self.compute_fn(_prediction_tensor, _target_tensor))
                 precision = torch.tensor(precision, device=_prediction_tensor.device, dtype=self._double_dtype)
                 recall = torch.tensor(recall, device=_prediction_tensor.device, dtype=self._double_dtype)
                 # thresholds can have negative strides, not compatible with torch tensors
@@ -126,4 +127,4 @@ class PrecisionRecallCurve(EpochMetric):
 
             self._result = (precision, recall, thresholds)  # type: ignore[assignment]
 
-        return cast(Tuple[torch.Tensor, torch.Tensor, torch.Tensor], self._result)
+        return cast(tuple[torch.Tensor, torch.Tensor, torch.Tensor], self._result)


### PR DESCRIPTION
Update type hints to use the new syntax and improve imports across the metrics module.

