### PR TITLE
Refactor compatibility for sphinxcontrib-versioning format_date

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,6 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import doctest
-
 import os
 import shutil
 import sys
@@ -24,6 +23,20 @@ from datetime import datetime
 import pytorch_sphinx_theme
 
 import ignite
+
+# Workaround for sphinxcontrib-versioning calling old incompatible
+# ``format_date`` signature.
+try:
+    import sphinxcontrib_versioning.sphinx_ as _scv_sphinx
+    from sphinx.util.i18n import format_date as _sphinx_format_date
+
+    def _format_date_compat(format, date, language=None):
+        return _sphinx_format_date(format=format, date=date, language=language)
+
+    _scv_sphinx.format_date = _format_date_compat
+except Exception:
+    # Best-effort monkeypatch; if import fails, leave things alone.
+    pass
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
This pull request introduces a workaround to address compatibility issues between `sphinxcontrib-versioning` and the current `sphinx.util.i18n.format_date` function signature. The main change is a monkeypatch that ensures `format_date` is called with the correct parameters, preventing potential errors during documentation builds.

Compatibility workaround:

* Added a monkeypatch in `docs/source/conf.py` to override `sphinxcontrib-versioning.sphinx_.format_date` with a compatible function that matches the current `sphinx.util.i18n.format_date` signature. This prevents failures caused by signature mismatches when building documentation.

Minor cleanup:

* Removed an unnecessary blank line after `import doctest` in `docs/source/conf.py`.