### PR TITLE
DOC: improve README logo in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 <!-- ![Ignite Logo](assets/logo/ignite_logo_mixed.svg) -->
 
-<img src="https://raw.githubusercontent.com/pytorch/ignite/master/assets/logo/ignite_logo_mixed.svg" width=512>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/pytorch/ignite/master/assets/logo/ignite_logo_mixed_light.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/pytorch/ignite/master/assets/logo/ignite_logo_mixed.svg">
+  <img src="https://raw.githubusercontent.com/pytorch/ignite/master/assets/logo/ignite_logo_mixed.svg"
+       alt="PyTorch-Ignite logo"
+       width="512">
+</picture>
 
 <!-- [![image](https://travis-ci.com/pytorch/ignite.svg?branch=master)](https://travis-ci.com/pytorch/ignite) -->
 


### PR DESCRIPTION
This PR improves logo rendering across light and dark themes by switching the displayed asset based on the viewer's color scheme.

Proposed README snippet:

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/pytorch/ignite/master/assets/logo/ignite_logo_mixed_light.svg">
  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/pytorch/ignite/master/assets/logo/ignite_logo_mixed.svg">
  <img src="https://raw.githubusercontent.com/pytorch/ignite/master/assets/logo/ignite_logo_mixed.svg"
       alt="PyTorch-Ignite logo"
       width="512">
</picture>
```

Preview of the current and updated rendering:

<p align="center">
  <img width="33%" alt="Current logo rendering" src="https://github.com/user-attachments/assets/d47967ea-ba7a-406f-99f4-ea5983209316" />
  <img width="33%" alt="Updated logo in light mode" src="https://github.com/user-attachments/assets/cdcfb80f-c1b7-40db-b06b-45694c795d99" />
  <img width="33%" alt="Updated logo in dark mode" src="https://github.com/user-attachments/assets/b0c59210-c117-450f-8034-1c05b1c75909" />
</p>

The first image is the proposed change, and the third is what the logo currently looks like.