### PR TITLE
Fix CI linkcheck and MLflow file store

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -375,6 +375,9 @@ linkcheck_ignore = [
     "https://github.com/pytorch/pytorch/issues/7844#issuecomment-503713840",
     "https://github.com/pytorch/pytorch/issues/23430#issuecomment-562350407",
     r"https://pytorch\.org/xla/release/.*",
+    # PyTorch docs anchors occasionally move while the linked pages remain valid.
+    r"https://(docs\.)?pytorch\.org/docs/stable/.*#.*",
+    "https://aclanthology.org/W04-1013",
 ]
 
 linkcheck_allowed_redirects = {

--- a/tests/ignite/conftest.py
+++ b/tests/ignite/conftest.py
@@ -45,6 +45,7 @@ def pytest_configure(config):
     This function is a pytest hook (due to its name) and is run after command
     line parsing is complete in order to configure the test session.
     """
+    os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
     config.addinivalue_line("markers", "distributed: run distributed")
     config.addinivalue_line("markers", "multinode_distributed: distributed")
     config.addinivalue_line("markers", "tpu: run on tpu")


### PR DESCRIPTION
Split from #3772 per maintainer request so the CI-only fix can be reviewed and merged separately.

## Summary
- ignore unstable external docs anchors that currently break `linkcheck`
- set `MLFLOW_ALLOW_FILE_STORE=true` for the test suite so existing MLflow tests can use local file-store tracking

## Verification
- `python -m ruff format --check docs/source/conf.py tests/ignite/conftest.py`
- `python -m ruff check docs/source/conf.py tests/ignite/conftest.py`
- `git diff --check`
- `python -m pytest tests/ignite/handlers/test_mlflow_logger.py`
- `cd docs && rm -rf source/generated build/linkcheck build/doctrees && sphinx-build -b linkcheck -W --keep-going source build/linkcheck`