### PR TITLE
docs: fix comment typos

### DIFF
--- a/examples/references/classification/imagenet/main.py
+++ b/examples/references/classification/imagenet/main.py
@@ -53,7 +53,7 @@ def training(local_rank, config, logger, with_clearml):
     val_interval = config.get("val_interval", 1)
 
     # Run validation on every val_interval epoch, in the end of the training
-    # and in the begining if config.start_by_validation is True
+    # and in the beginning if config.start_by_validation is True
     event = Events.EPOCH_COMPLETED(every=val_interval)
     if config.num_epochs % val_interval != 0:
         event |= Events.COMPLETED

--- a/examples/references/segmentation/pascal_voc2012/main.py
+++ b/examples/references/segmentation/pascal_voc2012/main.py
@@ -79,7 +79,7 @@ def training(local_rank, config, logger, with_clearml):
     val_interval = config.get("val_interval", 1)
 
     # Run validation on every val_interval epoch, in the end of the training
-    # and in the begining if config.start_by_validation is True
+    # and in the beginning if config.start_by_validation is True
     event = Events.EPOCH_COMPLETED(every=val_interval)
     if config.num_epochs % val_interval != 0:
         event |= Events.COMPLETED

--- a/tests/ignite/metrics/test_metric.py
+++ b/tests/ignite/metrics/test_metric.py
@@ -1433,7 +1433,7 @@ class DummyMetric5(Metric):
 
 
 def test_skip_unrolling():
-    # y_pred and y are ouputs recieved from a multi_output model
+    # y_pred and y are outputs received from a multi_output model
     a_pred = torch.rand(8, 1)
     b_pred = torch.rand(8, 1)
     y_pred = [a_pred, b_pred]


### PR DESCRIPTION
Fixes #3756

Description:

Fix a few typos in comments in the reference examples and metric tests.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)

Tests:

- `python3 -m pytest tests/ignite/metrics/test_metric.py::test_skip_unrolling`
- `python3 -m ruff check examples/references/classification/imagenet/main.py examples/references/segmentation/pascal_voc2012/main.py tests/ignite/metrics/test_metric.py`
