### PR TITLE
Improve code coverage for ignite/engine/engine.py

### DIFF
--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -1,6 +1,7 @@
 import math
 import os
 import time
+import weakref
 from unittest.mock import call, MagicMock, Mock
 
 import numpy as np
@@ -1393,6 +1394,46 @@ class TestEngine:
 
         with pytest.raises(ValueError, match="epoch_length should be provided if data is None"):
             engine.run(None, max_epochs=5)
+
+    def test_fire_event_raises_when_engine_ref_not_resolved(self):
+        # covers: RuntimeError raised in _fire_event when the engine weakref
+        # resolves to None (e.g. the engine has been garbage collected)
+        engine = Engine(lambda e, b: None)
+
+        class _Dummy:
+            pass
+
+        dead = _Dummy()
+        dead_ref = weakref.ref(dead)
+        del dead  # weakref now resolves to None
+
+        assert dead_ref() is None
+        # craft a handler whose first arg is a dead weakref to the engine
+        engine._event_handlers[Events.STARTED].append((MagicMock(), (dead_ref,), {}))
+
+        with pytest.raises(RuntimeError, match="Engine reference not resolved"):
+            engine._fire_event(Events.STARTED)
+
+    def test_run_handles_process_function_exception(self):
+        # covers: the `except Exception` block in _run_once_on_dataset (generator
+        # path) and _run_once_on_dataset_legacy when process_function raises;
+        # the exception is routed to the Events.EXCEPTION_RAISED handler
+        def process_fn(engine, batch):
+            raise ValueError("process function error")
+
+        engine = Engine(process_fn)
+
+        caught = []
+
+        @engine.on(Events.EXCEPTION_RAISED)
+        def on_exception(engine, e):
+            caught.append(e)
+
+        engine.run([0, 1, 2], max_epochs=1)
+
+        assert len(caught) == 1
+        assert isinstance(caught[0], ValueError)
+        assert str(caught[0]) == "process function error"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Adds tests for two previously-untested branches in `ignite/engine/engine.py`,
identified via `coverage report --show-missing`:

- **`_fire_event` engine-ref guard** (line 447): the `RuntimeError("Engine reference not resolved...")`
  raised when a handler's engine weakref resolves to `None`.
- **`_run_once_on_dataset` exception handling** (lines 1358-1360): the `except Exception`
  block that routes a `process_function` error to `Events.EXCEPTION_RAISED`. Covered on both
  the generator and legacy paths via the existing `interrupt_resume_enabled=[False, True]`
  parametrize on `TestEngine`.

After these, the only uncovered lines left in `engine.py` are the three internal
"please file an issue if you encounter this" guards (960, 1083, 1270), which are
not reachable through the public API without monkeypatching internal state.

## Check list

- [x] New tests added and passing locally
- [x] No changes to library source (test-only)

Towards #1790

cc @vfdev-5
