### PR TITLE
Simplify docs autosummary names

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -384,8 +384,6 @@ nitpick_aliases = {
     "ignite.metrics.metrics_lambda.MetricsLambda": "ignite.metrics.MetricsLambda",
     "ignite.metrics.precision.Precision": "ignite.metrics.Precision",
     "ignite.metrics.recall.Recall": "ignite.metrics.Recall",
-    "ignite.metrics.rec_sys.HitRate": "ignite.metrics.HitRate",
-    "ignite.metrics.rec_sys.NDCG": "ignite.metrics.NDCG",
     "ignite.metrics.vision.object_detection_average_precision_recall.coco_tensor_list_to_dict_list": (
         "ignite.metrics.coco_tensor_list_to_dict_list"
     ),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -367,6 +367,48 @@ nitpick_ignore = [
     ("py:class", "DataLoader"),
 ]
 
+nitpick_aliases = {
+    "ignite.handlers.checkpoint.Checkpoint": "ignite.handlers.Checkpoint",
+    "ignite.handlers.checkpoint.ModelCheckpoint": "ignite.handlers.ModelCheckpoint",
+    "ignite.handlers.ema_handler.EMAHandler": "ignite.handlers.EMAHandler",
+    "ignite.handlers.early_stopping.EarlyStopping": "ignite.handlers.EarlyStopping",
+    "ignite.handlers.lr_finder.FastaiLRFinder": "ignite.handlers.FastaiLRFinder",
+    "ignite.handlers.stores.EpochOutputStore": "ignite.handlers.EpochOutputStore",
+    "ignite.handlers.terminate_on_nan.TerminateOnNan": "ignite.handlers.TerminateOnNan",
+    "ignite.handlers.time_profilers.BasicTimeProfiler": "ignite.handlers.BasicTimeProfiler",
+    "ignite.handlers.time_profilers.HandlersTimeProfiler": "ignite.handlers.HandlersTimeProfiler",
+    "ignite.handlers.timing.Timer": "ignite.handlers.Timer",
+    "ignite.metrics.confusion_matrix.ConfusionMatrix": "ignite.metrics.ConfusionMatrix",
+    "ignite.metrics.metric.Metric": "ignite.metrics.Metric",
+    "ignite.metrics.metric_group.MetricGroup": "ignite.metrics.MetricGroup",
+    "ignite.metrics.metrics_lambda.MetricsLambda": "ignite.metrics.MetricsLambda",
+    "ignite.metrics.precision.Precision": "ignite.metrics.Precision",
+    "ignite.metrics.recall.Recall": "ignite.metrics.Recall",
+    "ignite.metrics.rec_sys.HitRate": "ignite.metrics.HitRate",
+    "ignite.metrics.rec_sys.NDCG": "ignite.metrics.NDCG",
+    "ignite.metrics.vision.object_detection_average_precision_recall.coco_tensor_list_to_dict_list": (
+        "ignite.metrics.coco_tensor_list_to_dict_list"
+    ),
+    "metrics.precision.Precision": "ignite.metrics.Precision",
+}
+
+
+def _resolve_nitpick_aliases(app, env, node, contnode):
+    target = node.get("reftarget")
+    if node.get("refdomain") != "py" or not isinstance(target, str):
+        return None
+
+    for source, alias in nitpick_aliases.items():
+        if target == source or target.startswith(f"{source}."):
+            ref_type = node["reftype"]
+            target = f"{alias}{target[len(source) :]}"
+            return app.env.domains["py"].resolve_xref(
+                env, node["refdoc"], app.builder, ref_type, target, node, contnode
+            )
+
+    return None
+
+
 linkcheck_ignore = [
     "https://github.com/fossasia/visdom#visdom-arguments-python-only",
     "https://github.com/pytorch/ignite/tree/master/examples/cifar10#check-resume-training",
@@ -388,3 +430,4 @@ linkcheck_allowed_redirects = {
 
 def setup(app):
     app.add_directive("autosummary", AutolistAutosummary, override=True)
+    app.connect("missing-reference", _resolve_nitpick_aliases)

--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -10,20 +10,20 @@ Complete list of generic handlers
     :nosignatures:
     :toctree: generated
 
-    checkpoint.Checkpoint
+    Checkpoint
     checkpoint.CheckpointEvents
     DiskSaver
-    checkpoint.ModelCheckpoint
-    ema_handler.EMAHandler
-    early_stopping.EarlyStopping
-    lr_finder.FastaiLRFinder
-    terminate_on_nan.TerminateOnNan
+    ModelCheckpoint
+    EMAHandler
+    EarlyStopping
+    FastaiLRFinder
+    TerminateOnNan
     TimeLimit
-    time_profilers.BasicTimeProfiler
-    time_profilers.HandlersTimeProfiler
-    timing.Timer
+    BasicTimeProfiler
+    HandlersTimeProfiler
+    Timer
     global_step_from_engine
-    stores.EpochOutputStore
+    EpochOutputStore
 
 .. autosummary::
     :nosignatures:

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -395,8 +395,8 @@ Complete list of metrics
     fairness.SelectionRate
     fairness.SubgroupDifference
     fairness.SubgroupMetric
-    HitRate
-    NDCG
+    rec_sys.HitRate
+    rec_sys.NDCG
 
 .. note::
 

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -321,7 +321,7 @@ Complete list of metrics
     GeometricAverage
     VariableAccumulation
     Accuracy
-    confusion_matrix.ConfusionMatrix
+    ConfusionMatrix
     ClassificationReport
     DiceCoefficient
     JaccardIndex
@@ -335,17 +335,17 @@ Complete list of metrics
     MeanAveragePrecision
     MeanPairwiseDistance
     MeanSquaredError
-    metric.Metric
-    metric_group.MetricGroup
-    metrics_lambda.MetricsLambda
+    Metric
+    MetricGroup
+    MetricsLambda
     MultiLabelConfusionMatrix
     MutualInformation
     ObjectDetectionAvgPrecisionRecall
     CommonObjectDetectionMetrics
-    vision.object_detection_average_precision_recall.coco_tensor_list_to_dict_list
-    precision.Precision
+    coco_tensor_list_to_dict_list
+    Precision
     PSNR
-    recall.Recall
+    Recall
     RootMeanSquaredError
     RunningAverage
     SSIM
@@ -395,8 +395,8 @@ Complete list of metrics
     fairness.SelectionRate
     fairness.SubgroupDifference
     fairness.SubgroupMetric
-    rec_sys.HitRate
-    rec_sys.NDCG
+    HitRate
+    NDCG
 
 .. note::
 


### PR DESCRIPTION
Fixes #1787.

## Summary
- use top-level handler names in the generic handlers autosummary where the names are already exported from `ignite.handlers`
- use top-level metric names in the complete metrics autosummary where the names are already exported from `ignite.metrics`
- keep RecSys metrics grouped as `rec_sys.HitRate` and `rec_sys.NDCG`
- leave submodule-only entries unchanged to avoid changing public exports or creating duplicate generated docs labels
- resolve existing full submodule references to the new shortened generated docs targets where needed

## Verification
- `cd docs && rm -rf source/generated build/html build/doctrees && ../.venv/bin/sphinx-build -b html -E -a -W --keep-going source build/html`
- deployed and checked the generated docs from the fork preview: https://hariharan077.github.io/ignite/
- checked that the generated docs use short pages such as `ignite.handlers.Checkpoint` and `ignite.metrics.ConfusionMatrix`
- checked that RecSys metrics remain grouped as `ignite.metrics.rec_sys.HitRate` and `ignite.metrics.rec_sys.NDCG`
- checked that the docs build has no duplicate-label or nitpicky warnings for the updated autosummary entries