### PR TITLE
Fix Distributed Initialization by Validating Legacy tcp:// and Updating Tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,6 +35,8 @@ jobs:
   cpu-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 85
+    env:
+      USE_LIBUV: "0"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,8 +35,6 @@ jobs:
   cpu-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 85
-    env:
-      USE_LIBUV: "0"
     defaults:
       run:
         shell: bash

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -54,6 +54,7 @@ if has_native_dist_support:
             init_method: str | None = None,
             world_size: int | None = None,
             rank: int | None = None,
+            store: Any | None = None,
             **kwargs: Any,
         ) -> _NativeDistModel:
             if backend not in _NativeDistModel.available_backends:
@@ -62,7 +63,7 @@ if has_native_dist_support:
             if dist.is_available() and dist.is_initialized():
                 raise RuntimeError("Can not create new distributed process group if default one is already initialized")
 
-            if init_method is None:
+            if init_method is None and store is None:
                 if world_size is not None or rank is not None:
                     raise ValueError("Arguments rank and world_size should be None if no init_method is provided")
             else:
@@ -72,7 +73,7 @@ if has_native_dist_support:
                     raise ValueError(f"Both rank and world_size should be provided, but given {rank} and {world_size}")
 
             return _NativeDistModel(
-                backend=backend, init_method=init_method, world_size=world_size, rank=rank, **kwargs
+                backend=backend, init_method=init_method, world_size=world_size, rank=rank, store=store, **kwargs
             )
 
         def __init__(
@@ -82,6 +83,7 @@ if has_native_dist_support:
             init_method: str | None = None,
             world_size: int | None = None,
             rank: int | None = None,
+            store: Any | None = None,
             **kwargs: Any,
         ) -> None:
             """This is a private method. Please, use `create_from_backend` or `create_from_context`"""
@@ -93,7 +95,13 @@ if has_native_dist_support:
             self._init_method: str | None = None
             if backend is not None:
                 self._create_from_backend(
-                    backend, timeout=timeout, init_method=init_method, world_size=world_size, rank=rank, **kwargs
+                    backend,
+                    timeout=timeout,
+                    init_method=init_method,
+                    world_size=world_size,
+                    rank=rank,
+                    store=store,
+                    **kwargs,
                 )
             else:
                 self._init_from_context()
@@ -105,27 +113,21 @@ if has_native_dist_support:
             init_method: str | None = None,
             world_size: int | None = None,
             rank: int | None = None,
+            store: Any | None = None,
             **kwargs: Any,
         ) -> None:
             if init_method is not None and init_method.startswith("tcp://"):
-                from urllib.parse import urlparse
-
-                try:
-                    parsed = urlparse(init_method)
-                    host = parsed.hostname or "127.0.0.1"
-                    port = parsed.port or 29500
-                except Exception:
-                    host = "127.0.0.1"
-                    port = 29500
-
                 raise ValueError(
                     f"TCP initialization via init_method='{init_method}' will hang. "
-                    "To fix this, please configure a TCPStore and initialize the process group using the store instead. "
-                    "For example:\n\n"
+                    "To fix this, please configure MASTER_ADDR and MASTER_PORT in the environment and "
+                    "use 'env://' (or omit init_method). Alternatively, you can configure a TCPStore and "
+                    "pass it using the 'store' argument. For example:\n\n"
                     "    import torch.distributed as dist\n"
-                    "    from datetime import timedelta\n\n"
-                    f'    store = dist.TCPStore("{host}", {port}, world_size, is_master, timedelta(seconds=30))\n'
-                    "    dist.init_process_group(backend, store=store, rank=rank, world_size=world_size)"
+                    '    store = dist.TCPStore("<master_addr>", <master_port>, world_size, is_master)\n'
+                    "    # Then pass the store to idist.initialize or idist.Parallel:\n"
+                    "    # idist.initialize(backend=backend, store=store, ...)\n"
+                    "    # or\n"
+                    "    # with idist.Parallel(backend=backend, store=store, ...) as parallel:\n"
                 )
 
             if backend == dist.Backend.NCCL and not torch.cuda.is_available():
@@ -137,15 +139,26 @@ if has_native_dist_support:
             if timeout is not None:
                 init_pg_kwargs["timeout"] = timeout
 
-            if init_method is None:
+            if init_method is None and store is None:
                 init_method = "env://"
 
-            if "env" not in init_method:
-                init_pg_kwargs["world_size"] = int(os.environ["WORLD_SIZE"])
-                init_pg_kwargs["rank"] = int(os.environ["RANK"])
-            self._init_method = init_method
+            if init_method is not None:
+                if "env" not in init_method:
+                    init_pg_kwargs["world_size"] = int(os.environ["WORLD_SIZE"])
+                    init_pg_kwargs["rank"] = int(os.environ["RANK"])
+                self._init_method = init_method
+                dist.init_process_group(backend, init_method=init_method, **init_pg_kwargs)
+            else:
+                if rank is not None:
+                    init_pg_kwargs["rank"] = rank
+                else:
+                    init_pg_kwargs["rank"] = int(os.environ.get("RANK", 0))
+                if world_size is not None:
+                    init_pg_kwargs["world_size"] = world_size
+                else:
+                    init_pg_kwargs["world_size"] = int(os.environ.get("WORLD_SIZE", 1))
 
-            dist.init_process_group(backend, init_method=init_method, **init_pg_kwargs)
+                dist.init_process_group(backend, store=store, **init_pg_kwargs)
 
             if torch.cuda.is_available():
                 torch.cuda.set_device(self._local_rank)

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -112,17 +112,14 @@ if has_native_dist_support:
 
                 try:
                     parsed = urlparse(init_method)
-                    host = parsed.hostname
-                    port = parsed.port
+                    host = parsed.hostname or "127.0.0.1"
+                    port = parsed.port or 29500
                 except Exception:
-                    host = None
-                    port = None
-
-                host = host or "127.0.0.1"
-                port = port or 29500
+                    host = "127.0.0.1"
+                    port = 29500
 
                 raise ValueError(
-                    f"init_method='{init_method}' is not supported by PyTorch. "
+                    f"TCP initialization via init_method='{init_method}' will hang. "
                     "To fix this, please configure a TCPStore and initialize the process group using the store instead. "
                     "For example:\n\n"
                     "    import torch.distributed as dist\n"

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -107,6 +107,30 @@ if has_native_dist_support:
             rank: int | None = None,
             **kwargs: Any,
         ) -> None:
+            if init_method is not None and init_method.startswith("tcp://"):
+                from urllib.parse import urlparse
+
+                try:
+                    parsed = urlparse(init_method)
+                    host = parsed.hostname
+                    port = parsed.port
+                except Exception:
+                    host = None
+                    port = None
+
+                host = host or "127.0.0.1"
+                port = port or 29500
+
+                raise ValueError(
+                    f"init_method='{init_method}' is not supported by PyTorch. "
+                    "To fix this, please configure a TCPStore and initialize the process group using the store instead. "
+                    "For example:\n\n"
+                    "    import torch.distributed as dist\n"
+                    "    from datetime import timedelta\n\n"
+                    f'    store = dist.TCPStore("{host}", {port}, world_size, is_master, timedelta(seconds=30))\n'
+                    "    dist.init_process_group(backend, store=store, rank=rank, world_size=world_size)"
+                )
+
             if backend == dist.Backend.NCCL and not torch.cuda.is_available():
                 raise RuntimeError("Nccl backend is required but no cuda capable devices")
             self._backend = backend

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -54,7 +54,6 @@ if has_native_dist_support:
             init_method: str | None = None,
             world_size: int | None = None,
             rank: int | None = None,
-            store: Any | None = None,
             **kwargs: Any,
         ) -> _NativeDistModel:
             if backend not in _NativeDistModel.available_backends:
@@ -63,6 +62,7 @@ if has_native_dist_support:
             if dist.is_available() and dist.is_initialized():
                 raise RuntimeError("Can not create new distributed process group if default one is already initialized")
 
+            store = kwargs.get("store", None)
             if init_method is None and store is None:
                 if world_size is not None or rank is not None:
                     raise ValueError("Arguments rank and world_size should be None if no init_method is provided")
@@ -73,7 +73,7 @@ if has_native_dist_support:
                     raise ValueError(f"Both rank and world_size should be provided, but given {rank} and {world_size}")
 
             return _NativeDistModel(
-                backend=backend, init_method=init_method, world_size=world_size, rank=rank, store=store, **kwargs
+                backend=backend, init_method=init_method, world_size=world_size, rank=rank, **kwargs
             )
 
         def __init__(
@@ -83,7 +83,6 @@ if has_native_dist_support:
             init_method: str | None = None,
             world_size: int | None = None,
             rank: int | None = None,
-            store: Any | None = None,
             **kwargs: Any,
         ) -> None:
             """This is a private method. Please, use `create_from_backend` or `create_from_context`"""
@@ -100,7 +99,6 @@ if has_native_dist_support:
                     init_method=init_method,
                     world_size=world_size,
                     rank=rank,
-                    store=store,
                     **kwargs,
                 )
             else:
@@ -113,9 +111,9 @@ if has_native_dist_support:
             init_method: str | None = None,
             world_size: int | None = None,
             rank: int | None = None,
-            store: Any | None = None,
             **kwargs: Any,
         ) -> None:
+            store = kwargs.pop("store", None)
             if init_method is not None and init_method.startswith("tcp://"):
                 raise ValueError(
                     f"TCP initialization via init_method='{init_method}' will hang. "

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -238,17 +238,14 @@ class Parallel:
 
             try:
                 parsed = urlparse(init_method)
-                host = parsed.hostname
-                port = parsed.port
+                host = parsed.hostname or "127.0.0.1"
+                port = parsed.port or 29500
             except Exception:
-                host = None
-                port = None
-
-            host = host or "127.0.0.1"
-            port = port or 29500
+                host = "127.0.0.1"
+                port = 29500
 
             raise ValueError(
-                f"init_method='{init_method}' is not supported by PyTorch. "
+                f"TCP initialization via init_method='{init_method}' will hang. "
                 "To fix this, please configure a TCPStore and initialize the process group using the store instead. "
                 "For example:\n\n"
                 "    import torch.distributed as dist\n"

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -132,11 +132,14 @@ class Parallel:
             with idist.Parallel(backend=backend, init_method='file:///d:/tmp/some_file', nproc_per_node=4) as parallel:
                 parallel.run(training, config, a=1, b=2)
 
-        Initializing the process using ``tcp://``
+        Initializing the process using ``store``
 
         .. code-block:: python
 
-            with idist.Parallel(backend=backend, init_method='tcp://10.1.1.20:23456', nproc_per_node=4) as parallel:
+            import torch.distributed as dist
+
+            store = dist.TCPStore("<master_addr>", <master_port>, world_size, is_master)
+            with idist.Parallel(backend=backend, store=store) as parallel:
                 parallel.run(training, config, a=1, b=2)
 
 
@@ -221,6 +224,7 @@ class Parallel:
         master_addr: str | None = None,
         master_port: int | None = None,
         init_method: str | None = None,
+        store: Any | None = None,
         **spawn_kwargs: Any,
     ) -> None:
         if backend is not None:
@@ -234,29 +238,21 @@ class Parallel:
                     raise ValueError(f"If backend is None, argument '{name}' should be also None, but given {value}")
 
         if init_method is not None and init_method.startswith("tcp://"):
-            from urllib.parse import urlparse
-
-            try:
-                parsed = urlparse(init_method)
-                host = parsed.hostname or "127.0.0.1"
-                port = parsed.port or 29500
-            except Exception:
-                host = "127.0.0.1"
-                port = 29500
-
             raise ValueError(
                 f"TCP initialization via init_method='{init_method}' will hang. "
-                "To fix this, please configure a TCPStore and initialize the process group using the store instead. "
-                "For example:\n\n"
+                "To fix this, please configure MASTER_ADDR and MASTER_PORT in the environment and "
+                "use 'env://' (or omit init_method). Alternatively, you can configure a TCPStore and "
+                "pass it using the 'store' argument. For example:\n\n"
                 "    import torch.distributed as dist\n"
-                "    from datetime import timedelta\n\n"
-                f'    store = dist.TCPStore("{host}", {port}, world_size, is_master, timedelta(seconds=30))\n'
-                "    dist.init_process_group(backend, store=store, rank=rank, world_size=world_size)"
+                '    store = dist.TCPStore("<master_addr>", <master_port>, world_size, is_master)\n'
+                "    # Then pass the store to idist.Parallel:\n"
+                "    # idist.Parallel(backend=backend, store=store, ...)"
             )
 
         self.backend = backend
         self._spawn_params = None
         self.init_method = init_method
+        self.store = store
 
         if self.backend is not None:
             if nproc_per_node is not None:
@@ -343,7 +339,7 @@ class Parallel:
 
     def __enter__(self) -> "Parallel":
         if self.backend is not None and self._spawn_params is None:
-            idist.initialize(self.backend, init_method=self.init_method)
+            idist.initialize(self.backend, init_method=self.init_method, store=self.store)
 
         # The logger can be setup from now since idist.initialize() has been called (if needed)
         self._logger = setup_logger(__name__ + "." + self.__class__.__name__)

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -224,7 +224,6 @@ class Parallel:
         master_addr: str | None = None,
         master_port: int | None = None,
         init_method: str | None = None,
-        store: Any | None = None,
         **spawn_kwargs: Any,
     ) -> None:
         if backend is not None:
@@ -252,7 +251,7 @@ class Parallel:
         self.backend = backend
         self._spawn_params = None
         self.init_method = init_method
-        self.store = store
+        self.store = spawn_kwargs.pop("store", None)
 
         if self.backend is not None:
             if nproc_per_node is not None:

--- a/ignite/distributed/launcher.py
+++ b/ignite/distributed/launcher.py
@@ -233,6 +233,30 @@ class Parallel:
                 if value is not None:
                     raise ValueError(f"If backend is None, argument '{name}' should be also None, but given {value}")
 
+        if init_method is not None and init_method.startswith("tcp://"):
+            from urllib.parse import urlparse
+
+            try:
+                parsed = urlparse(init_method)
+                host = parsed.hostname
+                port = parsed.port
+            except Exception:
+                host = None
+                port = None
+
+            host = host or "127.0.0.1"
+            port = port or 29500
+
+            raise ValueError(
+                f"init_method='{init_method}' is not supported by PyTorch. "
+                "To fix this, please configure a TCPStore and initialize the process group using the store instead. "
+                "For example:\n\n"
+                "    import torch.distributed as dist\n"
+                "    from datetime import timedelta\n\n"
+                f'    store = dist.TCPStore("{host}", {port}, world_size, is_master, timedelta(seconds=30))\n'
+                "    dist.init_process_group(backend, store=store, rank=rank, world_size=world_size)"
+            )
+
         self.backend = backend
         self._spawn_params = None
         self.init_method = init_method

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -576,7 +576,7 @@ def initialize(backend: str, **kwargs: Any) -> None:
         kwargs: acceptable kwargs according to provided backend:
 
             - | "nccl" or "gloo" : ``timeout(=timedelta(minutes=30))``, ``init_method(=None)``,
-              | ``rank(=None)``, ``world_size(=None)``.
+              | ``rank(=None)``, ``world_size(=None)``, ``store(=None)``.
               | By default, ``init_method`` will be "env://". See more info about parameters: `torch_init`_.
 
             - | "horovod" : comm(=None), more info: `hvd_init`_.
@@ -604,6 +604,9 @@ def initialize(backend: str, **kwargs: Any) -> None:
             idist.initialize(backend)
             # or for torch native distributed on Windows:
             # idist.initialize("nccl", init_method="file://tmp/shared")
+            # or using store:
+            # store = dist.TCPStore("<master_addr>", <master_port>, world_size, is_master)
+            # idist.initialize("nccl", store=store)
             local_rank = idist.get_local_rank()
             train_fn(local_rank, a, b, c)
             idist.finalize()

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -230,15 +230,19 @@ def _setup_free_port(local_rank):
 @pytest.fixture()
 def distributed_context_single_node_nccl(local_rank, world_size):
     free_port = _setup_free_port(local_rank)
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(free_port)
 
     dist_info = {
         "backend": "nccl",
         "world_size": world_size,
         "rank": local_rank,
-        "init_method": f"tcp://localhost:{free_port}",
+        "init_method": "env://",
     }
     yield _create_dist_context(dist_info, local_rank)
     _destroy_dist_context()
+    os.environ.pop("MASTER_ADDR", None)
+    os.environ.pop("MASTER_PORT", None)
 
 
 @pytest.fixture()
@@ -250,22 +254,32 @@ def distributed_context_single_node_gloo(local_rank, world_size):
         # can't use backslashes in f-strings
         backslash = "\\"
         init_method = f"file:///{temp_file.name.replace(backslash, '/')}"
+        dist_info = {
+            "backend": "gloo",
+            "world_size": world_size,
+            "rank": local_rank,
+            "init_method": init_method,
+            "timeout": timedelta(seconds=30),
+        }
+        yield _create_dist_context(dist_info, local_rank)
+        _destroy_dist_context()
+        temp_file.close()
     else:
         free_port = _setup_free_port(local_rank)
-        init_method = f"tcp://localhost:{free_port}"
-        temp_file = None
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(free_port)
 
-    dist_info = {
-        "backend": "gloo",
-        "world_size": world_size,
-        "rank": local_rank,
-        "init_method": init_method,
-        "timeout": timedelta(seconds=30),
-    }
-    yield _create_dist_context(dist_info, local_rank)
-    _destroy_dist_context()
-    if temp_file:
-        temp_file.close()
+        dist_info = {
+            "backend": "gloo",
+            "world_size": world_size,
+            "rank": local_rank,
+            "init_method": "env://",
+            "timeout": timedelta(seconds=30),
+        }
+        yield _create_dist_context(dist_info, local_rank)
+        _destroy_dist_context()
+        os.environ.pop("MASTER_ADDR", None)
+        os.environ.pop("MASTER_PORT", None)
 
 
 @pytest.fixture()
@@ -471,16 +485,21 @@ def distributed(request, local_rank, world_size):
             # can't use backslashes in f-strings
             backslash = "\\"
             init_method = f"file:///{temp_file.name.replace(backslash, '/')}"
+            dist_info = {
+                "world_size": world_size,
+                "rank": local_rank,
+                "init_method": init_method,
+            }
         else:
             temp_file = None
             free_port = _setup_free_port(local_rank)
-            init_method = f"tcp://localhost:{free_port}"
-
-        dist_info = {
-            "world_size": world_size,
-            "rank": local_rank,
-            "init_method": init_method,
-        }
+            os.environ["MASTER_ADDR"] = "localhost"
+            os.environ["MASTER_PORT"] = str(free_port)
+            dist_info = {
+                "world_size": world_size,
+                "rank": local_rank,
+                "init_method": "env://",
+            }
 
         if request.param == "nccl":
             dist_info["backend"] = "nccl"
@@ -493,6 +512,9 @@ def distributed(request, local_rank, world_size):
         _destroy_dist_context()
         if temp_file:
             temp_file.close()
+        else:
+            os.environ.pop("MASTER_ADDR", None)
+            os.environ.pop("MASTER_PORT", None)
 
     elif request.param == "horovod":
         request.node.stash[is_horovod_stash_key] = True

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -744,11 +744,7 @@ def test__native_dist_model_tcp_init_method_error():
     ],
 )
 def test__native_dist_model_store_init(clean_env, backend, device):
-    try:
-        store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True, use_libuv=False)
-    except TypeError:
-        # PyTorch < 2.4 doesn't support use_libuv
-        store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+    store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
 
     model = _NativeDistModel.create_from_backend(backend=backend, store=store, rank=0, world_size=1)
     assert model.backend() == backend

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -728,5 +728,5 @@ def test__setup_ddp_vars_from_slurm_env_bad_configs():
 
 
 def test__native_dist_model_tcp_init_method_error():
-    with pytest.raises(ValueError, match="is not supported by PyTorch. To fix this, please configure a TCPStore"):
+    with pytest.raises(ValueError, match="will hang. To fix this, please configure a TCPStore"):
         _NativeDistModel.create_from_backend(backend="gloo", init_method="tcp://10.1.1.20:23456", rank=0, world_size=1)

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -732,6 +732,7 @@ def test__native_dist_model_tcp_init_method_error():
         _NativeDistModel.create_from_backend(backend="gloo", init_method="tcp://10.1.1.20:23456", rank=0, world_size=1)
 
 
+@pytest.mark.distributed
 @pytest.mark.parametrize(
     "backend,device",
     [

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -728,5 +728,25 @@ def test__setup_ddp_vars_from_slurm_env_bad_configs():
 
 
 def test__native_dist_model_tcp_init_method_error():
-    with pytest.raises(ValueError, match="will hang. To fix this, please configure a TCPStore"):
+    with pytest.raises(ValueError, match="will hang. To fix this, please configure MASTER_ADDR"):
         _NativeDistModel.create_from_backend(backend="gloo", init_method="tcp://10.1.1.20:23456", rank=0, world_size=1)
+
+
+@pytest.mark.parametrize(
+    "backend,device",
+    [
+        ("gloo", torch.device("cpu")),
+        pytest.param(
+            "nccl",
+            torch.device("cuda:0"),
+            marks=pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU"),
+        ),
+    ],
+)
+def test__native_dist_model_store_init(clean_env, backend, device):
+    store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+    model = _NativeDistModel.create_from_backend(backend=backend, store=store, rank=0, world_size=1)
+    assert model.backend() == backend
+    assert model.get_world_size() == 1
+    assert model.get_rank() == 0
+    dist.destroy_process_group()

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -334,7 +334,8 @@ def _test__native_dist_model_create_from_context_set_local_rank(true_conf):
 def _test__native_dist_model_create_from_context_no_dist(true_backend, true_device):
     assert _NativeDistModel.create_from_context() is None
 
-    dist.init_process_group(true_backend, "tcp://0.0.0.0:2222", world_size=1, rank=0)
+    store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+    dist.init_process_group(true_backend, store=store, world_size=1, rank=0)
     dist.barrier()
 
     _test__native_dist_model_create_from_context_no_local_rank()
@@ -358,7 +359,9 @@ def _test__native_dist_model_create_from_context_no_dist(true_backend, true_devi
 def _test__native_dist_model_create_from_context_dist(local_rank, rank, world_size, true_backend, true_device):
     assert _NativeDistModel.create_from_context() is None
 
-    dist.init_process_group(true_backend, "tcp://0.0.0.0:2222", world_size=world_size, rank=rank)
+    is_master = rank == 0
+    store = dist.TCPStore("0.0.0.0", 2222, world_size=world_size, is_master=is_master)
+    dist.init_process_group(true_backend, store=store, world_size=world_size, rank=rank)
     dist.barrier()
     if torch.cuda.is_available():
         torch.cuda.set_device(local_rank)
@@ -397,7 +400,7 @@ def test__native_dist_model_create_no_dist_nccl(clean_env):
 
 
 @pytest.mark.distributed
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "FILE"])
 def test__native_dist_model_create_dist_gloo_1(init_method, get_fixed_dirname, local_rank, world_size):
     if init_method == "FILE":
         init_method = f"file://{get_fixed_dirname('native_dist_model_create_dist_gloo_1')}/shared"
@@ -418,7 +421,7 @@ def test__native_dist_model_create_dist_gloo_2(local_rank, world_size):
 
 @pytest.mark.distributed
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "FILE"])
 def test__native_dist_model_create_dist_nccl_1(init_method, get_fixed_dirname, local_rank, world_size):
     if init_method == "FILE":
         init_method = f"file://{get_fixed_dirname('native_dist_model_create_dist_nccl_1')}/shared"
@@ -444,7 +447,9 @@ def test__native_dist_model_create_dist_nccl_2(local_rank, world_size):
 def test__native_dist_model_warning_index_less_localrank(local_rank, world_size):
     assert _NativeDistModel.create_from_context() is None
 
-    dist.init_process_group("nccl", "tcp://0.0.0.0:2222", world_size=world_size, rank=local_rank)
+    is_master = local_rank == 0
+    store = dist.TCPStore("0.0.0.0", 2222, world_size=world_size, is_master=is_master)
+    dist.init_process_group("nccl", store=store, world_size=world_size, rank=local_rank)
     dist.barrier()
     # We deliberately incorrectly set cuda device to 0
     torch.cuda.set_device(0)
@@ -496,7 +501,7 @@ def _test__native_dist_model_spawn(backend, num_workers_per_machine, device, ini
 
 @pytest.mark.distributed
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
-@pytest.mark.parametrize("init_method", [None, "CUSTOM_ADDR_PORT", "env://", "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "CUSTOM_ADDR_PORT", "env://", "FILE"])
 def test__native_dist_model_spawn_gloo(init_method, dirname):
     spawn_kwargs = {}
 
@@ -532,7 +537,7 @@ def test__native_dist_model_spawn_gloo(init_method, dirname):
 @pytest.mark.distributed
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-@pytest.mark.parametrize("init_method", [None, "CUSTOM_ADDR_PORT", "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "CUSTOM_ADDR_PORT", "FILE"])
 def test__native_dist_model_spawn_nccl(init_method, dirname):
     spawn_kwargs = {}
 
@@ -720,3 +725,8 @@ def test__setup_ddp_vars_from_slurm_env_bad_configs():
             "SLURM_JOB_ID": "12345",
         }
         _setup_ddp_vars_from_slurm_env(environ)
+
+
+def test__native_dist_model_tcp_init_method_error():
+    with pytest.raises(ValueError, match="is not supported by PyTorch. To fix this, please configure a TCPStore"):
+        _NativeDistModel.create_from_backend(backend="gloo", init_method="tcp://10.1.1.20:23456", rank=0, world_size=1)

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -743,9 +743,13 @@ def test__native_dist_model_tcp_init_method_error():
         ),
     ],
 )
-def test__native_dist_model_store_init(clean_env, monkeypatch, backend, device):
-    monkeypatch.setenv("USE_LIBUV", "0")
-    store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+def test__native_dist_model_store_init(clean_env, backend, device):
+    try:
+        store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True, use_libuv=False)
+    except TypeError:
+        # PyTorch < 2.4 doesn't support use_libuv
+        store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+
     model = _NativeDistModel.create_from_backend(backend=backend, store=store, rank=0, world_size=1)
     assert model.backend() == backend
     assert model.get_world_size() == 1

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 import torch
@@ -732,7 +733,7 @@ def test__native_dist_model_tcp_init_method_error():
         _NativeDistModel.create_from_backend(backend="gloo", init_method="tcp://10.1.1.20:23456", rank=0, world_size=1)
 
 
-@pytest.mark.distributed
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows due to TCPStore libuv bugs")
 @pytest.mark.parametrize(
     "backend,device",
     [

--- a/tests/ignite/distributed/comp_models/test_native.py
+++ b/tests/ignite/distributed/comp_models/test_native.py
@@ -743,7 +743,8 @@ def test__native_dist_model_tcp_init_method_error():
         ),
     ],
 )
-def test__native_dist_model_store_init(clean_env, backend, device):
+def test__native_dist_model_store_init(clean_env, monkeypatch, backend, device):
+    monkeypatch.setenv("USE_LIBUV", "0")
     store = dist.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
     model = _NativeDistModel.create_from_backend(backend=backend, store=store, rank=0, world_size=1)
     assert model.backend() == backend

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -297,7 +297,7 @@ def test_idist_parallel_tcp_init_method_error():
             pass
 
 
-@pytest.mark.distributed
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows due to TCPStore libuv bugs")
 @pytest.mark.parametrize(
     "backend",
     [

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -297,6 +297,7 @@ def test_idist_parallel_tcp_init_method_error():
             pass
 
 
+@pytest.mark.distributed
 @pytest.mark.parametrize(
     "backend",
     [

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -308,11 +308,7 @@ def test_idist_parallel_tcp_init_method_error():
     ],
 )
 def test_idist_parallel_store_init(clean_env, backend):
-    try:
-        store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True, use_libuv=False)
-    except TypeError:
-        # PyTorch < 2.4 doesn't support use_libuv
-        store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+    store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
 
     with idist.Parallel(backend=backend, store=store) as parallel:
         assert idist.backend() == backend

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -307,9 +307,13 @@ def test_idist_parallel_tcp_init_method_error():
         ),
     ],
 )
-def test_idist_parallel_store_init(clean_env, monkeypatch, backend):
-    monkeypatch.setenv("USE_LIBUV", "0")
-    store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+def test_idist_parallel_store_init(clean_env, backend):
+    try:
+        store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True, use_libuv=False)
+    except TypeError:
+        # PyTorch < 2.4 doesn't support use_libuv
+        store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+
     with idist.Parallel(backend=backend, store=store) as parallel:
         assert idist.backend() == backend
         assert idist.get_world_size() == 1

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -103,13 +103,6 @@ def _test_check_idist_parallel_torch_launch(init_method, fp, backend, nprocs):
     "init_method",
     [
         None,
-        pytest.param(
-            "tcp://0.0.0.0:29500",
-            marks=pytest.mark.skipif(
-                "dev" in torch.__version__,
-                reason="Skip tcp:// init_method with torchrun on nightly due to incompatibility",
-            ),
-        ),
         "FILE",
     ],
 )
@@ -241,7 +234,7 @@ def _test_func(index, ws, device, backend, true_init_method):
 @pytest.mark.distributed
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.parametrize("init_method", ["env://", "tcp://0.0.0.0:29500", "FILE"])
+@pytest.mark.parametrize("init_method", ["env://", "FILE"])
 @pytest.mark.parametrize(
     "backend",
     ["gloo", pytest.param("nccl", marks=pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU"))],
@@ -259,7 +252,7 @@ def test_idist_parallel_spawn_n_procs_native(init_method, backend, dirname):
 @pytest.mark.distributed
 @pytest.mark.skipif("WORLD_SIZE" not in os.environ, reason="Skip if not launched as multiproc")
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.parametrize("init_method", ["env://", "tcp://0.0.0.0:29500", "FILE"])
+@pytest.mark.parametrize("init_method", ["env://", "FILE"])
 @pytest.mark.parametrize(
     "backend",
     ["gloo", pytest.param("nccl", marks=pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU"))],
@@ -296,3 +289,9 @@ def test_idist_parallel_spawn_params_xla():
         res = parallel._spawn_params
         assert "nproc_per_node" in res and res["nproc_per_node"] == 8
         assert "start_method" in res and res["start_method"] == "fork"
+
+
+def test_idist_parallel_tcp_init_method_error():
+    with pytest.raises(ValueError, match="is not supported by PyTorch. To fix this, please configure a TCPStore"):
+        with idist.Parallel(backend="gloo", init_method="tcp://10.1.1.20:23456", nproc_per_node=1) as parallel:
+            pass

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -292,6 +292,6 @@ def test_idist_parallel_spawn_params_xla():
 
 
 def test_idist_parallel_tcp_init_method_error():
-    with pytest.raises(ValueError, match="is not supported by PyTorch. To fix this, please configure a TCPStore"):
+    with pytest.raises(ValueError, match="will hang. To fix this, please configure a TCPStore"):
         with idist.Parallel(backend="gloo", init_method="tcp://10.1.1.20:23456", nproc_per_node=1) as parallel:
             pass

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -307,7 +307,8 @@ def test_idist_parallel_tcp_init_method_error():
         ),
     ],
 )
-def test_idist_parallel_store_init(clean_env, backend):
+def test_idist_parallel_store_init(clean_env, monkeypatch, backend):
+    monkeypatch.setenv("USE_LIBUV", "0")
     store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
     with idist.Parallel(backend=backend, store=store) as parallel:
         assert idist.backend() == backend

--- a/tests/ignite/distributed/test_launcher.py
+++ b/tests/ignite/distributed/test_launcher.py
@@ -292,6 +292,24 @@ def test_idist_parallel_spawn_params_xla():
 
 
 def test_idist_parallel_tcp_init_method_error():
-    with pytest.raises(ValueError, match="will hang. To fix this, please configure a TCPStore"):
+    with pytest.raises(ValueError, match="will hang. To fix this, please configure MASTER_ADDR"):
         with idist.Parallel(backend="gloo", init_method="tcp://10.1.1.20:23456", nproc_per_node=1) as parallel:
             pass
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "gloo",
+        pytest.param(
+            "nccl",
+            marks=pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU"),
+        ),
+    ],
+)
+def test_idist_parallel_store_init(clean_env, backend):
+    store = torch.distributed.TCPStore("0.0.0.0", 2222, world_size=1, is_master=True)
+    with idist.Parallel(backend=backend, store=store) as parallel:
+        assert idist.backend() == backend
+        assert idist.get_world_size() == 1
+        assert idist.get_rank() == 0

--- a/tests/ignite/distributed/utils/test_native.py
+++ b/tests/ignite/distributed/utils/test_native.py
@@ -38,7 +38,7 @@ def _test_native_distrib_single_node_launch_tool(backend, device, local_rank, wo
 
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "FILE"])
 def test_native_distrib_single_node_launch_tool_gloo(init_method, get_fixed_dirname, local_rank, world_size):
     from datetime import timedelta
 
@@ -56,7 +56,7 @@ def test_native_distrib_single_node_launch_tool_gloo(init_method, get_fixed_dirn
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "FILE"])
 def test_native_distrib_single_node_launch_tool_nccl(init_method, get_fixed_dirname, local_rank, world_size):
     if init_method == "FILE":
         init_method = f"file://{get_fixed_dirname('native_distrib_single_node_launch_tool_nccl')}/shared"
@@ -80,7 +80,7 @@ def _test_native_distrib_single_node_spawn(init_method, backend, device, **kwarg
 @pytest.mark.distributed
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "FILE"])
 def test_native_distrib_single_node_spawn_gloo(init_method, dirname):
     from datetime import timedelta
 
@@ -97,7 +97,7 @@ def test_native_distrib_single_node_spawn_gloo(init_method, dirname):
 @pytest.mark.skipif(not has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.skipif("WORLD_SIZE" in os.environ, reason="Skip if launched as multiproc")
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Skip if no GPU")
-@pytest.mark.parametrize("init_method", [None, "tcp://0.0.0.0:22334", "FILE"])
+@pytest.mark.parametrize("init_method", [None, "FILE"])
 def test_native_distrib_single_node_spawn_nccl(init_method, dirname):
     if init_method == "FILE":
         init_method = f"file://{dirname}/shared"


### PR DESCRIPTION
### **Problem**
Using `tcp://` directly in PyTorch's `init_method` causes multi-process communication to hang and fail in modern PyTorch versions.
  
### **Solution**
1. **Validation & User Error**: Added explicit validation in `Parallel` and `_NativeDistModel` that detects legacy `tcp://` initialization methods and raises a helpful, actionable `ValueError` guiding the user on how to use        PyTorch's native `TCPStore` instead.
2. **Updated Tests**: Cleaned up the distributed test suite to remove legacy `tcp://` connections from test parameterizations and updated low-level context tests to use modern `dist.TCPStore` objects directly.

Check list:

- [x] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
