### PR TITLE
fix: correct comment typos

### DIFF
--- a/examples/references/classification/imagenet/main.py
+++ b/examples/references/classification/imagenet/main.py
@@ -53,7 +53,7 @@ def training(local_rank, config, logger, with_clearml):
     val_interval = config.get("val_interval", 1)
 
     # Run validation on every val_interval epoch, in the end of the training
-    # and in the begining if config.start_by_validation is True
+    # and in the beginning if config.start_by_validation is True
     event = Events.EPOCH_COMPLETED(every=val_interval)
     if config.num_epochs % val_interval != 0:
         event |= Events.COMPLETED

--- a/examples/references/segmentation/pascal_voc2012/main.py
+++ b/examples/references/segmentation/pascal_voc2012/main.py
@@ -79,7 +79,7 @@ def training(local_rank, config, logger, with_clearml):
     val_interval = config.get("val_interval", 1)
 
     # Run validation on every val_interval epoch, in the end of the training
-    # and in the begining if config.start_by_validation is True
+    # and in the beginning if config.start_by_validation is True
     event = Events.EPOCH_COMPLETED(every=val_interval)
     if config.num_epochs % val_interval != 0:
         event |= Events.COMPLETED


### PR DESCRIPTION
Fixes #3756

Description:

Corrects misspelled "begining" comments in the ImageNet and Pascal VOC reference examples.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)

Testing:

- `python3 -m ruff check examples/references/classification/imagenet/main.py examples/references/segmentation/pascal_voc2012/main.py`
- `python3 -m pytest tests/ignite/metrics/test_metric.py::test_skip_unrolling`
