### PR TITLE
Remove deprecated `setup_any_logging` function

### DIFF
--- a/ignite/contrib/engines/common.py
+++ b/ignite/contrib/engines/common.py
@@ -45,7 +45,7 @@ from ignite.handlers.checkpoint import BaseSaveHandler
 from ignite.handlers.param_scheduler import ParamScheduler
 from ignite.metrics import GpuInfo, RunningAverage
 from ignite.metrics.metric import RunningBatchWise
-from ignite.utils import deprecated
+
 
 
 def setup_common_training_handlers(
@@ -287,21 +287,7 @@ def empty_cuda_cache(_: Engine) -> None:
     gc.collect()
 
 
-@deprecated(
-    "0.4.0",
-    "0.6.0",
-    ("Please use instead: setup_tb_logging, setup_visdom_logging or setup_mlflow_logging etc.",),
-    raise_exception=True,
-)
-def setup_any_logging(
-    logger: BaseLogger,
-    logger_module: Any,
-    trainer: Engine,
-    optimizers: Optimizer | dict[str, Optimizer] | dict[None, Optimizer] | None,
-    evaluators: Engine | dict[str, Engine] | None,
-    log_every_iters: int,
-) -> None:
-    pass
+
 
 
 get_default_score_fn = Checkpoint.get_default_score_fn

--- a/tests/ignite/contrib/handlers/test_logger_utils.py
+++ b/tests/ignite/contrib/handlers/test_logger_utils.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ignite.handlers as handlers
-from ignite.contrib.engines.common import setup_any_logging
+
 from ignite.engine import Engine, Events
 from ignite.handlers.logger_utils import (
     _setup_logging,
@@ -98,10 +98,6 @@ def _test_setup_logging(
 
     return x_logger
 
-
-def test_deprecated_setup_any_logging():
-    with pytest.raises(DeprecationWarning, match=r"deprecated since version 0.4.0"):
-        setup_any_logging(None, None, None, None, None, None)
 
 
 def test__setup_logging_wrong_args():


### PR DESCRIPTION
… 0.6.0

Fixes #3787

Description:## Summary

`setup_any_logging` was deprecated in version 0.4.0 and scheduled for 
removal in 0.6.0. Since we are now at 0.6.0, this PR removes the function 
and its corresponding test.

## Changes
- Removed `setup_any_logging` function from `ignite/contrib/engines/common.py`
- Removed unused `deprecated` import from `ignite/contrib/engines/common.py`
- Removed `test_deprecated_setup_any_logging` test from `tests/ignite/contrib/handlers/test_logger_utils.py`

Fixes the TODO introduced in #your-issue-number (if applicable)

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
