### PR TITLE
Use torch.inference_mode instead of torch.no_grad for evaluation/metrics

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -684,7 +684,7 @@ def supervised_evaluation_step(
 
     def evaluate_step(engine: Engine, batch: Sequence[torch.Tensor]) -> Any | tuple[torch.Tensor]:
         model.eval()
-        with torch.no_grad():
+        with torch.inference_mode():
             x, y = prepare_batch(batch, device=device, non_blocking=non_blocking)
             output = model_fn(model, x)
             y_pred = model_transform(output)
@@ -746,7 +746,7 @@ def supervised_evaluation_step_amp(
 
     def evaluate_step(engine: Engine, batch: Sequence[torch.Tensor]) -> Any | tuple[torch.Tensor]:
         model.eval()
-        with torch.no_grad():
+        with torch.inference_mode():
             x, y = prepare_batch(batch, device=device, non_blocking=non_blocking)
             with autocast("cuda", enabled=True):
                 output = model_fn(model, x)

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -137,7 +137,7 @@ class FID(_BaseInceptionMetric):
                     super().__init__()
                     self.fid_incv3 = fid_incv3
 
-                @torch.no_grad()
+                @torch.inference_mode()
                 def forward(self, x):
                     y = self.fid_incv3(x)
                     y = y[0]

--- a/ignite/metrics/gan/utils.py
+++ b/ignite/metrics/gan/utils.py
@@ -38,7 +38,7 @@ class InceptionModel(torch.nn.Module):
             self.model.fc = torch.nn.Sequential(self.model.fc, torch.nn.Softmax(dim=1))
         self.model.eval()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(self, data: torch.Tensor) -> torch.Tensor:
         if data.dim() != 4:
             raise ValueError(f"Inputs should be a tensor of dim 4, got {data.dim()}")
@@ -94,7 +94,7 @@ class _BaseInceptionMetric(Metric):
         if inputs.device != torch.device(self._device):
             inputs = inputs.to(self._device)
 
-        with torch.no_grad():
+        with torch.inference_mode():
             outputs = self._feature_extractor(inputs).to(self._device, dtype=self._double_dtype)
         self._check_feature_shapes(outputs)
 

--- a/ignite/metrics/metric.py
+++ b/ignite/metrics/metric.py
@@ -438,7 +438,7 @@ class Metric(Serializable, metaclass=ABCMeta):
         """
         self.reset()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def iteration_completed(self, engine: Engine) -> None:
         """Helper method to update metric's computation. It is automatically attached to the
         `engine` with :meth:`~ignite.metrics.metric.Metric.attach`.


### PR DESCRIPTION
Replaces torch.no_grad with torch.inference_mode in evaluation and metric computation paths, as inference_mode additionally disables view tracking and provides better performance for inference workloads.

Addresses: #2193

Description:

Closes #2193

Replaces `torch.no_grad` with `torch.inference_mode` in evaluation and 
metric computation paths across:
- [ignite/metrics/metric.py]
- [ignite/metrics/gan/utils.py]
- [ignite/metrics/gan/fid.py]
- [ignite/engine/__init__.py]

'torch.inference_mod' is strictly faster than 'torch.no_grad' as it 
additionally disables view tracking and version counting, making it more 
suitable for inference and metric computation workloads.

Available since PyTorch 1.9.0.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
