### PR TITLE
fix: skip tcp:// init_method with torchrun on nightly builds

### DIFF
--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -96,7 +96,20 @@ def _test_check_idist_parallel_torch_launch(init_method, fp, backend, nprocs):
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip because test uses torch launch")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:29500", "FILE"])
+@pytest.mark.parametrize(
+    "init_method",
+    [
+        None,
+        pytest.param(
+            "tcp://0.0.0.0:29500",
+            marks=pytest.mark.skipif(
+                "dev" in torch.__version__,
+                reason="Skip tcp:// init_method with torchrun on nightly due to incompatibility",
+            ),
+        ),
+        "FILE",
+    ],
+)
 @pytest.mark.parametrize(
     "backend",
     ["gloo", pytest.param("nccl", marks=pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU"))],


### PR DESCRIPTION
Related: #3652 

**Description**
The test is skipped on nightly only and will be re-enabled once the underlying deadlock issue is fixed.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
