### PR TITLE
replace process.wait() with process.communicate() in execute() to prevent deadlock

### DIFF
--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -48,11 +48,14 @@ def execute(cmd, env=None):
     env = dict(os.environ) if env is None else env
     env["PYTHONPATH"] = f"{os.path.dirname(ignite.__path__[0])}"
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
-    process.wait()
+    stdout, stderr = process.communicate()
+    stdout_str = stdout.decode("utf-8", errors="replace") if stdout else ""
+    stderr_str = stderr.decode("utf-8", errors="replace") if stderr else ""
+
     if process.returncode != 0:
-        print(str(process.stdout.read()) + str(process.stderr.read()))
-        raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd, stderr=process.stderr.read())
-    return str(process.stdout.read()) + str(process.stderr.read())
+        print(stdout_str + stderr_str)
+        raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd, stderr=stderr_str)
+    return stdout_str + stderr_str
 
 
 @pytest.mark.skipif(not is_mps_available_and_functional(), reason="Skip if MPS not functional")


### PR DESCRIPTION
Related: #3652

**Description**
Fixed potential deadlock in the `execute` function by replacing `process.wait()` with `process.communicate()`
following the note in Popen.wait doc: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait

> Note This will deadlock when using stdout=PIPE or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use [Popen.communicate()](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate) when using pipes to avoid that.


Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
