### PR TITLE
docs: add warmup scheduler mixed-events example

### DIFF
--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -1139,16 +1139,17 @@ def create_lr_scheduler_with_warmup(
             trainer = Engine(lambda engine, batch: None)
             optimizer = SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
             torch_lr_scheduler = ExponentialLR(optimizer, gamma=0.5)
+            warmup_duration = 5
             scheduler = create_lr_scheduler_with_warmup(
-                torch_lr_scheduler, warmup_start_value=0.0, warmup_duration=5
+                torch_lr_scheduler, warmup_start_value=0.0, warmup_duration=warmup_duration
             )
 
             epoch_length = 8
             combined_events = Events.ITERATION_STARTED(
-                event_filter=lambda engine, event: engine.state.iteration <= 5
+                event_filter=lambda engine, event: event <= warmup_duration
             )
             combined_events |= Events.EPOCH_STARTED(
-                event_filter=lambda engine, event: engine.state.epoch > 1 + 5 / epoch_length
+                event_filter=lambda engine, event: event > 1 + warmup_duration / epoch_length
             )
             trainer.add_event_handler(combined_events, scheduler)
 

--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -1125,6 +1125,33 @@ def create_lr_scheduler_with_warmup(
             0.09223...
             0.09039...
 
+        The warm-up and post-warm-up schedulers can also be attached to different events by combining event filters.
+        For example, run the warm-up on iterations and the wrapped scheduler at the start of each later epoch:
+
+        .. code-block:: python
+
+            import torch
+            from ignite.engine import Engine, Events
+            from ignite.handlers import create_lr_scheduler_with_warmup
+            from torch.optim import SGD
+            from torch.optim.lr_scheduler import ExponentialLR
+
+            trainer = Engine(lambda engine, batch: None)
+            optimizer = SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
+            torch_lr_scheduler = ExponentialLR(optimizer, gamma=0.5)
+            scheduler = create_lr_scheduler_with_warmup(
+                torch_lr_scheduler, warmup_start_value=0.0, warmup_duration=5
+            )
+
+            epoch_length = 8
+            combined_events = Events.ITERATION_STARTED(
+                event_filter=lambda engine, event: engine.state.iteration <= 5
+            )
+            combined_events |= Events.EPOCH_STARTED(
+                event_filter=lambda engine, event: engine.state.epoch > 1 + 5 / epoch_length
+            )
+            trainer.add_event_handler(combined_events, scheduler)
+
     .. versionadded:: 0.4.5
     """
     if not isinstance(lr_scheduler, (ParamScheduler, PyTorchLRScheduler)):


### PR DESCRIPTION
Fixes #2441

Description:

Adds a docstring example showing how to combine Ignite event filters so warm-up runs on iteration starts and the wrapped scheduler runs on later epoch starts.

Check list:

- [ ] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)