### PR TITLE
ci: declare workflow-level `contents: read` on 8 workflows

### DIFF
--- a/.github/workflows/code-style-checks.yml
+++ b/.github/workflows/code-style-checks.yml
@@ -38,6 +38,9 @@ concurrency:
   group: code-style-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   code-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/gpu-hvd-tests.yml
+++ b/.github/workflows/gpu-hvd-tests.yml
@@ -17,6 +17,9 @@ concurrency:
 
 # Cherry-picked from https://github.com/pytorch/test-infra/blob/main/.github/workflows/linux_job.yml
 
+permissions:
+  contents: read
+
 jobs:
   gpu-hvd-tests:
     strategy:

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -17,6 +17,9 @@ concurrency:
 
 # Cherry-picked from https://github.com/pytorch/test-infra/blob/main/.github/workflows/linux_job_v2.yml
 
+permissions:
+  contents: read
+
 jobs:
   gpu-tests:
     strategy:

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -23,6 +23,9 @@ concurrency:
   group: hvd-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   horovod-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/mps-tests.yml
+++ b/.github/workflows/mps-tests.yml
@@ -29,6 +29,9 @@ concurrency:
 # - https://github.com/pytorch/vision/blob/main/.github/workflows/tests.yml
 # - https://github.com/pytorch/test-infra/blob/main/.github/workflows/macos_job.yml
 
+permissions:
+  contents: read
+
 jobs:
   mps-tests:
     strategy:

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -24,6 +24,9 @@ concurrency:
   group: tpu-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tpu-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/typing-checks.yml
+++ b/.github/workflows/typing-checks.yml
@@ -30,6 +30,9 @@ concurrency:
   group: typing-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pyrefly:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,9 @@ concurrency:
   group: unit-tests-${{ github.ref_name }}-${{ !(github.ref_protected) || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cpu-tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 8 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `docker-build.yml`, `pytorch-version-tests.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.