### PR TITLE
feat(handlers): add GradientNormLogger for monitoring gradient norms

### DIFF
--- a/ignite/handlers/__init__.py
+++ b/ignite/handlers/__init__.py
@@ -8,6 +8,7 @@ from ignite.handlers.fbresearch_logger import FBResearchLogger
 from ignite.handlers.lr_finder import FastaiLRFinder
 from ignite.handlers.mlflow_logger import MLflowLogger
 from ignite.handlers.neptune_logger import NeptuneLogger
+from ignite.handlers.gradient_norm_logger import GradientNormLogger
 from ignite.handlers.param_scheduler import (
     BaseParamScheduler,
     BatchSizeScheduler,

--- a/ignite/handlers/gradient_norm_logger.py
+++ b/ignite/handlers/gradient_norm_logger.py
@@ -1,0 +1,47 @@
+from typing import Any, Optional
+
+import torch
+from ignite.engine import Engine, Events
+
+
+def compute_grad_norm(model: torch.nn.Module, norm_type: float = 2.0) -> float:
+    """Compute gradient norm of a model."""
+    total_norm = 0.0
+
+    for p in model.parameters():
+        if p.grad is not None:
+            param_norm = p.grad.data.norm(norm_type)
+            total_norm += param_norm.item() ** norm_type
+
+    return total_norm ** (1.0 / norm_type)
+
+
+class GradientNormLogger:
+    """Handler to log gradient norm during training.
+
+    Args:
+        model: PyTorch model
+        norm_type: Type of norm (default: L2)
+        output_transform: Optional transform applied to output
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        norm_type: float = 2.0,
+        output_transform: Optional[Any] = None,
+    ):
+        self.model = model
+        self.norm_type = norm_type
+        self.output_transform = output_transform
+
+    def __call__(self, engine: Engine) -> None:
+        norm = compute_grad_norm(self.model, self.norm_type)
+
+        if not hasattr(engine.state, "metrics"):
+            engine.state.metrics = {}
+
+        engine.state.metrics["grad_norm"] = norm
+
+    def attach(self, engine: Engine, event_name: Events = Events.ITERATION_COMPLETED) -> None:
+        engine.add_event_handler(event_name, self)

--- a/tests/ignite/handlers/test_gradient_norm_logger.py
+++ b/tests/ignite/handlers/test_gradient_norm_logger.py
@@ -1,0 +1,35 @@
+import torch
+from ignite.engine import Engine
+from ignite.handlers import GradientNormLogger
+
+
+def _dummy_step(engine, batch):
+    model = engine.state.model
+    optimizer = engine.state.optimizer
+
+    optimizer.zero_grad()
+    output = model(batch)
+    loss = output.sum()
+    loss.backward()
+    optimizer.step()
+
+    return loss.item()
+
+
+def test_gradient_norm_logger():
+    model = torch.nn.Linear(10, 1)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    engine = Engine(_dummy_step)
+    engine.state.model = model
+    engine.state.optimizer = optimizer
+
+    grad_logger = GradientNormLogger(model)
+    grad_logger.attach(engine)
+
+    data = [torch.randn(10) for _ in range(5)]
+
+    engine.run(data, max_epochs=1)
+
+    assert "grad_norm" in engine.state.metrics
+    assert engine.state.metrics["grad_norm"] >= 0


### PR DESCRIPTION
closes #3707 
## Description
This PR introduces a new handler `GradientNormLogger` to monitor gradient norms during training.

The handler computes the global L2 norm of gradients across model parameters and logs it into `engine.state.metrics["grad_norm"]` at a specified event (default: `ITERATION_COMPLETED`).

This feature helps users detect training instabilities such as exploding or vanishing gradients without needing to manually implement gradient tracking logic.

## Motivation
Monitoring gradient norms is a common debugging and stability-check practice in deep learning workflows. Currently, users need to manually implement this functionality in their training loops.

Adding this as a built-in handler:
- Improves usability
- Reduces boilerplate code
- Aligns with Ignite’s handler-based design philosophy

## Changes
- Added `GradientNormLogger` handler in `ignite/handlers`
- Implemented gradient norm computation utility
- Attached metric to `engine.state.metrics`
- Added unit tests to validate functionality

## Example Usage
```python
grad_logger = GradientNormLogger(model)
grad_logger.attach(trainer)