### PR TITLE
fix: prevent once handlers from refiring on epoch termination

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -325,6 +325,9 @@ class Engine(Serializable):
             return RemovableEventHandle(event_name, handler, self)
         if isinstance(event_name, CallableEventWithFilter) and event_name.filter is not None:
             event_filter = event_name.filter
+            once = getattr(event_filter, "_once", None)
+            if once is not None:
+                event_filter = Events.once_event_filter(list(once))
             handler = self._handler_wrapper(handler, event_name, event_filter)
 
         self._assert_allowed_event(event_name)

--- a/ignite/engine/events.py
+++ b/ignite/engine/events.py
@@ -140,12 +140,15 @@ class CallableEventWithFilter:
     @staticmethod
     def once_event_filter(once: list) -> Callable:
         """A wrapper for once event filter."""
+        remaining = set(once)
 
         def wrapper(engine: "Engine", event: int) -> bool:
-            if event in once:
+            if event in remaining:
+                remaining.remove(event)
                 return True
             return False
 
+        wrapper._once = tuple(once)  # type: ignore[attr-defined]
         return wrapper
 
     @staticmethod

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -395,6 +395,7 @@ class TestEngine:
 
             epoch_completed_events = [e for e in engine.called_events if e[2] == Events.EPOCH_COMPLETED.name]
             assert len(epoch_completed_events) == max_epochs - skip_epoch_completed
+            assert call_count == 1
 
     @pytest.mark.parametrize("data", [None, "mock_data_loader"])
     def test_iteration_events_are_fired(self, data):


### PR DESCRIPTION
## Summary

Fixes a case where `Events.GET_BATCH_STARTED(once=N)` could fire twice if `engine.terminate_epoch(False)` was called from that handler. `once` filters now consume matched values and each registered handler gets an independent once filter instance.

## Changes

- Make `once` event filters stateful so matched values are only emitted once.
- Clone once filters per handler registration to avoid sharing consumed state between handlers.
- Add a regression assertion to the epoch-termination event sequence test.

## Testing

- `python3 -m pytest tests/ignite/engine/test_engine.py::TestEngine::test_terminate_epoch_events_sequence -q`
- `python3 -m pytest tests/ignite/engine/test_custom_events.py::test_once_event_filter tests/ignite/engine/test_custom_events.py::test_custom_events_with_events_list -q`
- `python3 -m pytest tests/ignite/engine/test_engine.py tests/ignite/engine/test_custom_events.py -q -m 'not distributed'`

Fixes pytorch/ignite#3625
