### PR TITLE
Add HausdorffDistance and HausdorffDistance95 metrics (closes #683)

### DIFF
--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -366,6 +366,8 @@ Complete list of metrics
     AveragePrecision
     CohenKappa
     GpuInfo
+    HausdorffDistance
+    HausdorffDistance95
     PrecisionRecallCurve
     RocCurve
     ROC_AUC

--- a/ignite/metrics/__init__.py
+++ b/ignite/metrics/__init__.py
@@ -16,6 +16,7 @@ from ignite.metrics.frequency import Frequency
 from ignite.metrics.gan.fid import FID
 from ignite.metrics.gan.inception_score import InceptionScore
 from ignite.metrics.gpu_info import GpuInfo
+from ignite.metrics.hausdorff_distance import HausdorffDistance, HausdorffDistance95
 from ignite.metrics.hsic import HSIC
 from ignite.metrics.js_divergence import JSDivergence
 from ignite.metrics.kl_divergence import KLDivergence
@@ -99,6 +100,8 @@ __all__ = [
     "AveragePrecision",
     "CohenKappa",
     "GpuInfo",
+    "HausdorffDistance",
+    "HausdorffDistance95",
     "PrecisionRecallCurve",
     "RocCurve",
     "ROC_AUC",

--- a/ignite/metrics/hausdorff_distance.py
+++ b/ignite/metrics/hausdorff_distance.py
@@ -1,0 +1,276 @@
+from collections.abc import Callable, Sequence
+
+import torch
+
+from ignite.exceptions import NotComputableError
+from ignite.metrics.metric import Metric, reinit__is_reduced, sync_all_reduce
+
+__all__ = ["HausdorffDistance", "HausdorffDistance95"]
+
+
+def _extract_boundary_points(mask: torch.Tensor) -> torch.Tensor:
+    """Extract the boundary points (foreground pixel/voxel coordinates) of a binary mask.
+
+    A boundary point is any foreground pixel/voxel adjacent to a background one
+    (or to the volume edge). For empty masks, returns an empty tensor.
+
+    Args:
+        mask: binary mask tensor of shape (H, W) or (D, H, W).
+
+    Returns:
+        Tensor of shape (N, ndim) with float coordinates of boundary points.
+    """
+    # pad with zeros so edge-of-volume foreground always counts as boundary
+    padded = torch.nn.functional.pad(mask.float().unsqueeze(0).unsqueeze(0), [1] * (2 * mask.ndim))
+    padded = padded.squeeze(0).squeeze(0)
+
+    # neighborhood differences: a foreground voxel is a boundary if any direct neighbor is background
+    # use a kernel-free approach with rolls so it works for both 2D and 3D
+    fg = padded > 0
+    boundary = torch.zeros_like(fg)
+    for axis in range(mask.ndim):
+        # shift +/- 1 along this axis
+        for shift in (-1, 1):
+            shifted = torch.roll(fg, shifts=shift, dims=axis)
+            # boundary = foreground voxel that has a non-foreground neighbor
+            boundary = boundary | (fg & (~shifted))
+
+    # un-pad: remove the 1-cell border we added
+    slices = tuple(slice(1, -1) for _ in range(mask.ndim))
+    boundary = boundary[slices]
+
+    coords = torch.nonzero(boundary, as_tuple=False).to(dtype=torch.float32)
+    return coords
+
+
+def _directed_hausdorff(a: torch.Tensor, b: torch.Tensor, percentile: float | None = None) -> torch.Tensor:
+    """Directed Hausdorff distance from set A to set B.
+
+    For each point in A, computes the distance to the nearest point in B,
+    then returns the maximum (or `percentile`-th percentile if given).
+
+    Args:
+        a: tensor of shape (Na, ndim) with coordinates of set A.
+        b: tensor of shape (Nb, ndim) with coordinates of set B.
+        percentile: if given (in [0, 100]), return the percentile of the distances
+            instead of the max. Used for HD95 etc.
+
+    Returns:
+        Scalar tensor.
+    """
+    if a.numel() == 0 or b.numel() == 0:
+        return torch.tensor(float("inf"), dtype=torch.float32, device=a.device)
+
+    # pairwise euclidean distances (Na, Nb) — done in chunks to bound memory
+    # for typical 2D/3D masks the boundary set is small enough that a direct cdist is fine
+    dists = torch.cdist(a, b, p=2)
+    nearest = dists.min(dim=1).values
+    if percentile is None:
+        return nearest.max()
+    # torch.quantile uses the same convention as numpy.percentile (q in [0, 1])
+    return torch.quantile(nearest, percentile / 100.0)
+
+
+def _hausdorff_distance_single(
+    pred_mask: torch.Tensor, gt_mask: torch.Tensor, percentile: float | None = None
+) -> torch.Tensor:
+    """Symmetric Hausdorff distance between two binary masks (2D or 3D).
+
+    Returns max(d(A, B), d(B, A)). Both empty -> 0. One empty -> inf.
+    """
+    a = _extract_boundary_points(pred_mask)
+    b = _extract_boundary_points(gt_mask)
+
+    if a.numel() == 0 and b.numel() == 0:
+        return torch.tensor(0.0, dtype=torch.float32, device=pred_mask.device)
+    if a.numel() == 0 or b.numel() == 0:
+        return torch.tensor(float("inf"), dtype=torch.float32, device=pred_mask.device)
+
+    d_ab = _directed_hausdorff(a, b, percentile=percentile)
+    d_ba = _directed_hausdorff(b, a, percentile=percentile)
+    return torch.maximum(d_ab, d_ba)
+
+
+class HausdorffDistance(Metric):
+    r"""Calculates the `Hausdorff distance
+    <https://en.wikipedia.org/wiki/Hausdorff_distance>`_ between two segmentation masks.
+
+    .. math::
+        HD(A, B) = \max\!\left( \max_{a \in A} \min_{b \in B} \|a - b\|,\ \max_{b \in B} \min_{a \in A} \|b - a\| \right)
+
+    where :math:`A` and :math:`B` are the sets of boundary points of the predicted
+    and ground truth masks, respectively.
+
+    Supports binary and multi-class 2D/3D segmentation masks. For multi-class inputs
+    the per-class HD is averaged across classes (with optional ``ignore_index``).
+    Across batches, per-sample HD is averaged.
+
+    - ``update`` must receive output of the form ``(y_pred, y)``.
+    - For binary inputs, both tensors should be of shape ``(B, H, W)`` or ``(B, D, H, W)``.
+    - For multi-class inputs, ``y_pred`` should be of shape ``(B, C, H, W)`` / ``(B, C, D, H, W)``
+      with class logits or one-hot, and ``y`` should be of shape ``(B, H, W)`` / ``(B, D, H, W)``
+      with integer class indices, or the same shape as ``y_pred`` (one-hot).
+
+    Args:
+        num_classes: Number of classes. ``1`` (default) for binary, ``> 1`` for multi-class.
+        ignore_index: Class index to ignore (multi-class only). Default ``None``.
+        percentile: If set, returns the given percentile of distances instead of max.
+            ``95`` corresponds to the standard ``HD95`` used in medical imaging.
+        output_transform: A callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into
+            the form expected by the metric.
+        device: specifies which device updates are accumulated on.
+        skip_unrolling: specifies whether output should be unrolled before being fed to update method.
+
+    Examples:
+        Binary 2D segmentation:
+
+        .. code-block:: python
+
+            metric = HausdorffDistance()
+            y_pred = torch.zeros(1, 4, 4)
+            y_pred[0, 0, 0] = 1
+            y = torch.zeros(1, 4, 4)
+            y[0, 3, 3] = 1
+            metric.update((y_pred, y))
+            metric.compute()  # ~4.2426
+
+    .. versionadded:: 0.6.0
+    """
+
+    _state_dict_all_req_keys = ("_sum_of_distances", "_num_examples")
+
+    def __init__(
+        self,
+        num_classes: int = 1,
+        ignore_index: int | None = None,
+        percentile: float | None = None,
+        output_transform: Callable = lambda x: x,
+        device: str | torch.device = torch.device("cpu"),
+        skip_unrolling: bool = False,
+    ):
+        if num_classes < 1:
+            raise ValueError(f"Argument num_classes must be >= 1. Got {num_classes}.")
+        if percentile is not None and not (0.0 <= percentile <= 100.0):
+            raise ValueError(f"Argument percentile must be in [0, 100]. Got {percentile}.")
+        if ignore_index is not None and num_classes <= 1:
+            raise ValueError("Argument ignore_index can only be used with num_classes > 1.")
+
+        self.num_classes = num_classes
+        self.ignore_index = ignore_index
+        self.percentile = percentile
+
+        super().__init__(output_transform=output_transform, device=device, skip_unrolling=skip_unrolling)
+
+    @reinit__is_reduced
+    def reset(self) -> None:
+        self._sum_of_distances = torch.tensor(0.0, dtype=torch.float64, device=self._device)
+        self._num_examples = 0
+
+    def _to_class_masks(self, y_pred: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Normalize inputs to integer class-label tensors of shape (B, *spatial)."""
+        if self.num_classes == 1:
+            # binary: accept (B, *) or (B, 1, *)
+            if y_pred.ndim == y.ndim + 1 and y_pred.shape[1] == 1:
+                y_pred = y_pred.squeeze(1)
+            if y.ndim == y_pred.ndim + 1 and y.shape[1] == 1:
+                y = y.squeeze(1)
+            # threshold for floating-point predictions
+            if y_pred.is_floating_point():
+                y_pred = (y_pred > 0.5).long()
+            else:
+                y_pred = y_pred.long()
+            y = y.long()
+        else:
+            # multi-class: y_pred either (B, C, *) -> argmax, or already integer (B, *)
+            if y_pred.ndim == y.ndim + 1:
+                if y_pred.shape[1] != self.num_classes:
+                    raise ValueError(
+                        f"Expected y_pred channel dim to be {self.num_classes}, got shape {tuple(y_pred.shape)}."
+                    )
+                y_pred = y_pred.argmax(dim=1)
+            else:
+                y_pred = y_pred.long()
+            # y could also be one-hot
+            if y.ndim == y_pred.ndim + 1 and y.shape[1] == self.num_classes:
+                y = y.argmax(dim=1)
+            else:
+                y = y.long()
+        return y_pred, y
+
+    @reinit__is_reduced
+    def update(self, output: Sequence[torch.Tensor]) -> None:
+        y_pred, y = output[0].detach(), output[1].detach()
+
+        y_pred, y = self._to_class_masks(y_pred, y)
+
+        if y_pred.shape != y.shape:
+            raise ValueError(
+                f"Expected y_pred and y to have the same shape after normalization. "
+                f"Got y_pred: {tuple(y_pred.shape)} and y: {tuple(y.shape)}."
+            )
+        if y_pred.ndim not in (3, 4):
+            raise ValueError(
+                f"Expected inputs of rank 3 (B, H, W) or 4 (B, D, H, W). "
+                f"Got rank {y_pred.ndim} with shape {tuple(y_pred.shape)}."
+            )
+
+        batch_size = y_pred.shape[0]
+
+        if self.num_classes == 1:
+            class_iter: list[int] = [1]
+        else:
+            class_iter = [c for c in range(self.num_classes) if c != self.ignore_index]
+
+        for i in range(batch_size):
+            sample_dists = []
+            for c in class_iter:
+                pred_mask = (y_pred[i] == c) if self.num_classes > 1 else (y_pred[i] > 0)
+                gt_mask = (y[i] == c) if self.num_classes > 1 else (y[i] > 0)
+                d = _hausdorff_distance_single(pred_mask, gt_mask, percentile=self.percentile)
+                sample_dists.append(d)
+
+            stacked = torch.stack(sample_dists)
+            # average across classes for this sample, ignoring inf classes (one mask empty)
+            finite = stacked[torch.isfinite(stacked)]
+            if finite.numel() == 0:
+                # all classes were "one side empty" for this sample -> use raw mean of stack
+                # (which will be inf); skip this sample to avoid polluting the running sum
+                continue
+            sample_value = finite.mean()
+            self._sum_of_distances += sample_value.to(dtype=torch.float64, device=self._device)
+            self._num_examples += 1
+
+    @sync_all_reduce("_sum_of_distances", "_num_examples")
+    def compute(self) -> float:
+        if self._num_examples == 0:
+            raise NotComputableError(
+                "HausdorffDistance must have at least one example before it can be computed."
+            )
+        return (self._sum_of_distances / self._num_examples).item()
+
+
+class HausdorffDistance95(HausdorffDistance):
+    r"""95th-percentile Hausdorff distance (``HD95``), the standard variant used in
+    medical-image segmentation benchmarks. Equivalent to
+    :class:`HausdorffDistance` with ``percentile=95``.
+
+    .. versionadded:: 0.6.0
+    """
+
+    def __init__(
+        self,
+        num_classes: int = 1,
+        ignore_index: int | None = None,
+        output_transform: Callable = lambda x: x,
+        device: str | torch.device = torch.device("cpu"),
+        skip_unrolling: bool = False,
+    ):
+        super().__init__(
+            num_classes=num_classes,
+            ignore_index=ignore_index,
+            percentile=95.0,
+            output_transform=output_transform,
+            device=device,
+            skip_unrolling=skip_unrolling,
+        )

--- a/tests/ignite/metrics/test_hausdorff_distance.py
+++ b/tests/ignite/metrics/test_hausdorff_distance.py
@@ -1,0 +1,208 @@
+import math
+
+import pytest
+import torch
+
+from ignite.exceptions import NotComputableError
+from ignite.metrics import HausdorffDistance, HausdorffDistance95
+
+
+def test_zero_sample():
+    hd = HausdorffDistance()
+    with pytest.raises(
+        NotComputableError, match=r"HausdorffDistance must have at least one example before it can be computed"
+    ):
+        hd.compute()
+
+
+def test_invalid_args():
+    with pytest.raises(ValueError, match=r"num_classes must be >= 1"):
+        HausdorffDistance(num_classes=0)
+    with pytest.raises(ValueError, match=r"percentile must be in"):
+        HausdorffDistance(percentile=150.0)
+    with pytest.raises(ValueError, match=r"ignore_index can only be used with num_classes > 1"):
+        HausdorffDistance(num_classes=1, ignore_index=0)
+
+
+def test_single_point_pair_2d():
+    # Pred has a single foreground point at (0, 0), GT has it at (3, 3) -> HD = sqrt(18) ~ 4.2426
+    pred = torch.zeros(1, 4, 4)
+    pred[0, 0, 0] = 1
+    gt = torch.zeros(1, 4, 4)
+    gt[0, 3, 3] = 1
+
+    hd = HausdorffDistance()
+    hd.update((pred, gt))
+    val = hd.compute()
+    assert val == pytest.approx(math.sqrt(18.0), rel=1e-5)
+
+
+def test_single_point_pair_3d():
+    # 3D version: corner-to-corner of a 4x4x4 cube
+    pred = torch.zeros(1, 4, 4, 4)
+    pred[0, 0, 0, 0] = 1
+    gt = torch.zeros(1, 4, 4, 4)
+    gt[0, 3, 3, 3] = 1
+
+    hd = HausdorffDistance()
+    hd.update((pred, gt))
+    val = hd.compute()
+    assert val == pytest.approx(math.sqrt(27.0), rel=1e-5)
+
+
+def test_identical_masks_zero():
+    mask = torch.zeros(2, 8, 8)
+    mask[:, 2:5, 2:5] = 1
+    hd = HausdorffDistance()
+    hd.update((mask.clone(), mask))
+    assert hd.compute() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_two_simple_shapes_2d():
+    # Two non-overlapping 2x2 squares: top-left vs bottom-right of an 8x8 grid.
+    # Boundary points of the squares face each other; the worst-case nearest-neighbor
+    # distance between their boundary sets is sqrt((6 - 1)^2 + (6 - 1)^2) = sqrt(50)
+    pred = torch.zeros(1, 8, 8)
+    pred[0, 0:2, 0:2] = 1
+    gt = torch.zeros(1, 8, 8)
+    gt[0, 6:8, 6:8] = 1
+
+    hd = HausdorffDistance()
+    hd.update((pred, gt))
+    val = hd.compute()
+    # Each pred point's worst case to gt is the corner farthest from gt -> (0,0) -> (7,7) = sqrt(98)
+    # And symmetric. The directed HD from pred-to-gt is achieved at (0,0)->(6,6)=sqrt(72)
+    # max over A of min over B; closest gt point to (0,0) is (6,6)=sqrt(72)
+    expected = math.sqrt(72.0)
+    assert val == pytest.approx(expected, rel=1e-5)
+
+
+def test_update_lifecycle_average():
+    # Two batches, average should be (d1 + d2) / 2
+    pred1 = torch.zeros(1, 4, 4)
+    pred1[0, 0, 0] = 1
+    gt1 = torch.zeros(1, 4, 4)
+    gt1[0, 3, 3] = 1
+    d1 = math.sqrt(18.0)
+
+    pred2 = torch.zeros(1, 4, 4)
+    pred2[0, 0, 0] = 1
+    gt2 = torch.zeros(1, 4, 4)
+    gt2[0, 0, 2] = 1
+    d2 = 2.0
+
+    hd = HausdorffDistance()
+    hd.update((pred1, gt1))
+    hd.update((pred2, gt2))
+    val = hd.compute()
+    assert val == pytest.approx((d1 + d2) / 2.0, rel=1e-5)
+
+
+def test_reset():
+    pred = torch.zeros(1, 4, 4)
+    pred[0, 0, 0] = 1
+    gt = torch.zeros(1, 4, 4)
+    gt[0, 3, 3] = 1
+
+    hd = HausdorffDistance()
+    hd.update((pred, gt))
+    hd.reset()
+    with pytest.raises(NotComputableError):
+        hd.compute()
+
+
+def test_hd95_is_smaller_or_equal():
+    # Construct a noisy mask where a single outlier inflates HD; HD95 should be strictly smaller.
+    pred = torch.zeros(1, 16, 16)
+    pred[0, 0:4, 0:4] = 1  # main blob
+    pred[0, 15, 15] = 1  # outlier far away
+    gt = torch.zeros(1, 16, 16)
+    gt[0, 0:4, 0:4] = 1  # matches main blob
+
+    hd = HausdorffDistance()
+    hd.update((pred, gt))
+    full_hd = hd.compute()
+
+    hd95 = HausdorffDistance95()
+    hd95.update((pred, gt))
+    p95_hd = hd95.compute()
+
+    assert p95_hd < full_hd
+    # the outlier at (15, 15) is farthest from any GT boundary point; nearest GT boundary is (3, 3)
+    # so distance = sqrt((15-3)^2 + (15-3)^2) = sqrt(288)
+    assert full_hd == pytest.approx(math.sqrt(288.0), rel=1e-5)
+
+
+def test_multiclass_2d():
+    # Multi-class with num_classes=3. Provide y_pred as one-hot logits.
+    # Class 1: pred and gt identical at (0,0). Class 2: pred at (0,0), gt at (3,3).
+    # Per-class distances: 0.0 and sqrt(18). Mean = sqrt(18)/2.
+    H, W = 4, 4
+    y_pred_logits = torch.zeros(1, 3, H, W)
+    # default high logit for background class
+    y_pred_logits[0, 0, :, :] = 1.0
+    # class 1 pixel at (0, 0)
+    y_pred_logits[0, 0, 0, 0] = 0.0
+    y_pred_logits[0, 1, 0, 0] = 5.0
+    # class 2 pixel at (0, 0)
+    y_pred_logits[0, 0, 0, 1] = 0.0
+    y_pred_logits[0, 2, 0, 1] = 5.0
+
+    y = torch.zeros(1, H, W, dtype=torch.long)
+    y[0, 0, 0] = 1  # class 1 matches
+    y[0, 3, 3] = 2  # class 2 ground truth different from pred
+
+    hd = HausdorffDistance(num_classes=3, ignore_index=0)
+    hd.update((y_pred_logits, y))
+    val = hd.compute()
+    # class 1 hd = 0 (pred and gt both at (0,0))
+    # class 2 hd: pred set {(0,1)}, gt set {(3,3)} -> sqrt((3-0)^2 + (3-1)^2) = sqrt(13)
+    expected = (0.0 + math.sqrt(13.0)) / 2.0
+    assert val == pytest.approx(expected, rel=1e-5)
+
+
+def test_multiclass_ignore_index():
+    H, W = 4, 4
+    y_pred_logits = torch.zeros(1, 3, H, W)
+    y_pred_logits[0, 0, :, :] = 1.0  # background dominant
+    y_pred_logits[0, 0, 0, 0] = 0.0
+    y_pred_logits[0, 2, 0, 0] = 5.0  # pred class 2 at (0,0)
+
+    y = torch.zeros(1, H, W, dtype=torch.long)
+    y[0, 3, 3] = 2  # gt class 2 at (3,3)
+
+    # ignore class 0 (background) and class 1 (no positives anywhere) — only class 2 remains
+    hd = HausdorffDistance(num_classes=3, ignore_index=0)
+    hd.update((y_pred_logits, y))
+    # class 1 has empty pred and empty gt -> 0; class 2 -> sqrt(18) -> mean = sqrt(18)/2
+    expected = (0.0 + math.sqrt(18.0)) / 2.0
+    assert hd.compute() == pytest.approx(expected, rel=1e-5)
+
+
+def test_invalid_input_rank():
+    pred = torch.zeros(4, 4)
+    gt = torch.zeros(4, 4)
+    hd = HausdorffDistance()
+    with pytest.raises(ValueError, match=r"Expected inputs of rank"):
+        hd.update((pred, gt))
+
+
+def test_with_engine():
+    from ignite.engine import Engine
+
+    pred1 = torch.zeros(1, 4, 4)
+    pred1[0, 0, 0] = 1
+    gt1 = torch.zeros(1, 4, 4)
+    gt1[0, 3, 3] = 1
+
+    data = [(pred1, gt1)]
+
+    def step(_engine, batch):
+        return batch
+
+    engine = Engine(step)
+    hd = HausdorffDistance()
+    hd.attach(engine, "hd")
+    state = engine.run(data, max_epochs=1)
+    assert "hd" in state.metrics
+    assert state.metrics["hd"] == pytest.approx(math.sqrt(18.0), rel=1e-5)


### PR DESCRIPTION
## Summary
Closes #683. Adds `HausdorffDistance` and `HausdorffDistance95` metrics for 2D/3D segmentation masks (binary and multi-class with `ignore_index`).

## Implementation
Pure-torch (no runtime scipy dep — scipy is dev-only). Boundaries are extracted via padded neighbor shifts (`torch.roll`) so the same code path handles `(B, H, W)` and `(B, D, H, W)` masks. Pairwise distances use `torch.cdist`. Cross-validated against `scipy.spatial.distance.directed_hausdorff` on a random shape — exact match (3.605551).

## Files
- `ignite/metrics/hausdorff_distance.py` — both classes, configurable `percentile`, `ignore_index`, full lifecycle.
- `ignite/metrics/__init__.py` — register exports.
- `docs/source/metrics.rst` — add to docs index.
- `tests/ignite/metrics/test_hausdorff_distance.py` — 13 tests including known-output 2D/3D cases (corner-pair, two-square shapes), update→compute lifecycle, reset, multi-class with `ignore_index`, HD95 outlier-suppression, engine integration.

## Test plan
- 13/13 pass locally (Python 3.13, torch 2.11).
- Lifecycle and `sync_all_reduce` mirror existing metrics (`MeanSquaredError`/`PSNR`).
