### PR TITLE
Refactor type hints for consistency in regression metrics

### DIFF
--- a/ignite/metrics/multilabel_confusion_matrix.py
+++ b/ignite/metrics/multilabel_confusion_matrix.py
@@ -1,4 +1,4 @@
-from typing import Callable, Sequence, Union
+from typing import Callable, Sequence
 
 import torch
 
@@ -92,7 +92,7 @@ class MultiLabelConfusionMatrix(Metric):
         self,
         num_classes: int,
         output_transform: Callable = lambda x: x,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         normalized: bool = False,
         skip_unrolling: bool = False,
     ):

--- a/ignite/metrics/regression/_base.py
+++ b/ignite/metrics/regression/_base.py
@@ -1,12 +1,11 @@
 from abc import abstractmethod
-from typing import Tuple
 
 import torch
 
 from ignite.metrics.metric import Metric, reinit__is_reduced
 
 
-def _check_output_shapes(output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+def _check_output_shapes(output: tuple[torch.Tensor, torch.Tensor]) -> None:
     y_pred, y = output
     c1 = y_pred.ndimension() == 2 and y_pred.shape[1] == 1
     if not (y_pred.ndimension() == 1 or c1):
@@ -20,7 +19,7 @@ def _check_output_shapes(output: Tuple[torch.Tensor, torch.Tensor]) -> None:
         raise ValueError(f"Input data shapes should be the same, but given {y_pred.shape} and {y.shape}")
 
 
-def _check_output_types(output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+def _check_output_types(output: tuple[torch.Tensor, torch.Tensor]) -> None:
     y_pred, y = output
     if y_pred.dtype not in (torch.float16, torch.float32, torch.float64):
         raise TypeError(f"Input y_pred dtype should be float 16, 32 or 64, but given {y_pred.dtype}")
@@ -49,7 +48,7 @@ class _BaseRegression(Metric):
     # method `_update`.
 
     @reinit__is_reduced
-    def update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         _check_output_shapes(output)
         _check_output_types(output)
         y_pred, y = output[0].detach(), output[1].detach()
@@ -63,5 +62,5 @@ class _BaseRegression(Metric):
         self._update((y_pred, y))
 
     @abstractmethod
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         pass

--- a/ignite/metrics/regression/canberra_metric.py
+++ b/ignite/metrics/regression/canberra_metric.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce
@@ -71,7 +69,7 @@ class CanberraMetric(_BaseRegression):
     def reset(self) -> None:
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         errors = torch.abs(y - y_pred) / (torch.abs(y_pred) + torch.abs(y) + 1e-15)
         self._sum_of_errors += torch.sum(errors).to(self._device)

--- a/ignite/metrics/regression/fractional_absolute_error.py
+++ b/ignite/metrics/regression/fractional_absolute_error.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -67,7 +65,7 @@ class FractionalAbsoluteError(_BaseRegression):
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
         self._num_examples = 0
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         errors = 2 * torch.abs(y.view_as(y_pred) - y_pred) / (torch.abs(y_pred) + torch.abs(y.view_as(y_pred)))
         self._sum_of_errors += torch.sum(errors).to(self._device)

--- a/ignite/metrics/regression/fractional_bias.py
+++ b/ignite/metrics/regression/fractional_bias.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -67,7 +65,7 @@ class FractionalBias(_BaseRegression):
         self._sum_of_errors = torch.tensor(0.0, dtype=self._double_dtype, device=self._device)
         self._num_examples = 0
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         errors = 2 * (y.view_as(y_pred) - y_pred) / (y_pred + y.view_as(y_pred) + 1e-30)
         self._sum_of_errors += torch.sum(errors).to(self._device)

--- a/ignite/metrics/regression/geometric_mean_absolute_error.py
+++ b/ignite/metrics/regression/geometric_mean_absolute_error.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -67,7 +65,7 @@ class GeometricMeanAbsoluteError(_BaseRegression):
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
         self._num_examples = 0
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         errors = torch.log(torch.abs(y.view_as(y_pred) - y_pred))
         self._sum_of_errors += torch.sum(errors).to(self._device)

--- a/ignite/metrics/regression/geometric_mean_relative_absolute_error.py
+++ b/ignite/metrics/regression/geometric_mean_relative_absolute_error.py
@@ -1,4 +1,4 @@
-from typing import cast, List, Tuple
+from typing import cast
 
 import torch
 
@@ -74,10 +74,10 @@ class GeometricMeanRelativeAbsoluteError(_BaseRegression):
 
     @reinit__is_reduced
     def reset(self) -> None:
-        self._predictions: List[torch.Tensor] = []
-        self._targets: List[torch.Tensor] = []
+        self._predictions: list[torch.Tensor] = []
+        self._targets: list[torch.Tensor] = []
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
 
         y_pred = y_pred.clone().to(self._device)

--- a/ignite/metrics/regression/kendall_correlation.py
+++ b/ignite/metrics/regression/kendall_correlation.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Tuple, Union
+from typing import Any, Callable
 
 import torch
 
@@ -94,7 +94,7 @@ class KendallRankCorrelation(EpochMetric):
         variant: str = "b",
         output_transform: Callable[..., Any] = lambda x: x,
         check_compute_fn: bool = True,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ) -> None:
         try:
@@ -104,7 +104,7 @@ class KendallRankCorrelation(EpochMetric):
 
         super().__init__(_get_kendall_tau(variant), output_transform, check_compute_fn, device, skip_unrolling)
 
-    def update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         if y_pred.ndim == 1:
             y_pred = y_pred.unsqueeze(1)

--- a/ignite/metrics/regression/manhattan_distance.py
+++ b/ignite/metrics/regression/manhattan_distance.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce
@@ -67,7 +65,7 @@ class ManhattanDistance(_BaseRegression):
     def reset(self) -> None:
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output
         errors = torch.abs(y - y_pred)
         self._sum_of_errors += torch.sum(errors).to(self._device)

--- a/ignite/metrics/regression/maximum_absolute_error.py
+++ b/ignite/metrics/regression/maximum_absolute_error.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -66,7 +64,7 @@ class MaximumAbsoluteError(_BaseRegression):
     def reset(self) -> None:
         self._max_of_absolute_errors: float = -1
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         mae = torch.abs(y_pred - y.view_as(y_pred)).max().item()
         if self._max_of_absolute_errors < mae:

--- a/ignite/metrics/regression/mean_absolute_relative_error.py
+++ b/ignite/metrics/regression/mean_absolute_relative_error.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -67,7 +65,7 @@ class MeanAbsoluteRelativeError(_BaseRegression):
         self._sum_of_absolute_relative_errors = torch.tensor(0.0, device=self._device)
         self._num_samples = 0
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         if (y == 0).any():
             raise NotComputableError("The ground truth has 0.")


### PR DESCRIPTION
Refactor type hints from `Tuple` to `tuple` for consistency across regression metrics. This change enhances code readability and maintains uniformity in type annotations.

