### PR TITLE
Use Ruff formatter in devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,16 +6,14 @@
     "vscode": {
       "extensions": [
         "ms-python.python",
-        "charliermarsh.ruff",
-        "ms-python.black-formatter"
+        "astral-sh.ruff"
       ],
       "settings": {
         "editor.formatOnSave": true,
         "python.testing.pytestEnabled": true,
         "[python]": {
-          "editor.defaultFormatter": "ms-python.black-formatter"
+          "editor.defaultFormatter": "astral-sh.ruff"
         },
-        "black-formatter.args": ["--line-length", "120"],
         "editor.rulers": [80, 120]
       }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,7 @@
   "postCreateCommand": "pip install -e . && pip install -r requirements-dev.txt && pre-commit install",
   "customizations": {
     "vscode": {
-      "extensions": [
-        "ms-python.python",
-        "charliermarsh.ruff"
-      ],
+      "extensions": ["ms-python.python", "charliermarsh.ruff"],
       "settings": {
         "editor.formatOnSave": true,
         "python.testing.pytestEnabled": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,13 @@
     "vscode": {
       "extensions": [
         "ms-python.python",
-        "astral-sh.ruff"
+        "charliermarsh.ruff"
       ],
       "settings": {
         "editor.formatOnSave": true,
         "python.testing.pytestEnabled": true,
         "[python]": {
-          "editor.defaultFormatter": "astral-sh.ruff"
+          "editor.defaultFormatter": "charliermarsh.ruff"
         },
         "editor.rulers": [80, 120]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,9 +175,8 @@ pre-commit install
 git add .
 git commit -m "Added awesome feature"
 # DONT'T WORRY IF ERRORS ARE RAISED.
-# YOUR CODE IS NOT COMPLIANT WITH flake8, µsort or ruff format
-# Fix any flake8 errors by following their suggestions
-# µfmt will automatically format the files so they might look different, but you'll need to stage the files
+# YOUR CODE IS NOT COMPLIANT WITH ruff format
+# Fix any errors by following their suggestions
 # again for committing
 # After fixing any flake8 errors
 git add .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,9 @@ please run lint checking and tests:
 
 #### Checking Code Style
 
-To ensure the codebase complies with the PEP8 style guide, we use [ruff](https://docs.astral.sh/ruff/)
-and [black](https://black.readthedocs.io/en/stable/) to lint and format the codebase respectively.
+To ensure the codebase complies with the PEP8 style guide, we use
+[ruff](https://docs.astral.sh/ruff/) and
+[ruff format](https://docs.astral.sh/ruff/formatter/) to lint and format the codebase respectively.
 
 ##### Formatting the code
 
@@ -176,7 +177,7 @@ pre-commit install
 git add .
 git commit -m "Added awesome feature"
 # DONT'T WORRY IF ERRORS ARE RAISED.
-# YOUR CODE IS NOT COMPLIANT WITH flake8, µsort or black
+# YOUR CODE IS NOT COMPLIANT WITH flake8, µsort or ruff format
 # Fix any flake8 errors by following their suggestions
 # µfmt will automatically format the files so they might look different, but you'll need to stage the files
 # again for committing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,7 @@ please run lint checking and tests:
 
 #### Checking Code Style
 
-To ensure the codebase complies with the PEP8 style guide, we use
-[ruff](https://docs.astral.sh/ruff/) and
-[ruff format](https://docs.astral.sh/ruff/formatter/) to lint and format the codebase respectively.
+To ensure the codebase complies with the PEP8 style guide, we use [ruff](https://docs.astral.sh/ruff/) to lint and [ruff format](https://docs.astral.sh/ruff/formatter/) to format the codebase.
 
 ##### Formatting the code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,31 +123,6 @@ docstring-code-format = false
 # enabled.
 docstring-code-line-length = "dynamic"
 
-[tool.black]
-line-length = 120
-target-version = ['py311', 'py313']
-include = '\.pyi?$'
-exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-    | assets
-  )/
-  | foo.py           # also separately exclude a file named foo.py in
-                     # the root of the project
-)
-'''
-
 [tool.pytest.ini_options]
 markers = [
     "distributed: mark a test with distributed option",


### PR DESCRIPTION
Fixes #3736

Description:
- Replace `ms-python.black-formatter` with `astral-sh.ruff` in `.devcontainer/devcontainer.json`
- Set Ruff as the default formatter for Python files in VS Code devcontainer settings
- Remove the remaining Black-specific formatter configuration

Check list:
- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)

