### PR TITLE
Expose metric names in logger setup helpers

### DIFF
--- a/ignite/handlers/logger_utils.py
+++ b/ignite/handlers/logger_utils.py
@@ -117,6 +117,9 @@ def setup_tb_logging(
         evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
+
     Returns:
         :class:`~ignite.handlers.tensorboard_logger.TensorboardLogger`
 
@@ -182,6 +185,9 @@ def setup_visdom_logging(
         evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
+
     Returns:
         :class:`~ignite.handlers.visdom_logger.VisdomLogger`
 
@@ -240,6 +246,9 @@ def setup_mlflow_logging(
         trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
         evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
+
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
 
     Returns:
         :class:`~ignite.handlers.mlflow_logger.MLflowLogger`
@@ -300,6 +309,9 @@ def setup_neptune_logging(
         evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
+
     Returns:
         :class:`~ignite.handlers.neptune_logger.NeptuneLogger`
 
@@ -358,6 +370,9 @@ def setup_wandb_logging(
         trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
         evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
+
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
 
     Returns:
         :class:`~ignite.handlers.wandb_logger.WandBLogger`
@@ -418,6 +433,9 @@ def setup_plx_logging(
         evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
+
     Returns:
         :class:`~ignite.handlers.polyaxon_logger.PolyaxonLogger`
 
@@ -477,6 +495,9 @@ def setup_clearml_logging(
         evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
+
     Returns:
         :class:`~ignite.handlers.clearml_logger.ClearMLLogger`
 
@@ -518,7 +539,11 @@ def setup_trains_logging(
     evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> ClearMLLogger:
-    """``setup_trains_logging`` was renamed to :func:`~ignite.handlers.logger_utils.setup_clearml_logging`."""
+    """``setup_trains_logging`` was renamed to :func:`~ignite.handlers.logger_utils.setup_clearml_logging`.
+
+    .. versionchanged:: 0.6.0
+        Added ``trainer_metric_names`` and ``evaluator_metric_names`` parameters.
+    """
     warnings.warn("setup_trains_logging was renamed to setup_clearml_logging.")
     return setup_clearml_logging(
         trainer,

--- a/ignite/handlers/logger_utils.py
+++ b/ignite/handlers/logger_utils.py
@@ -29,6 +29,8 @@ __all__ = [
     "setup_trains_logging",
 ]
 
+_MetricNames = str | list[str]
+
 
 def _setup_logging(
     logger: BaseLogger,
@@ -36,6 +38,9 @@ def _setup_logging(
     optimizers: Optimizer | dict[str, Optimizer] | dict[None, Optimizer] | None,
     evaluators: Engine | dict[str, Engine] | None,
     log_every_iters: int,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
 ) -> None:
     if optimizers is not None:
         if not isinstance(optimizers, (Optimizer, Mapping)):
@@ -49,7 +54,10 @@ def _setup_logging(
         log_every_iters = 1
 
     logger.attach_output_handler(
-        trainer, event_name=Events.ITERATION_COMPLETED(every=log_every_iters), tag="training", metric_names="all"
+        trainer,
+        event_name=Events.ITERATION_COMPLETED(every=log_every_iters),
+        tag="training",
+        metric_names=trainer_metric_names,
     )
 
     if optimizers is not None:
@@ -71,7 +79,11 @@ def _setup_logging(
         gst = global_step_from_engine(trainer, custom_event_name=event_name)
         for k, evaluator in evaluators.items():
             logger.attach_output_handler(
-                evaluator, event_name=Events.COMPLETED, tag=k, metric_names="all", global_step_transform=gst
+                evaluator,
+                event_name=Events.COMPLETED,
+                tag=k,
+                metric_names=evaluator_metric_names,
+                global_step_transform=gst,
             )
 
 
@@ -81,6 +93,9 @@ def setup_tb_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> TensorboardLogger:
     """Method to setup TensorBoard logging on trainer and a list of evaluators. Logged metrics are:
@@ -98,6 +113,8 @@ def setup_tb_logging(
             keys are used as tags arguments for logging.
         log_every_iters: interval for loggers attached to iteration events. To log every iteration,
             value can be set to 1 or None.
+        trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
+        evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
     Returns:
@@ -120,7 +137,15 @@ def setup_tb_logging(
             tb_logger.close()
     """
     logger = TensorboardLogger(log_dir=output_path, **kwargs)
-    _setup_logging(logger, trainer, optimizers, evaluators, log_every_iters)
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+    )
     return logger
 
 
@@ -129,6 +154,9 @@ def setup_visdom_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> VisdomLogger:
     """Method to setup Visdom logging on trainer and a list of evaluators. Logged metrics are:
@@ -150,6 +178,8 @@ def setup_visdom_logging(
             keys are used as tags arguments for logging.
         log_every_iters: interval for loggers attached to iteration events. To log every iteration,
             value can be set to 1 or None.
+        trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
+        evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
     Returns:
@@ -171,7 +201,15 @@ def setup_visdom_logging(
             vd_logger.close()
     """
     logger = VisdomLogger(**kwargs)
-    _setup_logging(logger, trainer, optimizers, evaluators, log_every_iters)
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+    )
     return logger
 
 
@@ -180,6 +218,9 @@ def setup_mlflow_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> MLflowLogger:
     """Method to setup MLflow logging on trainer and a list of evaluators. Logged metrics are:
@@ -196,6 +237,8 @@ def setup_mlflow_logging(
             keys are used as tags arguments for logging.
         log_every_iters: interval for loggers attached to iteration events. To log every iteration,
             value can be set to 1 or None.
+        trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
+        evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
     Returns:
@@ -217,7 +260,15 @@ def setup_mlflow_logging(
             mlflow_logger.close()
     """
     logger = MLflowLogger(**kwargs)
-    _setup_logging(logger, trainer, optimizers, evaluators, log_every_iters)
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+    )
     return logger
 
 
@@ -226,6 +277,9 @@ def setup_neptune_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> NeptuneLogger:
     """Method to setup Neptune logging on trainer and a list of evaluators. Logged metrics are:
@@ -242,6 +296,8 @@ def setup_neptune_logging(
             keys are used as tags arguments for logging.
         log_every_iters: interval for loggers attached to iteration events. To log every iteration,
             value can be set to 1 or None.
+        trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
+        evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
     Returns:
@@ -263,7 +319,15 @@ def setup_neptune_logging(
             neptune_logger.close()
     """
     logger = NeptuneLogger(**kwargs)
-    _setup_logging(logger, trainer, optimizers, evaluators, log_every_iters)
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+    )
     return logger
 
 
@@ -272,6 +336,9 @@ def setup_wandb_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> WandBLogger:
     """Method to setup WandB logging on trainer and a list of evaluators. Logged metrics are:
@@ -288,6 +355,8 @@ def setup_wandb_logging(
             keys are used as tags arguments for logging.
         log_every_iters: interval for loggers attached to iteration events. To log every iteration,
             value can be set to 1 or None.
+        trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
+        evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
     Returns:
@@ -309,7 +378,15 @@ def setup_wandb_logging(
             wandb_logger.close()
     """
     logger = WandBLogger(**kwargs)
-    _setup_logging(logger, trainer, optimizers, evaluators, log_every_iters)
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+    )
     return logger
 
 
@@ -318,6 +395,9 @@ def setup_plx_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> PolyaxonLogger:
     """Method to setup Polyaxon logging on trainer and a list of evaluators. Logged metrics are:
@@ -334,6 +414,8 @@ def setup_plx_logging(
             keys are used as tags arguments for logging.
         log_every_iters: interval for loggers attached to iteration events. To log every iteration,
             value can be set to 1 or None.
+        trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
+        evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
     Returns:
@@ -355,7 +437,15 @@ def setup_plx_logging(
             plx_logger.close()
     """
     logger = PolyaxonLogger(**kwargs)
-    _setup_logging(logger, trainer, optimizers, evaluators, log_every_iters)
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+    )
     return logger
 
 
@@ -364,6 +454,9 @@ def setup_clearml_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> ClearMLLogger:
     """Method to setup ClearML logging on trainer and a list of evaluators. Logged metrics are:
@@ -380,6 +473,8 @@ def setup_clearml_logging(
             keys are used as tags arguments for logging.
         log_every_iters: interval for loggers attached to iteration events. To log every iteration,
             value can be set to 1 or None.
+        trainer_metric_names: list of trainer metric names to plot or a string "all" to plot all available metrics.
+        evaluator_metric_names: list of evaluator metric names to plot or a string "all" to plot all available metrics.
         kwargs: optional keyword args to be passed to construct the logger.
 
     Returns:
@@ -401,7 +496,15 @@ def setup_clearml_logging(
             clearml_logger.close()
     """
     logger = ClearMLLogger(**kwargs)
-    _setup_logging(logger, trainer, optimizers, evaluators, log_every_iters)
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+    )
     return logger
 
 
@@ -410,8 +513,19 @@ def setup_trains_logging(
     optimizers: Optimizer | dict[str, Optimizer] | None = None,
     evaluators: Engine | dict[str, Engine] | None = None,
     log_every_iters: int = 100,
+    *,
+    trainer_metric_names: _MetricNames = "all",
+    evaluator_metric_names: _MetricNames = "all",
     **kwargs: Any,
 ) -> ClearMLLogger:
     """``setup_trains_logging`` was renamed to :func:`~ignite.handlers.logger_utils.setup_clearml_logging`."""
     warnings.warn("setup_trains_logging was renamed to setup_clearml_logging.")
-    return setup_clearml_logging(trainer, optimizers, evaluators, log_every_iters, **kwargs)
+    return setup_clearml_logging(
+        trainer,
+        optimizers,
+        evaluators,
+        log_every_iters,
+        trainer_metric_names=trainer_metric_names,
+        evaluator_metric_names=evaluator_metric_names,
+        **kwargs,
+    )

--- a/tests/ignite/contrib/handlers/test_logger_utils.py
+++ b/tests/ignite/contrib/handlers/test_logger_utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -111,6 +112,26 @@ def test__setup_logging_wrong_args():
         _setup_logging(MagicMock(), MagicMock(), MagicMock(spec=torch.optim.SGD), "abc", 1)
 
 
+def test__setup_logging_metric_names():
+    trainer = Engine(lambda e, b: b)
+    evaluator = Engine(lambda e, b: b)
+    logger = MagicMock()
+
+    _setup_logging(
+        logger,
+        trainer,
+        optimizers=None,
+        evaluators={"validation": evaluator},
+        log_every_iters=10,
+        trainer_metric_names=["loss"],
+        evaluator_metric_names=["accuracy"],
+    )
+
+    assert logger.attach_output_handler.call_count == 2
+    assert logger.attach_output_handler.call_args_list[0].kwargs["metric_names"] == ["loss"]
+    assert logger.attach_output_handler.call_args_list[1].kwargs["metric_names"] == ["accuracy"]
+
+
 def test_setup_tb_logging(dirname):
     tb_logger = _test_setup_logging(
         setup_logging_fn=setup_tb_logging,
@@ -141,6 +162,35 @@ def test_setup_tb_logging(dirname):
         log_every_iters=None,
     )
     tb_logger.close()
+
+
+def test_setup_tb_logging_evaluator_metric_names_filter_tensor_metrics(dirname):
+    trainer = Engine(lambda e, b: b)
+    evaluator = Engine(lambda e, b: b)
+
+    @trainer.on(Events.EPOCH_COMPLETED)
+    def validate(engine):
+        evaluator.run([0])
+
+    @evaluator.on(Events.COMPLETED)
+    def set_eval_metrics(engine):
+        engine.state.metrics = {"acc": 0.75, "cm": torch.zeros(2, 2)}
+
+    tb_logger = setup_tb_logging(
+        output_path=dirname / "filtered",
+        trainer=trainer,
+        evaluators={"validation": evaluator},
+        log_every_iters=1,
+        evaluator_metric_names=["acc"],
+    )
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        trainer.run([0], max_epochs=1)
+
+    tb_logger.close()
+
+    assert not any("can not log metrics value type" in str(record.message) for record in records)
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")


### PR DESCRIPTION
Fixes #829.

## Summary
- add `trainer_metric_names` and `evaluator_metric_names` options to the simplified logger setup helpers
- keep the existing default behavior of logging `metric_names="all"`
- allow users to filter out unsupported metrics such as 2D `ConfusionMatrix` tensors when using `setup_tb_logging`

## Tests
- `python -m ruff format ignite/handlers/logger_utils.py tests/ignite/contrib/handlers/test_logger_utils.py`
- `python -m ruff check ignite/handlers/logger_utils.py tests/ignite/contrib/handlers/test_logger_utils.py`
- `python -m pytest tests/ignite/contrib/handlers/test_logger_utils.py::test__setup_logging_metric_names tests/ignite/contrib/handlers/test_logger_utils.py::test_setup_tb_logging tests/ignite/contrib/handlers/test_logger_utils.py::test_setup_tb_logging_evaluator_metric_names_filter_tensor_metrics`