### PR TITLE
ci: pin third-party GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/binaries-nightly-release.yml
+++ b/.github/workflows/binaries-nightly-release.yml
@@ -11,10 +11,10 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniconda-version: "latest"
           python-version: "3.13"
@@ -53,7 +53,7 @@ jobs:
           twine check dist/*
           TWINE_USERNAME="${{ secrets.PYPI_USER }}" TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" twine upload --verbose dist/*
 
-      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         name: Create issue if nightly releases failed
         if: failure()
         env:

--- a/.github/workflows/binaries-nightly-release.yml
+++ b/.github/workflows/binaries-nightly-release.yml
@@ -11,10 +11,10 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
         with:
           miniconda-version: "latest"
           python-version: "3.13"
@@ -53,7 +53,7 @@ jobs:
           twine check dist/*
           TWINE_USERNAME="${{ secrets.PYPI_USER }}" TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" twine upload --verbose dist/*
 
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
         name: Create issue if nightly releases failed
         if: failure()
         env:

--- a/.github/workflows/code-style-checks.yml
+++ b/.github/workflows/code-style-checks.yml
@@ -46,14 +46,14 @@ jobs:
         python-version: ["3.10", "3.13"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/code-style-checks.yml
+++ b/.github/workflows/code-style-checks.yml
@@ -46,14 +46,14 @@ jobs:
         python-version: ["3.10", "3.13"]
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/discord_issues.yml
+++ b/.github/workflows/discord_issues.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: "Discuss on Discord-Issues"
         if: ${{ github.event.label.name == 'help wanted' }}
-        uses: EndBug/discuss-on-discord@v1.1.0
+        uses: EndBug/discuss-on-discord@bff2908cbd855fff72c1007aed386e09144727e1 # v1.1.0
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           destination: ${{ secrets.DISCORD_BOT_DESTINATION }}

--- a/.github/workflows/discord_pull_requests.yaml
+++ b/.github/workflows/discord_pull_requests.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: "Discuss on Discord-PR (Non-maintainer only)"
         if: ${{ github.event.label.name == 'help wanted' }}
-        uses: EndBug/discuss-on-discord@v1.1.0
+        uses: EndBug/discuss-on-discord@bff2908cbd855fff72c1007aed386e09144727e1 # v1.1.0
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           destination: ${{ secrets.DISCORD_BOT_DESTINATION }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,11 +24,11 @@ jobs:
       hvd_version: ${{ steps.set-versions.outputs.hvd_version }}
       msdp_version: ${{ steps.set-versions.outputs.msdp_version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Changed Files Exporter
         if: github.event_name == 'pull_request'
         id: files
-        uses: umani/changed-files@v4.2.0
+        uses: umani/changed-files@138acc60bcaa548e0c194fc69ed36321ee8466d2 # v4.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get a list of modified files
@@ -63,7 +63,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -73,7 +73,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -122,7 +122,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -132,7 +132,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -181,7 +181,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -191,7 +191,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -240,7 +240,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -250,7 +250,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
       hvd_version: ${{ steps.set-versions.outputs.hvd_version }}
       msdp_version: ${{ steps.set-versions.outputs.msdp_version }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Changed Files Exporter
         if: github.event_name == 'pull_request'
         id: files
@@ -63,7 +63,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -73,7 +73,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -122,7 +122,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -132,7 +132,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -181,7 +181,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -191,7 +191,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -240,7 +240,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -250,7 +250,7 @@ jobs:
         uses: ./test-infra/.github/actions/setup-linux
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,14 +25,14 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: "${{ matrix.python-version }}"
@@ -53,7 +53,7 @@ jobs:
         run: bash .github/workflows/build_docs.sh
 
       - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html
@@ -72,14 +72,14 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -95,7 +95,7 @@ jobs:
         run: bash .github/workflows/install_docs_deps.sh
 
       - name: make linkcheck
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 3
           timeout_minutes: 10
@@ -111,14 +111,14 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: "${{ matrix.python-version }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,14 +25,14 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: "${{ matrix.python-version }}"
@@ -53,7 +53,7 @@ jobs:
         run: bash .github/workflows/build_docs.sh
 
       - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html
@@ -72,14 +72,14 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -111,14 +111,14 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: "${{ matrix.python-version }}"

--- a/.github/workflows/gpu-hvd-tests.yml
+++ b/.github/workflows/gpu-hvd-tests.yml
@@ -39,7 +39,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -54,7 +54,7 @@ jobs:
           docker-image: ${{ env.DOCKER_IMAGE }}
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -163,7 +163,7 @@ jobs:
           docker exec -t pthd /bin/bash -c "${script}"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ${{ github.repository }}/coverage.xml
           flags: gpu-2

--- a/.github/workflows/gpu-hvd-tests.yml
+++ b/.github/workflows/gpu-hvd-tests.yml
@@ -39,7 +39,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -54,7 +54,7 @@ jobs:
           docker-image: ${{ env.DOCKER_IMAGE }}
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -163,7 +163,7 @@ jobs:
           docker exec -t pthd /bin/bash -c "${script}"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ${{ github.repository }}/coverage.xml
           flags: gpu-2

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -39,7 +39,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -54,7 +54,7 @@ jobs:
           docker-image: ${{ env.DOCKER_IMAGE }}
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -133,7 +133,7 @@ jobs:
           new_command_on_retry: docker exec -e USE_LAST_FAILED=1 -t pthd /bin/bash -xec 'bash tests/run_gpu_tests.sh 4'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ${{ github.repository }}/coverage.xml
           flags: gpu-2

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -39,7 +39,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
@@ -54,7 +54,7 @@ jobs:
           docker-image: ${{ env.DOCKER_IMAGE }}
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Run GPU Unit Tests
         continue-on-error: false
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 5
           timeout_minutes: 45
@@ -133,7 +133,7 @@ jobs:
           new_command_on_retry: docker exec -e USE_LAST_FAILED=1 -t pthd /bin/bash -xec 'bash tests/run_gpu_tests.sh 4'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ${{ github.repository }}/coverage.xml
           flags: gpu-2

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -33,14 +33,14 @@ jobs:
         pytorch-channel: [pytorch]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
         shell: bash -l {0}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -79,12 +79,12 @@ jobs:
       # Download MNIST: https://github.com/pytorch/ignite/issues/1737
       # to "/tmp" for cpu tests
       - name: Download MNIST
-        uses: pytorch-ignite/download-mnist-github-action@master
+        uses: pytorch-ignite/download-mnist-github-action@622fc8c4ff50b24322819f54f48624f26932892b # master
         with:
           target_dir: /tmp
 
       - name: Run Tests
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 3
           timeout_minutes: 40
@@ -93,7 +93,7 @@ jobs:
           new_command_on_retry: USE_LAST_FAILED=1 USE_XDIST=0 bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./coverage.xml
           flags: hvd-cpu

--- a/.github/workflows/hvd-tests.yml
+++ b/.github/workflows/hvd-tests.yml
@@ -33,14 +33,14 @@ jobs:
         pytorch-channel: [pytorch]
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
         shell: bash -l {0}
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -93,7 +93,7 @@ jobs:
           new_command_on_retry: USE_LAST_FAILED=1 USE_XDIST=0 bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ./coverage.xml
           flags: hvd-cpu

--- a/.github/workflows/mps-tests.yml
+++ b/.github/workflows/mps-tests.yml
@@ -49,14 +49,14 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
           path: test-infra
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -135,7 +135,7 @@ jobs:
           SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ${{ github.repository }}/coverage.xml
           flags: mps

--- a/.github/workflows/mps-tests.yml
+++ b/.github/workflows/mps-tests.yml
@@ -49,14 +49,14 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository (pytorch/test-infra)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: pytorch/test-infra
           path: test-infra
 
       - name: Checkout repository (${{ github.repository }})
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Support the use case where we need to checkout someone's fork
           repository: ${{ github.repository }}
@@ -117,7 +117,7 @@ jobs:
       # Download MNIST: https://github.com/pytorch/ignite/issues/1737
       # to "/tmp" for unit tests
       - name: Download MNIST
-        uses: pytorch-ignite/download-mnist-github-action@master
+        uses: pytorch-ignite/download-mnist-github-action@622fc8c4ff50b24322819f54f48624f26932892b # master
         with:
           target_dir: /tmp
 
@@ -135,7 +135,7 @@ jobs:
           SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ${{ github.repository }}/coverage.xml
           flags: mps

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -22,14 +22,14 @@ jobs:
         #     python-version: "3.12"
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
         shell: bash -l {0}
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytorch-version-tests.yml
+++ b/.github/workflows/pytorch-version-tests.yml
@@ -22,14 +22,14 @@ jobs:
         #     python-version: "3.12"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
         shell: bash -l {0}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -55,12 +55,12 @@ jobs:
           uv pip install .
 
       - name: Download MNIST
-        uses: pytorch-ignite/download-mnist-github-action@master
+        uses: pytorch-ignite/download-mnist-github-action@622fc8c4ff50b24322819f54f48624f26932892b # master
         with:
           target_dir: /tmp
 
       - name: Run Tests
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 5
           timeout_minutes: 15

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -8,10 +8,10 @@ jobs:
   conda-build-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
         with:
           miniconda-version: "latest"
           python-version: "3.13"

--- a/.github/workflows/stable-release-anaconda.yml
+++ b/.github/workflows/stable-release-anaconda.yml
@@ -8,10 +8,10 @@ jobs:
   conda-build-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniconda-version: "latest"
           python-version: "3.13"

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -8,10 +8,10 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: "3.13"

--- a/.github/workflows/stable-release-pypi.yml
+++ b/.github/workflows/stable-release-pypi.yml
@@ -8,10 +8,10 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: "3.13"

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -33,9 +33,9 @@ jobs:
         xla-version: [nightly]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
           architecture: "x64"
@@ -52,7 +52,7 @@ jobs:
           echo "pip_cache=$(pip cache dir)" >> $GITHUB_OUTPUT
         shell: bash -l {0}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ${{ steps.pip-cache.outputs.pip_cache }}
@@ -81,12 +81,12 @@ jobs:
       # Download MNIST: https://github.com/pytorch/ignite/issues/1737
       # to "/tmp" for tpu tests
       - name: Download MNIST
-        uses: pytorch-ignite/download-mnist-github-action@master
+        uses: pytorch-ignite/download-mnist-github-action@622fc8c4ff50b24322819f54f48624f26932892b # master
         with:
           target_dir: /tmp
 
       - name: Run Tests
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 5
           timeout_minutes: 25
@@ -101,7 +101,7 @@ jobs:
           XRT_WORKERS: "localservice:0;grpc://localhost:40934"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./coverage.xml
           flags: tpu

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -33,9 +33,9 @@ jobs:
         xla-version: [nightly]
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python 3.10
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
           architecture: "x64"
@@ -52,7 +52,7 @@ jobs:
           echo "pip_cache=$(pip cache dir)" >> $GITHUB_OUTPUT
         shell: bash -l {0}
 
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ${{ steps.pip-cache.outputs.pip_cache }}
@@ -101,7 +101,7 @@ jobs:
           XRT_WORKERS: "localservice:0;grpc://localhost:40934"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ./coverage.xml
           flags: tpu

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,9 +13,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Pull Request Labeler
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           configuration-path: .github/pr-labeler-config.yml
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,9 +13,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Pull Request Labeler
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           configuration-path: .github/pr-labeler-config.yml
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/typing-checks.yml
+++ b/.github/workflows/typing-checks.yml
@@ -39,14 +39,14 @@ jobs:
         pytorch-channel: [pytorch]
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/typing-checks.yml
+++ b/.github/workflows/typing-checks.yml
@@ -39,14 +39,14 @@ jobs:
         pytorch-channel: [pytorch]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -58,14 +58,14 @@ jobs:
             skip-distrib-tests: 1
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -112,7 +112,7 @@ jobs:
           new_command_on_retry: USE_LAST_FAILED=1 SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ./coverage.xml
           flags: cpu

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -58,14 +58,14 @@ jobs:
             skip-distrib-tests: 1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get year & week number
         id: get-date
         run: |
           echo "date=$(/bin/date "+%Y-%U")" >> $GITHUB_OUTPUT
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           python-version: ${{ matrix.python-version }}
@@ -93,7 +93,7 @@ jobs:
       # Download MNIST: https://github.com/pytorch/ignite/issues/1737
       # to "/tmp" for unit tests
       - name: Download MNIST
-        uses: pytorch-ignite/download-mnist-github-action@master
+        uses: pytorch-ignite/download-mnist-github-action@622fc8c4ff50b24322819f54f48624f26932892b # master
         with:
           target_dir: /tmp
 
@@ -103,7 +103,7 @@ jobs:
           cp -R /tmp/MNIST .
 
       - name: Run Tests
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 5
           timeout_minutes: 15
@@ -112,7 +112,7 @@ jobs:
           new_command_on_retry: USE_LAST_FAILED=1 SKIP_DISTRIB_TESTS=${{ matrix.skip-distrib-tests }} bash tests/run_cpu_tests.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./coverage.xml
           flags: cpu


### PR DESCRIPTION
## Pin third-party GitHub Actions to full commit SHAs

This follows up on #3754. As @vfdev-5 suggested there (https://github.com/pytorch/ignite/pull/3754#issuecomment-4623823964), the higher-value hardening for these workflows is pinning the action references rather than touching permissions, so this PR does exactly that and nothing else.

Every external action `uses:` reference in `.github/workflows/` that was on a tag or branch (`actions/checkout@v6`, `astral-sh/setup-uv@v7`, `codecov/codecov-action@v6`, the `triage.yml` `@v*` refs, etc.) is now pinned to the full 40-character commit SHA, with the version kept as a trailing comment in the OpenSSF-recommended form:

```yaml
uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
```

### Why

A tag like `@v6` is mutable: the action author (or someone who compromises their account) can force-move it to point at different code at any time, and your CI would pick up that code on the next run with no diff in this repo. That is the mechanism behind the `tj-actions/changed-files` incident in March 2025, where a moved tag exposed secrets across thousands of repositories. A commit SHA is immutable, so pinning to it removes that class of supply-chain risk while still running the same code the tag points at today.

### Details

- Each SHA was resolved from the exact commit the current tag points to (annotated tags dereferenced to the underlying commit), so there is no behavior or version change here, only an immutable pin.
- Dependabot keeps working: with the github-actions ecosystem enabled it reads the version from the trailing comment and will continue to open bump PRs (and re-pin to the new SHA), so this does not freeze the actions or add maintenance burden.
- Local reusable actions (`./test-infra/.github/actions/...`) are intentionally left unpinned, since they resolve from the checked-out tree, not an external tag.
- Commented-out example steps were left untouched.
- No `permissions:` blocks or any other workflow content were changed; this PR is only SHA pinning.

Happy to adjust the comment style or split this per-file if you would prefer smaller diffs.
