### PR TITLE
Downgrading mlflow to avoid protobuf issues on nightly builds.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install -r requirements-dev.txt
+          uv pip install protobuf==3.18.1 --force-reinstall
           uv pip install .
           uv pip list
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,6 +35,8 @@ jobs:
   cpu-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 85
+    env:
+      PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     defaults:
       run:
         shell: bash
@@ -87,7 +89,6 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install -r requirements-dev.txt
-          uv pip install protobuf==3.18.1 --force-reinstall
           uv pip install .
           uv pip list
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,8 +35,8 @@ jobs:
   cpu-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 85
-    env:
-      PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
+    # env:
+    #   PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     defaults:
       run:
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,8 +35,6 @@ jobs:
   cpu-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 85
-    # env:
-    #   PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     defaults:
       run:
         shell: bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ tensorboardX
 # visdom  # Removed: unmaintained package, cannot be installed with modern packages
 polyaxon
 wandb
-mlflow
+mlflow==3.6.0
 neptune-client>=0.16.17
 tensorboard
 torchvision

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,7 @@ tensorboardX
 # visdom  # Removed: unmaintained package, cannot be installed with modern packages
 polyaxon
 wandb
+# Temporary workaround due to protobuf incompatbilities: see https://github.com/pytorch/ignite/pull/3784
 mlflow==3.12.0
 neptune-client>=0.16.17
 tensorboard

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ tensorboardX
 # visdom  # Removed: unmaintained package, cannot be installed with modern packages
 polyaxon
 wandb
-mlflow==3.6.0
+mlflow==3.12.0
 neptune-client>=0.16.17
 tensorboard
 torchvision


### PR DESCRIPTION
## Description:
Nightly CI/CD builds for pytorch/ignite were failing due to a protobuf compatibility issue introduced by a newer version of mlflow. This PR fixes the broken nightly test pipeline by downgrading mlflow to the last known working version, which resolves the protobuf conflict without requiring changes to the core library code.

Changes made:
- Downgraded mlflow in requirements-dev.txt to a stable version compatible with the current protobuf setup
- Investigated and ruled out alternative fixes (e.g., switching to Python backend for protobuf via env variable)

Root cause:
A newer mlflow release pulled in a protobuf version that conflicted with the nightly build environment, causing CI failures unrelated to any code changes in ignite itself.


Error message:
```
tests/ignite/contrib/handlers/test_logger_utils.py::test_setup_mlflow_logging FAILED [ 10%]
  tests/ignite/handlers/test_mlflow_logger.py::test_output_handler_output_transform FAILED [ 20%]
  tests/ignite/handlers/test_mlflow_logger.py::test_output_handler_metric_names FAILED [ 30%]
  tests/ignite/handlers/test_mlflow_logger.py::test_output_handler_both FAILED [ 40%]
  tests/ignite/handlers/test_mlflow_logger.py::test_output_handler_with_global_step_transform FAILED [ 50%]
  tests/ignite/handlers/test_mlflow_logger.py::test_output_handler_with_global_step_from_engine FAILED [ 60%]
  tests/ignite/handlers/test_mlflow_logger.py::test_output_handler_state_attrs FAILED [ 70%]
  tests/ignite/handlers/test_mlflow_logger.py::test_integration FAILED     [ 80%]
  tests/ignite/handlers/test_mlflow_logger.py::test_integration_as_context_manager FAILED [ 90%]
  tests/ignite/handlers/test_mlflow_logger.py::test_mlflow_bad_metric_name_handling FAILED [100%]
  
  =================================== FAILURES ===================================
  __________________________ test_setup_mlflow_logging ___________________________
  
  dirname = PosixPath('/tmp/tmpay6xvoa5')
  
      @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skip on Windows")
      def test_setup_mlflow_logging(dirname):
  >       mlf_logger = _test_setup_logging(
              setup_logging_fn=setup_mlflow_logging,
              kwargs_dict={"tracking_uri": str(dirname / "p1")},
              output_handler_cls=handlers.mlflow_logger.OutputHandler,
              opt_params_handler_cls=handlers.mlflow_logger.OptimizerParamsHandler,
              with_eval=False,
              with_optim=False,
          )
  
  tests/ignite/contrib/handlers/test_logger_utils.py:243: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  tests/ignite/contrib/handlers/test_logger_utils.py:66: in _test_setup_logging
      x_logger = setup_logging_fn(**kwargs_dict)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ignite/handlers/logger_utils.py:271: in setup_mlflow_logging
      logger = MLflowLogger(**kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^
  ignite/handlers/mlflow_logger.py:148: in __init__
      import mlflow
  .venv/lib/python3.13/site-packages/mlflow/__init__.py:44: in <module>
      from mlflow import (
  .venv/lib/python3.13/site-packages/mlflow/artifacts/__init__.py:11: in <module>
      from mlflow.entities.file_info import FileInfo
  .venv/lib/python3.13/site-packages/mlflow/entities/__init__.py:15: in <module>
      from mlflow.entities.dataset import Dataset
  .venv/lib/python3.13/site-packages/mlflow/entities/dataset.py:2: in <module>
      from mlflow.protos.service_pb2 import Dataset as ProtoDataset
  .venv/lib/python3.13/site-packages/mlflow/protos/service_pb2.py:26: in <module>
      from opentelemetry.proto.trace.v1 import trace_pb2 as opentelemetry_dot_proto_dot_trace_dot_v1_dot_trace__pb2
  .venv/lib/python3.13/site-packages/opentelemetry/proto/trace/v1/trace_pb2.py:14: in <module>
      from opentelemetry.proto.common.v1 import common_pb2 as opentelemetry_dot_proto_dot_common_dot_v1_dot_common__pb2
  .venv/lib/python3.13/site-packages/opentelemetry/proto/common/v1/common_pb2.py:36: in <module>
      _descriptor.FieldDescriptor(
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  cls = <class 'google.protobuf.descriptor.FieldDescriptor'>
  name = 'string_value'
  full_name = 'opentelemetry.proto.common.v1.AnyValue.string_value', index = 0
  number = 1, type = 9, cpp_type = 9, label = 1, default_value = ''
  message_type = None, enum_type = None, containing_type = None
  is_extension = False, extension_scope = None, options = None
  serialized_options = None, has_default_value = False, containing_oneof = None
  json_name = None
  file = <google._upb._message.FileDescriptor object at 0x7f0f7db704f0>
  create_key = <object object at 0x7f0f7eb276d0>
  
      def __new__(
          cls,
          name,
          full_name,
          index,
          number,
          type,
          cpp_type,
          label,
          default_value,
          message_type,
          enum_type,
          containing_type,
          is_extension,
          extension_scope,
          options=None,
          serialized_options=None,
          has_default_value=True,
          containing_oneof=None,
          json_name=None,
          file=None,
          create_key=None,
      ):  # pylint: disable=redefined-builtin
  >     _message.Message._CheckCalledFromGeneratedFile()
  E     TypeError: Descriptors cannot be created directly.
  E     If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
  E     If you cannot immediately regenerate your protos, some other possible workarounds are:
  E      1. Downgrade the protobuf package to 3.20.x or lower.
  E      2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
  E     
  E     More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
  
  .venv/lib/python3.13/site-packages/google/protobuf/descriptor.py:675: TypeError
```