### PR TITLE
docs: clarify _prepare_batch docstring

### DIFF
--- a/ignite/engine/__init__.py
+++ b/ignite/engine/__init__.py
@@ -47,7 +47,7 @@ __all__ = [
 def _prepare_batch(
     batch: Sequence[torch.Tensor], device: str | torch.device | None = None, non_blocking: bool = False
 ) -> tuple[torch.Tensor | Sequence | Mapping | str | bytes, ...]:
-    """Prepare batch for training or evaluation: pass to a device with options."""
+    """Prepare batch for training or evaluation by moving it to a device with options."""
     x, y = batch
     return (
         convert_tensor(x, device=device, non_blocking=non_blocking),


### PR DESCRIPTION
Fixes #2661

Description:
- clarify that `_prepare_batch` moves the batch to the target device for both training and evaluation

Check list:
- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)