### PR TITLE
remove sklearn dependency from cohenkappa score calculation logic and applied custom calculation and updated tests

### DIFF
--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -1,15 +1,67 @@
 from collections.abc import Callable
+from functools import partial
 from typing import Literal
 
 import torch
+import torch.nn.functional as F
 
+from ignite.exceptions import NotComputableError
+from ignite.metrics.confusion_matrix import ConfusionMatrix
 from ignite.metrics.epoch_metric import EpochMetric
+from ignite.metrics.metric import reinit__is_reduced
+
+
+def _kappa_from_conf(conf: torch.Tensor, weights: Literal["linear", "quadratic"] | None) -> float:
+    n = conf.sum()
+    if n == 0:
+        raise NotComputableError("CohenKappa cannot be computed on an empty confusion matrix (n == 0).")
+
+    n_classes = conf.shape[0]
+
+    if weights is None:
+        p_o = conf.trace() / n
+        row = conf.sum(dim=1)
+        col = conf.sum(dim=0)
+        p_e = (row * col).sum() / (n * n)
+    else:
+        idx = torch.arange(n_classes, device=conf.device)
+        if weights == "linear":
+            w = torch.abs(idx.unsqueeze(0) - idx.unsqueeze(1)).double()
+        else:
+            w = ((idx.unsqueeze(0) - idx.unsqueeze(1)) ** 2).double()
+
+        w = w / w.max()
+        p_o = 1 - (w * conf).sum() / n
+        row = conf.sum(dim=1)
+        col = conf.sum(dim=0)
+        expected = row.unsqueeze(1) * col.unsqueeze(0) / n
+        p_e = 1 - (w * expected).sum() / n
+
+    if (1 - p_e).abs() < 1e-9:
+        return 1.0 if (p_o - p_e).abs() < 1e-9 else float("nan")
+
+    return ((p_o - p_e) / (1 - p_e)).item()
+
+
+def _cohen_kappa_score(
+    y_pred: torch.Tensor,
+    y: torch.Tensor,
+    weights: Literal["linear", "quadratic"] | None,
+) -> float:
+    num_classes = int(max(y_pred.max().item(), y.max().item())) + 1
+
+    cm = ConfusionMatrix(num_classes=num_classes, device=y_pred.device)
+    y_pred_oh = F.one_hot(y_pred.long(), num_classes).float()
+    cm.update((y_pred_oh, y.long()))
+    conf = cm.compute().double()
+
+    return _kappa_from_conf(conf, weights)
 
 
 class CohenKappa(EpochMetric):
     """Compute different types of Cohen's Kappa: Non-Weighted, Linear, Quadratic.
-    Accumulating predictions and the ground-truth during an epoch and computing
-    Cohen's Kappa using native PyTorch operations via the formula:
+    Buffers predictions and targets across batches, then computes the confusion
+    matrix via :class:`~ignite.metrics.ConfusionMatrix` and applies the formula:
     κ = (p_o - p_e) / (1 - p_e), where p_o is the observed agreement and p_e
     is the expected agreement computed from marginal probabilities.
 
@@ -20,9 +72,6 @@ class CohenKappa(EpochMetric):
             you want to compute the metric with respect to one of the outputs.
         weights: a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear
             or Quadratic. Default, None.
-        check_compute_fn: Default False. If True, the compute function is run on the first batch
-            of data to ensure there are no issues. User will be warned in case there are any issues
-            computing the function.
         device: optional device specification for internal storage.
         skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
             true for multi-output model, for example, if ``y_pred`` contains multi-output as ``(y_pred_a, y_pred_b)``
@@ -61,52 +110,38 @@ class CohenKappa(EpochMetric):
         self,
         output_transform: Callable = lambda x: x,
         weights: Literal["linear", "quadratic"] | None = None,
-        check_compute_fn: bool = False,
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
         if weights not in (None, "linear", "quadratic"):
             raise ValueError("Kappa Weighting type must be None or linear or quadratic.")
 
-        # initialize weights
         self.weights: Literal["linear", "quadratic"] | None = weights
 
         super().__init__(
-            self._cohen_kappa_score,
+            compute_fn=partial(_cohen_kappa_score, weights=weights),
             output_transform=output_transform,
-            check_compute_fn=check_compute_fn,
+            check_compute_fn=False,
             device=device,
             skip_unrolling=skip_unrolling,
         )
 
-    def _cohen_kappa_score(self, y_targets: torch.Tensor, y_preds: torch.Tensor) -> float:
-        if y_targets.ndim > 1 or y_preds.ndim > 1:
+    @reinit__is_reduced
+    def update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
+        y_pred, y = output[0].detach(), output[1].detach()
+
+        if y_pred.ndim == 2 and y_pred.shape[1] == 1:
+            y_pred = y_pred.squeeze(dim=-1)
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.squeeze(dim=-1)
+
+        if y_pred.ndim > 1 or y.ndim > 1:
             raise ValueError("multilabel-indicator is not supported")
-        n_classes = int(max(y_targets.max().item(), y_preds.max().item())) + 1
 
-        indices = y_targets * n_classes + y_preds
-        conf = torch.bincount(indices, minlength=n_classes * n_classes).reshape(n_classes, n_classes).double()
-        n = conf.sum()
+        super().update((y_pred, y))
 
-        if self.weights is None:
-            p_o = conf.trace() / n
-            row = conf.sum(dim=1)
-            col = conf.sum(dim=0)
-            p_e = (row * col).sum() / (n * n)
-
-        else:
-            idx = torch.arange(n_classes, device=y_targets.device)
-            if self.weights == "linear":
-                w = torch.abs(idx.unsqueeze(0) - idx.unsqueeze(1)).double()
-            else:
-                w = ((idx.unsqueeze(0) - idx.unsqueeze(1)) ** 2).double()
-
-            w = w / w.max()
-            p_o = 1 - (w * conf).sum() / n
-            row = conf.sum(dim=1)
-            col = conf.sum(dim=0)
-            expected = row.unsqueeze(1) * col.unsqueeze(0) / n
-            p_e = 1 - (w * expected).sum() / n
-
-        kappa = (p_o - p_e) / (1 - p_e)
-        return kappa.item()
+    def compute(self) -> float:
+        try:
+            return super().compute()
+        except NotComputableError:
+            raise NotComputableError("CohenKappa must have at least one example before it can be computed.")

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -187,8 +187,6 @@ class CohenKappa(Metric):
 
     .. versionchanged:: 0.6.0
         Replaced scikit-learn dependency with a native PyTorch implementation.
-
-    .. versionchanged:: 0.6.2
         Added ``num_classes`` argument; routes to a running-confusion-matrix backend when provided.
     """
 

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -37,10 +37,8 @@ def _kappa_from_conf(conf: torch.Tensor, weights: Literal["linear", "quadratic"]
         expected = row.unsqueeze(1) * col.unsqueeze(0) / n
         p_e = 1 - (w * expected).sum() / n
 
-    if (1 - p_e).abs() < 1e-9:
-        return 1.0 if (p_o - p_e).abs() < 1e-9 else float("nan")
-
-    return ((p_o - p_e) / (1 - p_e)).item()
+    epsilon = 1e-9
+    return ((p_o - p_e) / (1 - p_e).clamp(min=epsilon)).item()
 
 
 def _cohen_kappa_score(
@@ -48,6 +46,9 @@ def _cohen_kappa_score(
     y: torch.Tensor,
     weights: Literal["linear", "quadratic"] | None,
 ) -> float:
+    if y_pred.ndim > 1 or y.ndim > 1:
+        raise ValueError("multilabel-indicator is not supported")
+
     num_classes = int(max(y_pred.max().item(), y.max().item())) + 1
 
     cm = ConfusionMatrix(num_classes=num_classes, device=y_pred.device)
@@ -85,16 +86,7 @@ class _CohenKappaEpochMetric(EpochMetric):
         if y.ndim == 2 and y.shape[1] == 1:
             y = y.squeeze(dim=-1)
 
-        if y_pred.ndim > 1 or y.ndim > 1:
-            raise ValueError("multilabel-indicator is not supported")
-
         super().update((y_pred, y))
-
-    def compute(self) -> float:
-        try:
-            return super().compute()
-        except NotComputableError:
-            raise NotComputableError("CohenKappa must have at least one example before it can be computed.")
 
 
 class _CohenKappaConfusionMatrix(Metric):
@@ -142,8 +134,6 @@ class _CohenKappaConfusionMatrix(Metric):
         self._cm.update((y_pred_oh, y.long().to(self._device)))
 
     def compute(self) -> float:
-        if self._cm.confusion_matrix.sum() == 0:
-            raise NotComputableError("CohenKappa must have at least one example before it can be computed.")
         conf = self._cm.compute().to(dtype=self._double_dtype)
         return _kappa_from_conf(conf, self._weights)
 

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from functools import partial
 from typing import Literal
 
 import torch
@@ -45,6 +44,7 @@ def _cohen_kappa_score(
     y_pred: torch.Tensor,
     y: torch.Tensor,
     weights: Literal["linear", "quadratic"] | None,
+    double_dtype: torch.dtype,
 ) -> float:
     if y_pred.ndim > 1 or y.ndim > 1:
         raise ValueError("multilabel-indicator is not supported")
@@ -58,8 +58,6 @@ def _cohen_kappa_score(
     y, y_pred = y.long(), y_pred.long()
     indices = num_classes * y + y_pred
     conf = torch.bincount(indices, minlength=num_classes**2)
-    # MPS framework doesn't support float64, fall back to float32 (mirrors Metric._double_dtype)
-    double_dtype = torch.float32 if y_pred.device.type == "mps" else torch.float64
     conf = conf.reshape(num_classes, num_classes).to(dtype=double_dtype)
 
     return _kappa_from_conf(conf, weights)
@@ -77,7 +75,9 @@ class _CohenKappaEpochMetric(EpochMetric):
         check_compute_fn: bool,
     ):
         super().__init__(
-            compute_fn=partial(_cohen_kappa_score, weights=weights),
+            # ``self._double_dtype`` (set in Metric.__init__, float32 on MPS / float64 otherwise)
+            # is resolved lazily at compute time.
+            compute_fn=lambda y_pred, y: _cohen_kappa_score(y_pred, y, weights, self._double_dtype),
             output_transform=output_transform,
             check_compute_fn=check_compute_fn,
             device=device,

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -51,10 +51,16 @@ def _cohen_kappa_score(
 
     num_classes = int(max(y_pred.max().item(), y.max().item())) + 1
 
-    cm = ConfusionMatrix(num_classes=num_classes, device=y_pred.device)
-    y_pred_oh = F.one_hot(y_pred.long(), num_classes).float()
-    cm.update((y_pred_oh, y.long()))
-    conf = cm.compute().to(dtype=cm._double_dtype)
+    # Build the confusion matrix locally with plain tensor ops. We must NOT use the
+    # ``ConfusionMatrix`` metric here: its ``compute()`` is wrapped with ``sync_all_reduce``
+    # and this function runs on rank 0 only (see ``EpochMetric.compute``), so a collective
+    # would deadlock the other ranks.
+    y, y_pred = y.long(), y_pred.long()
+    indices = num_classes * y + y_pred
+    conf = torch.bincount(indices, minlength=num_classes**2)
+    # MPS framework doesn't support float64, fall back to float32 (mirrors Metric._double_dtype)
+    double_dtype = torch.float32 if y_pred.device.type == "mps" else torch.float64
+    conf = conf.reshape(num_classes, num_classes).to(dtype=double_dtype)
 
     return _kappa_from_conf(conf, weights)
 

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -7,10 +7,11 @@ from ignite.metrics.epoch_metric import EpochMetric
 
 
 class CohenKappa(EpochMetric):
-    """Compute different types of Cohen's Kappa: Non-Wieghted, Linear, Quadratic.
-    Accumulating predictions and the ground-truth during an epoch and applying
-    `sklearn.metrics.cohen_kappa_score <https://scikit-learn.org/stable/modules/
-    generated/sklearn.metrics.cohen_kappa_score.html>`_ .
+    """Compute different types of Cohen's Kappa: Non-Weighted, Linear, Quadratic.
+    Accumulating predictions and the ground-truth during an epoch and computing
+    Cohen's Kappa using native PyTorch operations via the formula:
+    κ = (p_o - p_e) / (1 - p_e), where p_o is the observed agreement and p_e
+    is the expected agreement computed from marginal probabilities.
 
     Args:
         output_transform: a callable that is used to transform the
@@ -19,10 +20,9 @@ class CohenKappa(EpochMetric):
             you want to compute the metric with respect to one of the outputs.
         weights: a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear
             or Quadratic. Default, None.
-        check_compute_fn: Default False. If True, `cohen_kappa_score
-            <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.cohen_kappa_score.html>`_
-            is run on the first batch of data to ensure there are
-            no issues. User will be warned in case there are any issues computing the function.
+        check_compute_fn: Default False. If True, the compute function is run on the first batch
+            of data to ensure there are no issues. User will be warned in case there are any issues
+            computing the function.
         device: optional device specification for internal storage.
         skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
             true for multi-output model, for example, if ``y_pred`` contains multi-output as ``(y_pred_a, y_pred_b)``
@@ -31,7 +31,7 @@ class CohenKappa(EpochMetric):
     Examples:
         To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
         The output of the engine's ``process_function`` needs to be in the format of
-        ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``. If not, ``output_tranform`` can be added
+        ``(y_pred, y)`` or ``{'y_pred': y_pred, 'y': y, ...}``. If not, ``output_transform`` can be added
         to the metric to transform the output into the form expected by the metric.
 
         .. include:: defaults.rst
@@ -52,6 +52,9 @@ class CohenKappa(EpochMetric):
 
     .. versionchanged:: 0.5.1
         ``skip_unrolling`` argument is added.
+
+    .. versionchanged:: 0.6.0
+        Replaced scikit-learn dependency with a native PyTorch implementation.
     """
 
     def __init__(

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -53,8 +53,7 @@ def _cohen_kappa_score(
     cm = ConfusionMatrix(num_classes=num_classes, device=y_pred.device)
     y_pred_oh = F.one_hot(y_pred.long(), num_classes).float()
     cm.update((y_pred_oh, y.long()))
-    double_dtype = torch.float32 if y_pred.device.type == "mps" else torch.float64
-    conf = cm.compute().to(dtype=double_dtype)
+    conf = cm.compute().to(dtype=cm._double_dtype)
 
     return _kappa_from_conf(conf, weights)
 

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -154,15 +154,15 @@ class CohenKappa(Metric):
             you want to compute the metric with respect to one of the outputs.
         weights: a string is used to define the type of Cohen's Kappa whether Non-Weighted or Linear
             or Quadratic. Default, None.
+        check_compute_fn: Default False. If True, the compute function is run on the first batch
+            of data to ensure there are no issues. User will be warned in case there are any issues
+            computing the function.
         device: optional device specification for internal storage.
         skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
             true for multi-output model, for example, if ``y_pred`` contains multi-output as ``(y_pred_a, y_pred_b)``
             Alternatively, ``output_transform`` can be used to handle this.
         num_classes: number of classes. If provided, uses a running confusion matrix
             (memory-efficient). If ``None``, infers from data at compute time (backward-compatible default).
-        check_compute_fn: if True and ``num_classes`` is ``None``, the internal compute function is run on the
-            first batch of data to ensure there are no issues. If issues exist, user is warned that there might
-            be an error in the compute function. Default, False. Ignored when ``num_classes`` is provided.
 
     Examples:
         To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
@@ -198,10 +198,10 @@ class CohenKappa(Metric):
         self,
         output_transform: Callable = lambda x: x,
         weights: Literal["linear", "quadratic"] | None = None,
+        check_compute_fn: bool = False,
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
         num_classes: int | None = None,
-        check_compute_fn: bool = False,
     ):
         if weights not in (None, "linear", "quadratic"):
             raise ValueError("Kappa Weighting type must be None or linear or quadratic.")

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from ignite.exceptions import NotComputableError
 from ignite.metrics.confusion_matrix import ConfusionMatrix
 from ignite.metrics.epoch_metric import EpochMetric
-from ignite.metrics.metric import reinit__is_reduced
+from ignite.metrics.metric import Metric, reinit__is_reduced
 
 
 def _kappa_from_conf(conf: torch.Tensor, weights: Literal["linear", "quadratic"] | None) -> float:
@@ -53,17 +53,108 @@ def _cohen_kappa_score(
     cm = ConfusionMatrix(num_classes=num_classes, device=y_pred.device)
     y_pred_oh = F.one_hot(y_pred.long(), num_classes).float()
     cm.update((y_pred_oh, y.long()))
-    conf = cm.compute().double()
+    conf = cm.compute().cpu().double()
 
     return _kappa_from_conf(conf, weights)
 
 
-class CohenKappa(EpochMetric):
+class _CohenKappaEpochMetric(EpochMetric):
+    """CohenKappa backed by EpochMetric — infers num_classes dynamically from data."""
+
+    def __init__(
+        self,
+        weights: Literal["linear", "quadratic"] | None,
+        output_transform: Callable,
+        device: str | torch.device,
+        skip_unrolling: bool,
+    ):
+        super().__init__(
+            compute_fn=partial(_cohen_kappa_score, weights=weights),
+            output_transform=output_transform,
+            check_compute_fn=False,
+            device=device,
+            skip_unrolling=skip_unrolling,
+        )
+
+    @reinit__is_reduced
+    def update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
+        y_pred, y = output[0].detach(), output[1].detach()
+
+        if y_pred.ndim == 2 and y_pred.shape[1] == 1:
+            y_pred = y_pred.squeeze(dim=-1)
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.squeeze(dim=-1)
+
+        if y_pred.ndim > 1 or y.ndim > 1:
+            raise ValueError("multilabel-indicator is not supported")
+
+        super().update((y_pred, y))
+
+    def compute(self) -> float:
+        try:
+            return super().compute()
+        except NotComputableError:
+            raise NotComputableError("CohenKappa must have at least one example before it can be computed.")
+
+
+class _CohenKappaConfusionMatrix(Metric):
+    """CohenKappa backed by ConfusionMatrix — requires num_classes at construction time.
+    Accumulates a running confusion matrix; no raw tensor buffering.
+    """
+
+    _state_dict_all_req_keys = ("_cm",)
+
+    def __init__(
+        self,
+        num_classes: int,
+        weights: Literal["linear", "quadratic"] | None,
+        output_transform: Callable,
+        device: str | torch.device,
+        skip_unrolling: bool,
+    ):
+        self._weights = weights
+        self._cm = ConfusionMatrix(
+            num_classes=num_classes,
+            output_transform=output_transform,
+            device=device,
+            skip_unrolling=skip_unrolling,
+        )
+        super().__init__(output_transform=output_transform, device=device, skip_unrolling=skip_unrolling)
+
+    @reinit__is_reduced
+    def reset(self) -> None:
+        self._cm.reset()
+
+    @reinit__is_reduced
+    def update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
+        y_pred, y = output[0].detach(), output[1].detach()
+
+        if y_pred.ndim == 2 and y_pred.shape[1] == 1:
+            y_pred = y_pred.squeeze(dim=-1)
+        if y.ndim == 2 and y.shape[1] == 1:
+            y = y.squeeze(dim=-1)
+
+        if y_pred.ndim > 1 or y.ndim > 1:
+            raise ValueError("multilabel-indicator is not supported")
+
+        num_classes = self._cm.num_classes
+        y_pred_oh = F.one_hot(y_pred.long(), num_classes).float().to(self._device)
+        self._cm.update((y_pred_oh, y.long().to(self._device)))
+
+    def compute(self) -> float:
+        if self._cm.confusion_matrix.sum() == 0:
+            raise NotComputableError("CohenKappa must have at least one example before it can be computed.")
+        conf = self._cm.compute().cpu().double()
+        return _kappa_from_conf(conf, self._weights)
+
+
+class CohenKappa(Metric):
     """Compute different types of Cohen's Kappa: Non-Weighted, Linear, Quadratic.
-    Buffers predictions and targets across batches, then computes the confusion
-    matrix via :class:`~ignite.metrics.ConfusionMatrix` and applies the formula:
-    κ = (p_o - p_e) / (1 - p_e), where p_o is the observed agreement and p_e
-    is the expected agreement computed from marginal probabilities.
+
+    When ``num_classes`` is provided, accumulates a running confusion matrix via
+    :class:`~ignite.metrics.ConfusionMatrix` (memory-efficient, no raw tensor buffering).
+    When ``num_classes`` is ``None`` (default), buffers predictions and targets via
+    :class:`~ignite.metrics.EpochMetric` and infers the number of classes from data.
 
     Args:
         output_transform: a callable that is used to transform the
@@ -76,6 +167,8 @@ class CohenKappa(EpochMetric):
         skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
             true for multi-output model, for example, if ``y_pred`` contains multi-output as ``(y_pred_a, y_pred_b)``
             Alternatively, ``output_transform`` can be used to handle this.
+        num_classes: number of classes. If provided, uses a running confusion matrix
+            (memory-efficient). If ``None``, infers from data at compute time (backward-compatible default).
 
     Examples:
         To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
@@ -104,6 +197,9 @@ class CohenKappa(EpochMetric):
 
     .. versionchanged:: 0.6.0
         Replaced scikit-learn dependency with a native PyTorch implementation.
+
+    .. versionchanged:: 0.6.2
+        Added ``num_classes`` argument; routes to a running-confusion-matrix backend when provided.
     """
 
     def __init__(
@@ -112,36 +208,38 @@ class CohenKappa(EpochMetric):
         weights: Literal["linear", "quadratic"] | None = None,
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
+        num_classes: int | None = None,
     ):
         if weights not in (None, "linear", "quadratic"):
             raise ValueError("Kappa Weighting type must be None or linear or quadratic.")
 
         self.weights: Literal["linear", "quadratic"] | None = weights
 
-        super().__init__(
-            compute_fn=partial(_cohen_kappa_score, weights=weights),
-            output_transform=output_transform,
-            check_compute_fn=False,
-            device=device,
-            skip_unrolling=skip_unrolling,
-        )
+        if num_classes is not None:
+            self._impl: Metric = _CohenKappaConfusionMatrix(
+                num_classes=num_classes,
+                weights=weights,
+                output_transform=output_transform,
+                device=device,
+                skip_unrolling=skip_unrolling,
+            )
+        else:
+            self._impl = _CohenKappaEpochMetric(
+                weights=weights,
+                output_transform=output_transform,
+                device=device,
+                skip_unrolling=skip_unrolling,
+            )
+
+        super().__init__(output_transform=output_transform, device=device, skip_unrolling=skip_unrolling)
+
+    @reinit__is_reduced
+    def reset(self) -> None:
+        self._impl.reset()
 
     @reinit__is_reduced
     def update(self, output: tuple[torch.Tensor, torch.Tensor]) -> None:
-        y_pred, y = output[0].detach(), output[1].detach()
-
-        if y_pred.ndim == 2 and y_pred.shape[1] == 1:
-            y_pred = y_pred.squeeze(dim=-1)
-        if y.ndim == 2 and y.shape[1] == 1:
-            y = y.squeeze(dim=-1)
-
-        if y_pred.ndim > 1 or y.ndim > 1:
-            raise ValueError("multilabel-indicator is not supported")
-
-        super().update((y_pred, y))
+        self._impl.update(output)
 
     def compute(self) -> float:
-        try:
-            return super().compute()
-        except NotComputableError:
-            raise NotComputableError("CohenKappa must have at least one example before it can be computed.")
+        return self._impl.compute()

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -26,9 +26,9 @@ def _kappa_from_conf(conf: torch.Tensor, weights: Literal["linear", "quadratic"]
     else:
         idx = torch.arange(n_classes, device=conf.device)
         if weights == "linear":
-            w = torch.abs(idx.unsqueeze(0) - idx.unsqueeze(1)).double()
+            w = torch.abs(idx.unsqueeze(0) - idx.unsqueeze(1)).to(dtype=conf.dtype)
         else:
-            w = ((idx.unsqueeze(0) - idx.unsqueeze(1)) ** 2).double()
+            w = ((idx.unsqueeze(0) - idx.unsqueeze(1)) ** 2).to(dtype=conf.dtype)
 
         w = w / w.max()
         p_o = 1 - (w * conf).sum() / n
@@ -53,7 +53,8 @@ def _cohen_kappa_score(
     cm = ConfusionMatrix(num_classes=num_classes, device=y_pred.device)
     y_pred_oh = F.one_hot(y_pred.long(), num_classes).float()
     cm.update((y_pred_oh, y.long()))
-    conf = cm.compute().cpu().double()
+    double_dtype = torch.float32 if y_pred.device.type == "mps" else torch.float64
+    conf = cm.compute().to(dtype=double_dtype)
 
     return _kappa_from_conf(conf, weights)
 
@@ -144,7 +145,7 @@ class _CohenKappaConfusionMatrix(Metric):
     def compute(self) -> float:
         if self._cm.confusion_matrix.sum() == 0:
             raise NotComputableError("CohenKappa must have at least one example before it can be computed.")
-        conf = self._cm.compute().cpu().double()
+        conf = self._cm.compute().to(dtype=self._double_dtype)
         return _kappa_from_conf(conf, self._weights)
 
 

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -62,10 +62,6 @@ class CohenKappa(EpochMetric):
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
-        try:
-            from sklearn.metrics import cohen_kappa_score  # noqa: F401
-        except ImportError:
-            raise ModuleNotFoundError("This contrib module requires scikit-learn to be installed.")
         if weights not in (None, "linear", "quadratic"):
             raise ValueError("Kappa Weighting type must be None or linear or quadratic.")
 
@@ -81,8 +77,33 @@ class CohenKappa(EpochMetric):
         )
 
     def _cohen_kappa_score(self, y_targets: torch.Tensor, y_preds: torch.Tensor) -> float:
-        from sklearn.metrics import cohen_kappa_score
+        if y_targets.ndim > 1 or y_preds.ndim > 1:
+            raise ValueError("multilabel-indicator is not supported")
+        n_classes = int(max(y_targets.max().item(), y_preds.max().item())) + 1
 
-        y_true = y_targets.cpu().numpy()
-        y_pred = y_preds.cpu().numpy()
-        return cohen_kappa_score(y_true, y_pred, weights=self.weights)
+        indices = y_targets * n_classes + y_preds
+        conf = torch.bincount(indices, minlength=n_classes * n_classes).reshape(n_classes, n_classes).double()
+        n = conf.sum()
+
+        if self.weights is None:
+            p_o = conf.trace() / n
+            row = conf.sum(dim=1)
+            col = conf.sum(dim=0)
+            p_e = (row * col).sum() / (n * n)
+
+        else:
+            idx = torch.arange(n_classes, device=y_targets.device)
+            if self.weights == "linear":
+                w = torch.abs(idx.unsqueeze(0) - idx.unsqueeze(1)).double()
+            else:
+                w = ((idx.unsqueeze(0) - idx.unsqueeze(1)) ** 2).double()
+
+            w = w / w.max()
+            p_o = 1 - (w * conf).sum() / n
+            row = conf.sum(dim=1)
+            col = conf.sum(dim=0)
+            expected = row.unsqueeze(1) * col.unsqueeze(0) / n
+            p_e = 1 - (w * expected).sum() / n
+
+        kappa = (p_o - p_e) / (1 - p_e)
+        return kappa.item()

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -153,7 +153,7 @@ class CohenKappa(Metric):
     """Compute different types of Cohen's Kappa: Non-Weighted, Linear, Quadratic.
 
     When ``num_classes`` is provided, accumulates a running confusion matrix via
-    :class:`~ignite.metrics.ConfusionMatrix` (memory-efficient, no raw tensor buffering).
+    :class:`~ignite.metrics.confusion_matrix.ConfusionMatrix` (memory-efficient, no raw tensor buffering).
     When ``num_classes`` is ``None`` (default), buffers predictions and targets via
     :class:`~ignite.metrics.EpochMetric` and infers the number of classes from data.
 

--- a/ignite/metrics/cohen_kappa.py
+++ b/ignite/metrics/cohen_kappa.py
@@ -68,11 +68,12 @@ class _CohenKappaEpochMetric(EpochMetric):
         output_transform: Callable,
         device: str | torch.device,
         skip_unrolling: bool,
+        check_compute_fn: bool,
     ):
         super().__init__(
             compute_fn=partial(_cohen_kappa_score, weights=weights),
             output_transform=output_transform,
-            check_compute_fn=False,
+            check_compute_fn=check_compute_fn,
             device=device,
             skip_unrolling=skip_unrolling,
         )
@@ -159,6 +160,9 @@ class CohenKappa(Metric):
             Alternatively, ``output_transform`` can be used to handle this.
         num_classes: number of classes. If provided, uses a running confusion matrix
             (memory-efficient). If ``None``, infers from data at compute time (backward-compatible default).
+        check_compute_fn: if True and ``num_classes`` is ``None``, the internal compute function is run on the
+            first batch of data to ensure there are no issues. If issues exist, user is warned that there might
+            be an error in the compute function. Default, False. Ignored when ``num_classes`` is provided.
 
     Examples:
         To use with ``Engine`` and ``process_function``, simply attach the metric instance to the engine.
@@ -197,6 +201,7 @@ class CohenKappa(Metric):
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
         num_classes: int | None = None,
+        check_compute_fn: bool = False,
     ):
         if weights not in (None, "linear", "quadratic"):
             raise ValueError("Kappa Weighting type must be None or linear or quadratic.")
@@ -217,6 +222,7 @@ class CohenKappa(Metric):
                 output_transform=output_transform,
                 device=device,
                 skip_unrolling=skip_unrolling,
+                check_compute_fn=check_compute_fn,
             )
 
         super().__init__(output_transform=output_transform, device=device, skip_unrolling=skip_unrolling)

--- a/ignite/metrics/epoch_metric.py
+++ b/ignite/metrics/epoch_metric.py
@@ -144,7 +144,7 @@ class EpochMetric(Metric):
 
     def compute(self) -> float:
         if len(self._predictions) < 1 or len(self._targets) < 1:
-            raise NotComputableError("EpochMetric must have at least one example before it can be computed.")
+            raise NotComputableError(f"{type(self).__name__} must have at least one example before it can be computed.")
 
         if self._result is None:
             _prediction_tensor = torch.cat(self._predictions, dim=0)

--- a/tests/ignite/metrics/regression/test_median_absolute_error.py
+++ b/tests/ignite/metrics/regression/test_median_absolute_error.py
@@ -13,7 +13,7 @@ from ignite.metrics.regression import MedianAbsoluteError
 def test_zero_sample():
     m = MedianAbsoluteError()
     with pytest.raises(
-        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+        NotComputableError, match=r"MedianAbsoluteError must have at least one example before it can be computed"
     ):
         m.compute()
 

--- a/tests/ignite/metrics/regression/test_median_absolute_percentage_error.py
+++ b/tests/ignite/metrics/regression/test_median_absolute_percentage_error.py
@@ -13,7 +13,8 @@ from ignite.metrics.regression import MedianAbsolutePercentageError
 def test_zero_sample():
     m = MedianAbsolutePercentageError()
     with pytest.raises(
-        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+        NotComputableError,
+        match=r"MedianAbsolutePercentageError must have at least one example before it can be computed",
     ):
         m.compute()
 

--- a/tests/ignite/metrics/regression/test_median_relative_absolute_error.py
+++ b/tests/ignite/metrics/regression/test_median_relative_absolute_error.py
@@ -13,7 +13,8 @@ from ignite.metrics.regression import MedianRelativeAbsoluteError
 def test_zero_sample():
     m = MedianRelativeAbsoluteError()
     with pytest.raises(
-        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+        NotComputableError,
+        match=r"MedianRelativeAbsoluteError must have at least one example before it can be computed",
     ):
         m.compute()
 

--- a/tests/ignite/metrics/test_average_precision.py
+++ b/tests/ignite/metrics/test_average_precision.py
@@ -29,7 +29,7 @@ def test_no_update():
     ap = AveragePrecision()
 
     with pytest.raises(
-        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+        NotComputableError, match=r"AveragePrecision must have at least one example before it can be computed"
     ):
         ap.compute()
 

--- a/tests/ignite/metrics/test_cohen_kappa.py
+++ b/tests/ignite/metrics/test_cohen_kappa.py
@@ -21,6 +21,33 @@ def test_no_update():
         ck.compute()
 
 
+def test_input_types():
+    ck = CohenKappa()
+    ck.reset()
+    output1 = (torch.rand(10), torch.randint(0, 2, size=(10,), dtype=torch.long))
+    ck.update(output1)
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        ck.update((torch.randint(0, 5, size=(10,)), torch.randint(0, 2, size=(10,))))
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
+        ck.update((torch.rand(10), torch.randint(0, 2, size=(10,)).to(torch.int32)))
+
+
+def test_check_shape():
+    ck = CohenKappa()
+    impl = ck._impl
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        impl._check_shape((torch.tensor(0), torch.tensor(0)))
+
+    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
+        impl._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
+
+    with pytest.raises(ValueError, match=r"Targets should be of shape"):
+        impl._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
+
+
 def test_cohen_kappa_wrong_weights_type():
     with pytest.raises(ValueError, match=r"Kappa Weighting type must be"):
         ck = CohenKappa(weights=7)

--- a/tests/ignite/metrics/test_cohen_kappa.py
+++ b/tests/ignite/metrics/test_cohen_kappa.py
@@ -287,3 +287,70 @@ def _test_distrib_xla_nprocs(index):
 def test_distrib_xla_nprocs(xmp_executor):
     n = int(os.environ["NUM_TPU_WORKERS"])
     xmp_executor(_test_distrib_xla_nprocs, args=(), nprocs=n)
+
+
+# --- num_classes path tests ---
+
+
+def test_num_classes_no_update():
+    ck = CohenKappa(num_classes=3)
+    with pytest.raises(
+        NotComputableError, match=r"CohenKappa must have at least one example before it can be computed"
+    ):
+        ck.compute()
+
+
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_num_classes_matches_dynamic(weights, available_device):
+    torch.manual_seed(42)
+    y_pred = torch.randint(0, 4, size=(60,)).long()
+    y = torch.randint(0, 4, size=(60,)).long()
+    batch_size = 10
+
+    ck_dynamic = CohenKappa(weights=weights, device=available_device)
+    ck_fixed = CohenKappa(weights=weights, device=available_device, num_classes=4)
+
+    for ck in (ck_dynamic, ck_fixed):
+        ck.reset()
+        for i in range(60 // batch_size):
+            idx = i * batch_size
+            ck.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+
+    assert ck_dynamic.compute() == pytest.approx(ck_fixed.compute())
+
+
+@pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
+def test_num_classes_single_batch(weights, available_device):
+    torch.manual_seed(0)
+    y_pred = torch.randint(0, 3, size=(30,)).long()
+    y = torch.randint(0, 3, size=(30,)).long()
+
+    ck = CohenKappa(weights=weights, device=available_device, num_classes=3)
+    ck.reset()
+    ck.update((y_pred, y))
+    res = ck.compute()
+
+    assert isinstance(res, float)
+    assert cohen_kappa_score(y.numpy(), y_pred.numpy(), weights=weights) == pytest.approx(res)
+
+
+def test_num_classes_multilabel_inputs():
+    ck = CohenKappa(num_classes=4)
+    with pytest.raises(ValueError, match=r"multilabel-indicator is not supported"):
+        ck.reset()
+        ck.update((torch.randint(0, 2, size=(10, 4)).long(), torch.randint(0, 2, size=(10, 4)).long()))
+        ck.compute()
+
+
+def test_num_classes_squeeze_n1():
+    torch.manual_seed(7)
+    y_pred = torch.randint(0, 2, size=(20, 1)).long()
+    y = torch.randint(0, 2, size=(20, 1)).long()
+
+    ck = CohenKappa(num_classes=2)
+    ck.reset()
+    ck.update((y_pred, y))
+    res = ck.compute()
+
+    assert isinstance(res, float)
+    assert cohen_kappa_score(y.squeeze().numpy(), y_pred.squeeze().numpy()) == pytest.approx(res)

--- a/tests/ignite/metrics/test_cohen_kappa.py
+++ b/tests/ignite/metrics/test_cohen_kappa.py
@@ -16,7 +16,7 @@ def test_no_update():
     ck = CohenKappa()
 
     with pytest.raises(
-        NotComputableError, match=r"CohenKappa must have at least one example before it can be computed"
+        NotComputableError, match=r"_CohenKappaEpochMetric must have at least one example before it can be computed"
     ):
         ck.compute()
 
@@ -24,14 +24,17 @@ def test_no_update():
 def test_input_types():
     ck = CohenKappa()
     ck.reset()
-    output1 = (torch.rand(10), torch.randint(0, 2, size=(10,), dtype=torch.long))
+    output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 3), dtype=torch.long))
     ck.update(output1)
 
     with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
-        ck.update((torch.randint(0, 5, size=(10,)), torch.randint(0, 2, size=(10,))))
+        ck.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
 
     with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
-        ck.update((torch.rand(10), torch.randint(0, 2, size=(10,)).to(torch.int32)))
+        ck.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
+
+    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
+        ck.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
 
 
 def test_check_shape():
@@ -322,7 +325,7 @@ def test_distrib_xla_nprocs(xmp_executor):
 def test_num_classes_no_update():
     ck = CohenKappa(num_classes=3)
     with pytest.raises(
-        NotComputableError, match=r"CohenKappa must have at least one example before it can be computed"
+        NotComputableError, match=r"Confusion matrix must have at least one example before it can be computed"
     ):
         ck.compute()
 

--- a/tests/ignite/metrics/test_cohen_kappa.py
+++ b/tests/ignite/metrics/test_cohen_kappa.py
@@ -16,38 +16,9 @@ def test_no_update():
     ck = CohenKappa()
 
     with pytest.raises(
-        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+        NotComputableError, match=r"CohenKappa must have at least one example before it can be computed"
     ):
         ck.compute()
-
-
-def test_input_types():
-    ck = CohenKappa()
-    ck.reset()
-    output1 = (torch.rand(4, 3), torch.randint(0, 2, size=(4, 3), dtype=torch.long))
-    ck.update(output1)
-
-    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
-        ck.update((torch.randint(0, 5, size=(4, 3)), torch.randint(0, 2, size=(4, 3))))
-
-    with pytest.raises(ValueError, match=r"Incoherent types between input y and stored targets"):
-        ck.update((torch.rand(4, 3), torch.randint(0, 2, size=(4, 3)).to(torch.int32)))
-
-    with pytest.raises(ValueError, match=r"Incoherent types between input y_pred and stored predictions"):
-        ck.update((torch.randint(0, 2, size=(10,)).long(), torch.randint(0, 2, size=(10, 5)).long()))
-
-
-def test_check_shape():
-    ck = CohenKappa()
-
-    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
-        ck._check_shape((torch.tensor(0), torch.tensor(0)))
-
-    with pytest.raises(ValueError, match=r"Predictions should be of shape"):
-        ck._check_shape((torch.rand(4, 3, 1), torch.rand(4, 3)))
-
-    with pytest.raises(ValueError, match=r"Targets should be of shape"):
-        ck._check_shape((torch.rand(4, 3), torch.rand(4, 3, 1)))
 
 
 def test_cohen_kappa_wrong_weights_type():

--- a/tests/ignite/metrics/test_cohen_kappa.py
+++ b/tests/ignite/metrics/test_cohen_kappa.py
@@ -1,8 +1,6 @@
 import os
-from unittest.mock import patch
 
 import pytest
-import sklearn
 import torch
 from sklearn.metrics import cohen_kappa_score
 
@@ -12,17 +10,6 @@ from ignite.exceptions import NotComputableError
 from ignite.metrics import CohenKappa
 
 torch.manual_seed(12)
-
-
-@pytest.fixture()
-def mock_no_sklearn():
-    with patch.dict("sys.modules", {"sklearn.metrics": None}):
-        yield sklearn
-
-
-def test_no_sklearn(mock_no_sklearn):
-    with pytest.raises(ModuleNotFoundError, match=r"This contrib module requires scikit-learn to be installed."):
-        CohenKappa()
 
 
 def test_no_update():

--- a/tests/ignite/metrics/test_cohen_kappa.py
+++ b/tests/ignite/metrics/test_cohen_kappa.py
@@ -92,7 +92,9 @@ def test_binary_input(n_times, weights, test_data_binary, available_device):
 
     res = ck.compute()
     assert isinstance(res, float)
-    assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res)
+    # mps falls back to float32 (no float64 support), so relax tolerance there
+    tol = 1e-4 if available_device == "mps" else 1e-6
+    assert cohen_kappa_score(np_y, np_y_pred, weights=weights) == pytest.approx(res, abs=tol)
 
 
 def test_multilabel_inputs():
@@ -150,7 +152,9 @@ def test_integration_binary_input(n_times, weights, test_data_integration_binary
     ck = engine.run(data, max_epochs=1).metrics["ck"]
 
     assert isinstance(ck, float)
-    assert np_ck == pytest.approx(ck)
+    # mps falls back to float32 (no float64 support), so relax tolerance there
+    tol = 1e-4 if available_device == "mps" else 1e-6
+    assert np_ck == pytest.approx(ck, abs=tol)
 
 
 def _test_distrib_binary_input(device):
@@ -346,7 +350,9 @@ def test_num_classes_matches_dynamic(weights, available_device):
             idx = i * batch_size
             ck.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
 
-    assert ck_dynamic.compute() == pytest.approx(ck_fixed.compute())
+    # mps falls back to float32 (no float64 support), so relax tolerance there
+    tol = 1e-4 if available_device == "mps" else 1e-6
+    assert ck_dynamic.compute() == pytest.approx(ck_fixed.compute(), abs=tol)
 
 
 @pytest.mark.parametrize("weights", [None, "linear", "quadratic"])
@@ -361,7 +367,9 @@ def test_num_classes_single_batch(weights, available_device):
     res = ck.compute()
 
     assert isinstance(res, float)
-    assert cohen_kappa_score(y.numpy(), y_pred.numpy(), weights=weights) == pytest.approx(res)
+    # mps falls back to float32 (no float64 support), so relax tolerance there
+    tol = 1e-4 if available_device == "mps" else 1e-6
+    assert cohen_kappa_score(y.numpy(), y_pred.numpy(), weights=weights) == pytest.approx(res, abs=tol)
 
 
 def test_num_classes_multilabel_inputs():

--- a/tests/ignite/metrics/test_matthews_corrcoef.py
+++ b/tests/ignite/metrics/test_matthews_corrcoef.py
@@ -27,7 +27,7 @@ def test_no_update():
     mcc = MatthewsCorrCoef()
 
     with pytest.raises(
-        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
+        NotComputableError, match=r"MatthewsCorrCoef must have at least one example before it can be computed"
     ):
         mcc.compute()
 

--- a/tests/ignite/metrics/test_roc_auc.py
+++ b/tests/ignite/metrics/test_roc_auc.py
@@ -30,9 +30,7 @@ def test_no_sklearn(mock_no_sklearn):
 def test_no_update():
     roc_auc = ROC_AUC()
 
-    with pytest.raises(
-        NotComputableError, match=r"EpochMetric must have at least one example before it can be computed"
-    ):
+    with pytest.raises(NotComputableError, match=r"ROC_AUC must have at least one example before it can be computed"):
         roc_auc.compute()
 
 


### PR DESCRIPTION
Fixes #3701

  ## Description:
  Remove scikit-learn dependency from `CohenKappa` by implementing a native PyTorch version.

  - Replaced `sklearn.metrics.cohen_kappa_score` with a pure PyTorch implementation
  - Removed forced GPU→CPU transfer (`.cpu().numpy()`) — metric now runs fully on the configured device
  - Built confusion matrix with `torch.bincount` (single vectorised kernel) instead of a Python loop
  - Used `float64` throughout to match sklearn's numerical precision
  - Added explicit multilabel input validation (previously handled implicitly by sklearn
  
Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
