### PR TITLE
Refactor type hints for consistency in regression metrics

### DIFF
--- a/ignite/metrics/regression/mean_error.py
+++ b/ignite/metrics/regression/mean_error.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -64,7 +62,7 @@ class MeanError(_BaseRegression):
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
         self._num_examples = 0
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         errors = y.view_as(y_pred) - y_pred
         self._sum_of_errors += torch.sum(errors).item()

--- a/ignite/metrics/regression/mean_normalized_bias.py
+++ b/ignite/metrics/regression/mean_normalized_bias.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -67,7 +65,7 @@ class MeanNormalizedBias(_BaseRegression):
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
         self._num_examples = 0
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
 
         if (y == 0).any():

--- a/ignite/metrics/regression/median_absolute_error.py
+++ b/ignite/metrics/regression/median_absolute_error.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 

--- a/ignite/metrics/regression/median_absolute_percentage_error.py
+++ b/ignite/metrics/regression/median_absolute_percentage_error.py
@@ -1,9 +1,8 @@
-from typing import Callable, Union
+from collections.abc import Callable
 
 import torch
 
 from ignite.metrics.epoch_metric import EpochMetric
-
 from ignite.metrics.regression._base import _torch_median
 
 
@@ -62,7 +61,5 @@ class MedianAbsolutePercentageError(EpochMetric):
             25.0...
     """
 
-    def __init__(
-        self, output_transform: Callable = lambda x: x, device: Union[str, torch.device] = torch.device("cpu")
-    ):
+    def __init__(self, output_transform: Callable = lambda x: x, device: str | torch.device = torch.device("cpu")):
         super().__init__(median_absolute_percentage_error_compute_fn, output_transform=output_transform, device=device)

--- a/ignite/metrics/regression/median_relative_absolute_error.py
+++ b/ignite/metrics/regression/median_relative_absolute_error.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union
+from collections.abc import Callable
 
 import torch
 
@@ -62,7 +62,5 @@ class MedianRelativeAbsoluteError(EpochMetric):
             0.5...
     """
 
-    def __init__(
-        self, output_transform: Callable = lambda x: x, device: Union[str, torch.device] = torch.device("cpu")
-    ):
+    def __init__(self, output_transform: Callable = lambda x: x, device: str | torch.device = torch.device("cpu")):
         super().__init__(median_relative_absolute_error_compute_fn, output_transform=output_transform, device=device)

--- a/ignite/metrics/regression/pearson_correlation.py
+++ b/ignite/metrics/regression/pearson_correlation.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Union
+from collections.abc import Callable
 
 import torch
 
@@ -61,7 +61,7 @@ class PearsonCorrelation(_BaseRegression):
         self,
         eps: float = 1e-8,
         output_transform: Callable = lambda x: x,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
     ):
         super().__init__(output_transform, device)
 
@@ -85,7 +85,7 @@ class PearsonCorrelation(_BaseRegression):
         self._sum_of_products = torch.tensor(0.0, device=self._device)
         self._num_examples = 0
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         self._sum_of_y_preds += y_pred.sum().to(self._device)
         self._sum_of_ys += y.sum().to(self._device)

--- a/ignite/metrics/regression/r2_score.py
+++ b/ignite/metrics/regression/r2_score.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.exceptions import NotComputableError
@@ -67,7 +65,7 @@ class R2Score(_BaseRegression):
         self._y_sq_sum = torch.tensor(0.0, device=self._device)
         self._y_sum = torch.tensor(0.0, device=self._device)
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output
         self._num_examples += y.shape[0]
         self._sum_of_errors += torch.sum(torch.pow(y_pred - y, 2)).to(self._device)

--- a/ignite/metrics/regression/spearman_correlation.py
+++ b/ignite/metrics/regression/spearman_correlation.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Tuple, Union
+from typing import Any
+from collections.abc import Callable
 
 import torch
 
@@ -81,7 +82,7 @@ class SpearmanRankCorrelation(EpochMetric):
         self,
         output_transform: Callable[..., Any] = lambda x: x,
         check_compute_fn: bool = True,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ) -> None:
         try:
@@ -91,7 +92,7 @@ class SpearmanRankCorrelation(EpochMetric):
 
         super().__init__(_spearman_r, output_transform, check_compute_fn, device, skip_unrolling)
 
-    def update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         if y_pred.ndim == 1:
             y_pred = y_pred.unsqueeze(1)

--- a/ignite/metrics/regression/wave_hedges_distance.py
+++ b/ignite/metrics/regression/wave_hedges_distance.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 
 from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce
@@ -65,7 +63,7 @@ class WaveHedgesDistance(_BaseRegression):
     def reset(self) -> None:
         self._sum_of_errors = torch.tensor(0.0, device=self._device)
 
-    def _update(self, output: Tuple[torch.Tensor, torch.Tensor]) -> None:
+    def _update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
         y_pred, y = output[0].detach(), output[1].detach()
         errors = torch.abs(y.view_as(y_pred) - y_pred) / (torch.max(y_pred, y.view_as(y_pred)) + 1e-30)
         self._sum_of_errors += torch.sum(errors).to(self._device)

--- a/ignite/metrics/vision/object_detection_average_precision_recall.py
+++ b/ignite/metrics/vision/object_detection_average_precision_recall.py
@@ -1,20 +1,20 @@
-from typing import Callable, cast, Dict, List, Optional, Sequence, Tuple, Union
+from collections.abc import Callable, Sequence
+from typing import cast
 
 import torch
 from typing_extensions import Literal
 
 from ignite.metrics import MetricGroup
-
 from ignite.metrics.mean_average_precision import _BaseAveragePrecision, _cat_and_agg_tensors
 from ignite.metrics.metric import Metric, reinit__is_reduced, sync_all_reduce
 
 
 def coco_tensor_list_to_dict_list(
-    output: Tuple[
-        Union[List[torch.Tensor], List[Dict[str, torch.Tensor]]],
-        Union[List[torch.Tensor], List[Dict[str, torch.Tensor]]],
-    ]
-) -> Tuple[List[Dict[str, torch.Tensor]], List[Dict[str, torch.Tensor]]]:
+    output: tuple[
+        list[torch.Tensor] | list[dict[str, torch.Tensor]],
+        list[torch.Tensor] | list[dict[str, torch.Tensor]],
+    ],
+) -> tuple[list[dict[str, torch.Tensor]], list[dict[str, torch.Tensor]]]:
     """Convert either of output's `y_pred` or `y` from list of `(N, 6)` tensors to list of str-to-tensor dictionaries,
     or keep them unchanged if they're already in the deisred format.
 
@@ -31,32 +31,32 @@ def coco_tensor_list_to_dict_list(
     """
     y_pred, y = output
     if len(y_pred) > 0 and isinstance(y_pred[0], torch.Tensor):
-        y_pred = [{"bbox": t[:, :4], "confidence": t[:, 4], "class": t[:, 5]} for t in cast(List[torch.Tensor], y_pred)]
+        y_pred = [{"bbox": t[:, :4], "confidence": t[:, 4], "class": t[:, 5]} for t in cast(list[torch.Tensor], y_pred)]
     if len(y) > 0 and isinstance(y[0], torch.Tensor):
         if y[0].size(1) == 5:
-            y = [{"bbox": t[:, :4], "class": t[:, 4]} for t in cast(List[torch.Tensor], y)]
+            y = [{"bbox": t[:, :4], "class": t[:, 4]} for t in cast(list[torch.Tensor], y)]
         else:
-            y = [{"bbox": t[:, :4], "class": t[:, 4], "iscrowd": t[:, 5]} for t in cast(List[torch.Tensor], y)]
-    return cast(Tuple[List[Dict[str, torch.Tensor]], List[Dict[str, torch.Tensor]]], (y_pred, y))
+            y = [{"bbox": t[:, :4], "class": t[:, 4], "iscrowd": t[:, 5]} for t in cast(list[torch.Tensor], y)]
+    return cast(tuple[list[dict[str, torch.Tensor]], list[dict[str, torch.Tensor]]], (y_pred, y))
 
 
 class ObjectDetectionAvgPrecisionRecall(Metric, _BaseAveragePrecision):
-    _tps: List[torch.Tensor]
-    _fps: List[torch.Tensor]
-    _scores: List[torch.Tensor]
-    _y_pred_labels: List[torch.Tensor]
+    _tps: list[torch.Tensor]
+    _fps: list[torch.Tensor]
+    _scores: list[torch.Tensor]
+    _y_pred_labels: list[torch.Tensor]
     _y_true_count: torch.Tensor
     _num_classes: int
 
     def __init__(
         self,
-        iou_thresholds: Optional[Union[Sequence[float], torch.Tensor]] = None,
-        rec_thresholds: Optional[Union[Sequence[float], torch.Tensor]] = None,
+        iou_thresholds: Sequence[float] | torch.Tensor | None = None,
+        rec_thresholds: Sequence[float] | torch.Tensor | None = None,
         num_classes: int = 80,
         max_detections_per_image_per_class: int = 100,
         area_range: Literal["small", "medium", "large", "all"] = "all",
         output_transform: Callable = lambda x: x,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ) -> None:
         r"""Calculate mean average precision & recall for evaluating an object detector in the COCO way.
@@ -166,7 +166,7 @@ class ObjectDetectionAvgPrecisionRecall(Metric, _BaseAveragePrecision):
         return torch.logical_and(areas >= min_area, areas <= max_area)
 
     def _check_matching_input(
-        self, output: Tuple[List[Dict[str, torch.Tensor]], List[Dict[str, torch.Tensor]]]
+        self, output: tuple[list[dict[str, torch.Tensor]], list[dict[str, torch.Tensor]]]
     ) -> None:
         y_pred, y = output
         if len(y_pred) != len(y):
@@ -190,7 +190,7 @@ class ObjectDetectionAvgPrecisionRecall(Metric, _BaseAveragePrecision):
 
     def _compute_recall_and_precision(
         self, TP: torch.Tensor, FP: torch.Tensor, scores: torch.Tensor, y_true_count: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         r"""Measuring recall & precision
 
         This method is different from that of MeanAveragePrecision since in the pycocotools reference implementation,
@@ -267,7 +267,7 @@ class ObjectDetectionAvgPrecisionRecall(Metric, _BaseAveragePrecision):
         return torch.sum(precision_integrand, dim=-1) / len(cast(torch.Tensor, self.rec_thresholds))
 
     @reinit__is_reduced
-    def update(self, output: Tuple[List[Dict[str, torch.Tensor]], List[Dict[str, torch.Tensor]]]) -> None:
+    def update(self, output: tuple[list[dict[str, torch.Tensor]], list[dict[str, torch.Tensor]]]) -> None:
         r"""Metric update method using prediction and target.
 
         Args:
@@ -369,11 +369,11 @@ class ObjectDetectionAvgPrecisionRecall(Metric, _BaseAveragePrecision):
 
     @sync_all_reduce("_y_true_count")
     def _compute(self) -> torch.Tensor:
-        pred_labels = _cat_and_agg_tensors(self._y_pred_labels, cast(Tuple[int], ()), torch.int, self._device)
+        pred_labels = _cat_and_agg_tensors(self._y_pred_labels, cast(tuple[int], ()), torch.int, self._device)
         TP = _cat_and_agg_tensors(self._tps, (len(self._iou_thresholds),), torch.uint8, self._device)
         FP = _cat_and_agg_tensors(self._fps, (len(self._iou_thresholds),), torch.uint8, self._device)
         fp_precision = torch.double if self._device.type != "mps" else torch.float32
-        scores = _cat_and_agg_tensors(self._scores, cast(Tuple[int], ()), fp_precision, self._device)
+        scores = _cat_and_agg_tensors(self._scores, cast(tuple[int], ()), fp_precision, self._device)
 
         average_precisions_recalls = -torch.ones(
             (2, self._num_classes, len(self._iou_thresholds)),
@@ -397,7 +397,7 @@ class ObjectDetectionAvgPrecisionRecall(Metric, _BaseAveragePrecision):
             average_precisions_recalls[1, cls] = recall[..., -1]
         return average_precisions_recalls
 
-    def compute(self) -> Tuple[float, float]:
+    def compute(self) -> tuple[float, float]:
         average_precisions_recalls = self._compute()
         if (average_precisions_recalls == -1).all():
             return -1.0, -1.0
@@ -443,7 +443,7 @@ class CommonObjectDetectionMetrics(MetricGroup):
         self,
         num_classes: int = 80,
         output_transform: Callable = lambda x: x,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = True,
     ):
         self.ap_50_95 = ObjectDetectionAvgPrecisionRecall(num_classes=num_classes, device=device)
@@ -472,7 +472,7 @@ class CommonObjectDetectionMetrics(MetricGroup):
         super().update(output)
         self.ap_50_95.update(output)
 
-    def compute(self) -> Dict[str, float]:
+    def compute(self) -> dict[str, float]:
         average_precisions_recalls = self.ap_50_95._compute()
 
         average_precisions_50 = average_precisions_recalls[0, :, 0]


### PR DESCRIPTION
Refactor type hints to use built-in types across regression metrics for improved consistency and clarity. This change enhances code readability and aligns with modern Python typing practices.

