### PR TITLE
fix: return NaN for invalid cluster counts in SilhouetteScore and DaviesBouldinScore

### DIFF
--- a/ignite/metrics/clustering/davies_bouldin_score.py
+++ b/ignite/metrics/clustering/davies_bouldin_score.py
@@ -14,6 +14,11 @@ def _davies_bouldin_score(features: Tensor, labels: Tensor) -> float:
 
     np_features = features.cpu().numpy()
     np_labels = labels.cpu().numpy()
+
+    n_unique_labels = len(set(np_labels))
+    if n_unique_labels < 2:
+        return float("nan")
+
     score = davies_bouldin_score(np_features, np_labels)
     return score
 
@@ -29,6 +34,8 @@ class DaviesBouldinScore(_ClusteringMetricBase):
 
     The Davies-Bouldin score is non-negative,
     where values closer to zero indicate that the clustering result is good (i.e., clusters are well-separated).
+
+    When the number of unique labels is less than 2 (i.e., the index is undefined), ``float('nan')`` is returned.
 
     The computation of this metric is implemented with
     `sklearn.metrics.davies_bouldin_score

--- a/ignite/metrics/clustering/silhouette_score.py
+++ b/ignite/metrics/clustering/silhouette_score.py
@@ -29,6 +29,9 @@ class SilhouetteScore(_ClusteringMetricBase):
     The silhouette score ranges from -1 to +1,
     where the score becomes close to +1 when the clustering result is good (i.e., clusters are well-separated).
 
+    When the number of unique labels is less than 2 or equal to the number of samples (i.e., the score is
+    undefined), ``float('nan')`` is returned.
+
     The computation of this metric is implemented with
     `sklearn.metrics.silhouette_score
     <https://scikit-learn.org/1.5/modules/generated/sklearn.metrics.silhouette_score.html>`_.
@@ -114,5 +117,11 @@ class SilhouetteScore(_ClusteringMetricBase):
 
         np_features = features.cpu().numpy()
         np_labels = labels.cpu().numpy()
+
+        n_unique_labels = len(set(np_labels))
+        n_samples = len(np_labels)
+        if n_unique_labels < 2 or n_unique_labels >= n_samples:
+            return float("nan")
+
         score = silhouette_score(np_features, np_labels, **self._silhouette_kwargs)
         return score

--- a/tests/ignite/metrics/clustering/test_davies_bouldin_score.py
+++ b/tests/ignite/metrics/clustering/test_davies_bouldin_score.py
@@ -19,6 +19,18 @@ def test_zero_sample():
         metric.compute()
 
 
+def test_single_cluster_returns_nan():
+    """DaviesBouldinScore should return NaN when all samples belong to a single cluster."""
+    import math
+
+    metric = DaviesBouldinScore()
+    features = torch.randn(10, 5)
+    labels = torch.zeros(10, dtype=torch.long)
+    metric.update((features, labels))
+    result = metric.compute()
+    assert math.isnan(result)
+
+
 def test_wrong_output_shape():
     wrong_features = torch.zeros(4, dtype=torch.float)
     correct_features = torch.zeros(4, 3, dtype=torch.float)

--- a/tests/ignite/metrics/clustering/test_silhouette_score.py
+++ b/tests/ignite/metrics/clustering/test_silhouette_score.py
@@ -19,6 +19,30 @@ def test_zero_sample():
         metric.compute()
 
 
+def test_single_cluster_returns_nan():
+    """SilhouetteScore should return NaN when all samples belong to a single cluster."""
+    import math
+
+    metric = SilhouetteScore()
+    features = torch.randn(10, 5)
+    labels = torch.zeros(10, dtype=torch.long)
+    metric.update((features, labels))
+    result = metric.compute()
+    assert math.isnan(result)
+
+
+def test_all_unique_clusters_returns_nan():
+    """SilhouetteScore should return NaN when every sample is its own cluster."""
+    import math
+
+    metric = SilhouetteScore()
+    features = torch.randn(10, 5)
+    labels = torch.arange(10, dtype=torch.long)
+    metric.update((features, labels))
+    result = metric.compute()
+    assert math.isnan(result)
+
+
 def test_wrong_output_shape():
     wrong_features = torch.zeros(4, dtype=torch.float)
     correct_features = torch.zeros(4, 3, dtype=torch.float)


### PR DESCRIPTION
Fixes #3641
Fixes #3642

## Description

`SilhouetteScore` and `DaviesBouldinScore` currently crash with a `ValueError` when passed labels with invalid cluster counts (e.g., all samples in a single cluster, or every sample being its own cluster). This commonly happens during early training epochs before the model has learned to separate data.

**Root cause:** Both metrics delegate to `sklearn`, which raises `ValueError` when the number of unique labels is outside its valid range:
- `davies_bouldin_score` requires 2 ≤ n_labels ≤ n_samples
- `silhouette_score` requires 2 ≤ n_labels ≤ n_samples - 1

**Fix:** Add a pre-validation guard in both compute functions. When the cluster count is invalid, return `float('nan')` instead of raising an exception. This allows an `Engine`-based training loop to continue without crashing.

## Changes

- `ignite/metrics/clustering/davies_bouldin_score.py`: Return `float('nan')` when fewer than 2 unique cluster labels are present.
- `ignite/metrics/clustering/silhouette_score.py`: Return `float('nan')` when the number of unique cluster labels is < 2 or ≥ n_samples.
- Added tests for both edge cases in the respective test files.

## Check list

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)