### PR TITLE
Installing conda-build in base to fix failing nightly release

### DIFF
--- a/conda.recipe/build_and_upload.sh
+++ b/conda.recipe/build_and_upload.sh
@@ -25,7 +25,7 @@ version=$(sed -nE 's/__version__ = "(.*)"/\1/p' ignite/__init__.py)
 sed -i "s/__version__ = \"\(.*\)\"/__version__ = \"$version\"/g" conda.recipe/meta.yaml
 cat conda.recipe/meta.yaml | grep version
 
-conda install -y conda-build anaconda-client conda-package-handling
+conda install -n base -y conda-build anaconda-client conda-package-handling
 conda config --set anaconda_upload no
 
 conda build --no-test --output-folder conda_build conda.recipe -c pytorch --package-format 1


### PR DESCRIPTION
Description:

The failure was triggered by an update to Conda (version **26.3.1+**). As noted in the [Conda Release Notes](https://github.com/conda/conda/releases/tag/26.3.1), the following change was introduced:
> * **Deprecation: No longer search for `conda-*` executables on `PATH` when building the CLI parser.**

Previously, the script installed `conda-build` into the active sub-environment. Since that sub-environment was on the `PATH`, Conda could find the `conda-build` executable and register the `build` command. With the new version, Conda ignores the `PATH` and only looks for plugins registered in the **base** environment.

#### **Solution**
Updated `conda.recipe/build_and_upload.sh` to explicitly install build dependencies into the `base` environment using the `-n base` flag. This ensures that the `build` command is correctly registered as a plugin for the main `conda` executable.

#### **Reproduction Steps**

I verified this fix locally by reproducing the failure on Conda `26.3.2` using these steps:

**1. Reproduce the Failure:**
```bash
# Ensure local conda is 26.3.2+
conda install -n base -y conda=26.3.2

# Ensure base is clean of build tools
conda remove -n base -y conda-build

# Install tools ONLY in a sub-environment
conda create -y -n reproduce_failure
conda install -y -n reproduce_failure conda-build

# Try to run build from the sub-environment
conda activate reproduce_failure
conda build --version

# RESULT: Fails with "invalid choice: 'build'"
```

**2. Verify the Fix:**
```bash
# Install tools into the base environment
conda install -y -n base conda-build

# Try again from the sub-environment
conda activate reproduce_failure
conda build --version

# RESULT: Success! (Prints conda-build version)
```

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
