### PR TITLE
Add pathlib Path support to idist broadcast

### DIFF
--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -122,6 +122,8 @@ class ComputationModel(metaclass=ABCMeta):
         elif isinstance(x, str):
             encoded_msg[0] = 2
         elif isinstance(x, Path):
+            # Keep a distinct tag so non-source ranks in safe mode can reconstruct
+            # Path placeholders and return Path values rather than strings.
             encoded_msg[0] = 3
         return encoded_msg
 

--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
 from numbers import Number
+from pathlib import Path
 from typing import Any, cast
 
 import torch
@@ -105,7 +106,7 @@ class ComputationModel(metaclass=ABCMeta):
         return cast(int, size.item())
 
     @staticmethod
-    def _encode_input_data(x: torch.Tensor | float | str | None, is_src: bool) -> list[int]:
+    def _encode_input_data(x: torch.Tensor | float | str | Path | None, is_src: bool) -> list[int]:
         encoded_msg = [-1] * 512
         if not is_src:
             # Discard input type if not source
@@ -120,10 +121,12 @@ class ComputationModel(metaclass=ABCMeta):
             encoded_msg[0] = 1
         elif isinstance(x, str):
             encoded_msg[0] = 2
+        elif isinstance(x, Path):
+            encoded_msg[0] = 3
         return encoded_msg
 
     @staticmethod
-    def _decode_as_placeholder(encoded_msg: list[int], device: torch.device) -> torch.Tensor | float | str:
+    def _decode_as_placeholder(encoded_msg: list[int], device: torch.device) -> torch.Tensor | float | str | Path:
         if encoded_msg[0] == 0:
             len_shape = encoded_msg[1]
             le = 2 + len_shape
@@ -136,12 +139,14 @@ class ComputationModel(metaclass=ABCMeta):
             return 0.0
         elif encoded_msg[0] == 2:
             return ""
+        elif encoded_msg[0] == 3:
+            return Path("")
         else:
             raise RuntimeError(f"Internal error: unhandled dtype {encoded_msg[0]}, encoded_msg={encoded_msg}")
 
     def _setup_placeholder(
-        self, x: torch.Tensor | float | str | None, device: torch.device, is_src: bool
-    ) -> torch.Tensor | float | str:
+        self, x: torch.Tensor | float | str | Path | None, device: torch.device, is_src: bool
+    ) -> torch.Tensor | float | str | Path:
         encoded_msg_per_rank = self._encode_input_data(x, is_src)
         encoded_msg_all_ranks = self._do_all_reduce(torch.tensor(encoded_msg_per_rank, device=device), op="MAX")
 
@@ -233,9 +238,9 @@ class ComputationModel(metaclass=ABCMeta):
             raise ValueError("Argument ranks should be list of int")
 
     def broadcast(
-        self, tensor: torch.Tensor | float | str | None, src: int = 0, safe_mode: bool = False
-    ) -> torch.Tensor | float | str:
-        if not (isinstance(tensor, (torch.Tensor, Number, str)) or tensor is None):
+        self, tensor: torch.Tensor | float | str | Path | None, src: int = 0, safe_mode: bool = False
+    ) -> torch.Tensor | float | str | Path:
+        if not (isinstance(tensor, (torch.Tensor, Number, str, Path)) or tensor is None):
             raise TypeError(f"Unhandled input type {type(tensor)}")
 
         rank = self.get_rank()
@@ -246,7 +251,7 @@ class ComputationModel(metaclass=ABCMeta):
                 raise ValueError("Argument safe_mode should be True if None is passed for non src rank")
 
         device = self.device()
-        tensor_to_number = tensor_to_str = False
+        tensor_to_number = tensor_to_str = tensor_to_path = False
 
         if safe_mode:
             tensor = self._setup_placeholder(tensor, device, rank == src)
@@ -260,13 +265,15 @@ class ComputationModel(metaclass=ABCMeta):
                 tensor = torch.empty(1, device=device, dtype=torch.float)
             else:
                 tensor = torch.tensor([tensor], device=device, dtype=torch.float)
-        elif isinstance(tensor, str):
-            tensor_to_str = True
-            max_length = self._get_max_length(tensor, device)
+        elif isinstance(tensor, (str, Path)):
+            tensor_to_str = isinstance(tensor, str)
+            tensor_to_path = isinstance(tensor, Path)
+            tensor_str = str(tensor)
+            max_length = self._get_max_length(tensor_str, device)
             if rank != src:
                 tensor = torch.empty(1, max_length + 1, device=device, dtype=torch.long)
             else:
-                tensor = self._encode_str(tensor, device, size=max_length)
+                tensor = self._encode_str(tensor_str, device, size=max_length)
 
         tensor = self._apply_op(tensor, device, self._do_broadcast, src)
 
@@ -275,6 +282,9 @@ class ComputationModel(metaclass=ABCMeta):
         if tensor_to_str:
             list_str = self._decode_str(tensor)
             return list_str[0]
+        if tensor_to_path:
+            list_str = self._decode_str(tensor)
+            return Path(list_str[0])
         return tensor
 
     @abstractmethod
@@ -374,8 +384,8 @@ class _SerialModel(ComputationModel):
         return cast(list[float] | list[str] | list[Any], [tensor])
 
     def broadcast(
-        self, tensor: torch.Tensor | float | str | None, src: int = 0, safe_mode: bool = False
-    ) -> torch.Tensor | float | str:
+        self, tensor: torch.Tensor | float | str | Path | None, src: int = 0, safe_mode: bool = False
+    ) -> torch.Tensor | float | str | Path:
         if tensor is None:
             raise ValueError("Argument tensor should not be None")
         return tensor

--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -279,12 +279,10 @@ class ComputationModel(metaclass=ABCMeta):
 
         if tensor_to_number:
             return tensor.item()
-        if tensor_to_str:
+        if tensor_to_str or tensor_to_path:
             list_str = self._decode_str(tensor)
-            return list_str[0]
-        if tensor_to_path:
-            list_str = self._decode_str(tensor)
-            return Path(list_str[0])
+            result = list_str[0]
+            return Path(result) if tensor_to_path else result
         return tensor
 
     @abstractmethod

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import socket
+from pathlib import Path
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import contextmanager
 from functools import wraps
@@ -432,12 +433,12 @@ def all_gather(
 
 
 def broadcast(
-    tensor: torch.Tensor | float | str | None, src: int = 0, safe_mode: bool = False
-) -> torch.Tensor | float | str:
+    tensor: torch.Tensor | float | str | Path | None, src: int = 0, safe_mode: bool = False
+) -> torch.Tensor | float | str | Path:
     """Helper method to perform broadcast operation.
 
     Args:
-        tensor: tensor or number or str to broadcast to participating processes.
+        tensor: tensor, number, str or pathlib.Path to broadcast to participating processes.
             Make sure to respect data type of torch tensor input for all processes, otherwise execution will crash.
             Can use None for non-source data with ``safe_mode=True``.
         src: source rank. Default, 0.
@@ -447,7 +448,7 @@ def broadcast(
             collectives before the broadcast, making it slower than without using this mode. Default, False.
 
     Returns:
-        torch.Tensor or string or number
+        torch.Tensor, string, pathlib.Path or number
 
     Examples:
         .. code-block:: python

--- a/tests/ignite/distributed/comp_models/test_base.py
+++ b/tests/ignite/distributed/comp_models/test_base.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import torch
 
@@ -57,6 +59,9 @@ def test__encode_input_data():
     encoded_msg = ComputationModel._encode_input_data("abc", is_src=True)
     assert encoded_msg == [2] + [-1] * 511
 
+    encoded_msg = ComputationModel._encode_input_data(Path("abc"), is_src=True)
+    assert encoded_msg == [3] + [-1] * 511
+
     t = torch.rand(2, 512, 32, 32, 64)
     encoded_msg = ComputationModel._encode_input_data(t, is_src=True)
     dtype_str = str(t.dtype)
@@ -94,6 +99,11 @@ def test__decode_as_placeholder():
     assert isinstance(res, str) and res == ""
 
     encoded_msg = [-1] * 512
+    encoded_msg[0] = 3
+    res = ComputationModel._decode_as_placeholder(encoded_msg, device)
+    assert isinstance(res, Path) and res == Path("")
+
+    encoded_msg = [-1] * 512
     encoded_msg[0] = 0
     encoded_msg[1 : 1 + 7] = [6, 2, 3, 4, 5, 6, 7]
     dtype_str = "torch.int64"
@@ -122,7 +132,7 @@ def test__setup_placeholder():
 
     from ignite.distributed.utils import _model
 
-    for t in [torch.rand(2, 3, 4), "abc", 123.45]:
+    for t in [torch.rand(2, 3, 4), "abc", Path("abc"), 123.45]:
         data = _model._setup_placeholder(t, device, True)
         assert isinstance(data, type(t))
         if isinstance(data, torch.Tensor):

--- a/tests/ignite/distributed/utils/__init__.py
+++ b/tests/ignite/distributed/utils/__init__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -364,6 +366,11 @@ def _test_distrib_broadcast(device):
     _test("test-abcdefg", "", safe_mode=False)
     _test("test-abcdefg", None, safe_mode=True)
     _test("test-abcdefg", 1.2, safe_mode=True)
+
+    path = Path("tests/ignite/distributed/utils/test_horovod.py")
+    _test(path, Path(""), safe_mode=False)
+    _test(path, None, safe_mode=True)
+    _test(path, "", safe_mode=True)
 
     s = "tests/ignite/distributed/utils/test_horovod.py::test_idist_broadcast_hvd" * 200
     _test(s, "", safe_mode=False)


### PR DESCRIPTION
Fixes #3025

Description:

Adds `pathlib.Path` support to `idist.broadcast` by encoding paths through the existing string broadcast path and decoding them back to `Path` objects, including safe-mode placeholder handling.

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
