### PR TITLE
feat: Add top-k multilabel precision and recall metrics

### DIFF
--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -350,6 +350,8 @@ Complete list of metrics
     RunningAverage
     SSIM
     TopKCategoricalAccuracy
+    TopKMultilabelPrecision
+    TopKMultilabelRecall
     Bleu
     Rouge
     RougeL

--- a/ignite/metrics/__init__.py
+++ b/ignite/metrics/__init__.py
@@ -44,6 +44,7 @@ from ignite.metrics.root_mean_squared_error import RootMeanSquaredError
 from ignite.metrics.running_average import RunningAverage
 from ignite.metrics.ssim import SSIM
 from ignite.metrics.top_k_categorical_accuracy import TopKCategoricalAccuracy
+from ignite.metrics.top_k_multilabel_precision_recall import TopKMultilabelPrecision, TopKMultilabelRecall
 from ignite.metrics.vision.object_detection_average_precision_recall import (
     coco_tensor_list_to_dict_list,
     CommonObjectDetectionMetrics,
@@ -64,6 +65,8 @@ __all__ = [
     "CosineSimilarity",
     "ClassificationReport",
     "TopKCategoricalAccuracy",
+    "TopKMultilabelPrecision",
+    "TopKMultilabelRecall",
     "Average",
     "DiceCoefficient",
     "Entropy",

--- a/ignite/metrics/top_k_multilabel_precision_recall.py
+++ b/ignite/metrics/top_k_multilabel_precision_recall.py
@@ -11,7 +11,7 @@ __all__ = ["TopKMultilabelPrecision", "TopKMultilabelRecall"]
 class _BaseTopKMultilabelPrecisionRecall(_BasePrecisionRecall):
     """Base class for top-k multilabel precision and recall metrics.
 
-    For each sample, the ``k`` labels with the highest prediction scores are
+    For each sample, the k labels with the highest prediction scores are
     selected as positive predictions. Precision and recall are then computed per
     label, treating each label independently across the accumulated samples.
     """
@@ -37,14 +37,7 @@ class _BaseTopKMultilabelPrecisionRecall(_BasePrecisionRecall):
         )
 
     def _check_type(self, output: Sequence[torch.Tensor]) -> None:
-        self._check_shape(output)
         y_pred, y = output
-
-        if not (y.shape == y_pred.shape and y.ndimension() > 1 and y.shape[1] > 1):
-            raise ValueError(
-                "y and y_pred must have same shape of (batch_size, num_labels, ...) "
-                f"with num_labels > 1, but given {y.shape} vs {y_pred.shape}."
-            )
 
         if not torch.equal(y, y**2):
             raise ValueError("For multilabel cases, y must be comprised of 0's and 1's.")
@@ -59,9 +52,7 @@ class _BaseTopKMultilabelPrecisionRecall(_BasePrecisionRecall):
         elif self._type != "multilabel":
             raise RuntimeError(f"Input data type has changed from {self._type} to multilabel.")
         elif self._num_classes != num_labels:
-            raise ValueError(
-                f"Input data number of labels has changed from {self._num_classes} to {num_labels}."
-            )
+            raise ValueError(f"Input data number of labels has changed from {self._num_classes} to {num_labels}.")
 
     def _prepare_output(self, output: Sequence[torch.Tensor]) -> Sequence[torch.Tensor]:
         y_pred, y = output[0].detach(), output[1].detach()
@@ -70,6 +61,8 @@ class _BaseTopKMultilabelPrecisionRecall(_BasePrecisionRecall):
         y_pred = torch.transpose(y_pred, 1, -1).reshape(-1, num_labels)
         y = torch.transpose(y, 1, -1).reshape(-1, num_labels)
 
+        # Select the top-k highest-scoring labels per sample as positive predictions.
+        # k is clamped to num_labels: when k >= num_labels every label is selected.
         k = min(self._k, num_labels)
         topk_indices = torch.topk(y_pred, k, dim=1).indices
         y_pred_topk = torch.zeros_like(y_pred)
@@ -85,26 +78,128 @@ class _BaseTopKMultilabelPrecisionRecall(_BasePrecisionRecall):
 class TopKMultilabelPrecision(_BaseTopKMultilabelPrecisionRecall):
     r"""Calculates top-k precision for multilabel data.
 
-    For each sample, the ``k`` labels with the highest scores are treated as
-    positive predictions. Per-label precision is then computed as
+    For each sample, the ``k`` labels with the highest prediction scores are treated as positive
+    predictions. Per-label precision is then computed as
 
     .. math:: \text{Precision}_k = \frac{TP_k}{TP_k + FP_k}
 
-    where :math:`TP_k` and :math:`FP_k` are counted per label across samples.
+    where :math:`TP_k` is the number of true positives and :math:`FP_k` the number of false positives,
+    counted per label across all accumulated samples.
 
     - ``update`` must receive output of the form ``(y_pred, y)``.
-    - ``y_pred`` must be prediction scores of shape ``(batch_size, num_labels, ...)``.
-    - ``y`` must be a binary tensor of the same shape as ``y_pred``.
+    - ``y_pred`` must contain prediction scores of shape ``(batch_size, num_labels, ...)``.
+    - ``y`` must be a binary tensor (0's and 1's) of the same shape as ``y_pred``.
 
     Args:
-        k: number of top-scoring labels to consider as positive predictions per sample.
+        k: number of top-scoring labels to consider as positive predictions per sample. If ``k`` is greater
+            than the number of labels, it is clamped to the number of labels (i.e. every label is selected).
+            By default, 5.
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
-            form expected by the metric.
-        average: reduction option. Same semantics as :class:`~ignite.metrics.precision.Precision`
-            for multilabel inputs.
-        device: specifies which device updates are accumulated on.
-        skip_unrolling: specifies whether output should be unrolled before being fed to update method.
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        average: available options are
+
+            False
+              default option. Per label precision is returned.
+
+            None
+              like the ``False`` option.
+
+            'micro'
+              precision is computed counting stats of all labels altogether.
+
+              .. math::
+                  \text{Micro Precision} = \frac{\sum_{k=1}^C TP_k}{\sum_{k=1}^C TP_k+FP_k}
+
+              where :math:`C` is the number of labels.
+
+            'samples'
+              precision is computed on a per sample basis and then averaged across samples.
+
+              .. math::
+                  \text{Sample-averaged Precision} = \frac{\sum_{n=1}^N \frac{TP_n}{TP_n+FP_n}}{N}
+
+              where :math:`N` is the number of samples.
+
+            'weighted'
+              like macro precision but considers label imbalance. It computes precision for each label
+              then returns the average of them weighted by the support of labels (number of actual positive
+              samples in each label).
+
+              .. math::
+                  \text{Weighted Precision} = \frac{\sum_{k=1}^C P_k \cdot \text{Precision}_k}{\sum_{k=1}^C P_k}
+
+              where :math:`P_k` is the number of positive samples belonging to label :math:`k`.
+
+            macro
+              computes macro precision which is the unweighted average of the per-label precision.
+
+              .. math::
+                  \text{Macro Precision} = \frac{\sum_{k=1}^C \text{Precision}_k}{C}
+
+            True
+              like macro option.
+        device: specifies which device updates are accumulated on. Setting the metric's
+            device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
+            default, CPU.
+        skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
+            true for multi-output model, for example, if ``y_pred`` contains multi-output as ``(y_pred_a, y_pred_b)``
+            Alternatively, ``output_transform`` can be used to handle this.
+
+    Examples:
+
+        For more information on how metric works with :class:`~ignite.engine.engine.Engine`, visit :ref:`attach-engine`.
+
+        .. include:: defaults.rst
+            :start-after: :orphan:
+
+        The shapes must be ``(batch_size, num_labels, ...)``. ``y_pred`` holds prediction scores and ``y`` is binary.
+
+        .. testcode::
+
+            metric = TopKMultilabelPrecision(k=2)
+            micro_metric = TopKMultilabelPrecision(k=2, average='micro')
+            macro_metric = TopKMultilabelPrecision(k=2, average=True)
+            weighted_metric = TopKMultilabelPrecision(k=2, average='weighted')
+            samples_metric = TopKMultilabelPrecision(k=2, average='samples')
+
+            metric.attach(default_evaluator, "precision")
+            micro_metric.attach(default_evaluator, "micro precision")
+            macro_metric.attach(default_evaluator, "macro precision")
+            weighted_metric.attach(default_evaluator, "weighted precision")
+            samples_metric.attach(default_evaluator, "samples precision")
+
+            y_true = torch.tensor([
+                [0, 1, 0, 1],
+                [1, 0, 0, 1],
+                [0, 0, 1, 0],
+                [1, 1, 0, 0],
+                [0, 1, 1, 0],
+            ])
+            y_pred = torch.tensor([
+                [0.1, 0.9, 0.2, 0.8],
+                [0.7, 0.3, 0.6, 0.4],
+                [0.2, 0.5, 0.6, 0.1],
+                [0.9, 0.85, 0.05, 0.1],
+                [0.3, 0.7, 0.75, 0.2],
+            ])
+            state = default_evaluator.run([[y_pred, y_true]])
+            print(f"Precision: {state.metrics['precision']}")
+            print(f"Micro Precision: {state.metrics['micro precision']}")
+            print(f"Macro Precision: {state.metrics['macro precision']}")
+            print(f"Weighted Precision: {state.metrics['weighted precision']}")
+            print(f"Samples Precision: {state.metrics['samples precision']}")
+
+        .. testoutput::
+
+            Precision: tensor([1.0000, 0.7500, 0.6667, 1.0000], dtype=torch.float64)
+            Micro Precision: 0.8
+            Macro Precision: 0.8541666666666666
+            Weighted Precision: 0.8425925925925926
+            Samples Precision: 0.8
+
+    .. versionadded:: 0.6.0
     """
 
     @reinit__is_reduced
@@ -121,7 +216,7 @@ class TopKMultilabelPrecision(_BaseTopKMultilabelPrecisionRecall):
         elif self._average == "micro":
             self._denominator += y_pred.sum()
             self._numerator += correct.sum()
-        else:
+        else:  # _average in [False, None, 'macro', 'weighted']
             self._denominator += y_pred.sum(dim=0)
             self._numerator += correct.sum(dim=0)
 
@@ -134,26 +229,128 @@ class TopKMultilabelPrecision(_BaseTopKMultilabelPrecisionRecall):
 class TopKMultilabelRecall(_BaseTopKMultilabelPrecisionRecall):
     r"""Calculates top-k recall for multilabel data.
 
-    For each sample, the ``k`` labels with the highest scores are treated as
-    positive predictions. Per-label recall is then computed as
+    For each sample, the ``k`` labels with the highest prediction scores are treated as positive
+    predictions. Per-label recall is then computed as
 
     .. math:: \text{Recall}_k = \frac{TP_k}{TP_k + FN_k}
 
-    where :math:`TP_k` and :math:`FN_k` are counted per label across samples.
+    where :math:`TP_k` is the number of true positives and :math:`FN_k` the number of false negatives,
+    counted per label across all accumulated samples.
 
     - ``update`` must receive output of the form ``(y_pred, y)``.
-    - ``y_pred`` must be prediction scores of shape ``(batch_size, num_labels, ...)``.
-    - ``y`` must be a binary tensor of the same shape as ``y_pred``.
+    - ``y_pred`` must contain prediction scores of shape ``(batch_size, num_labels, ...)``.
+    - ``y`` must be a binary tensor (0's and 1's) of the same shape as ``y_pred``.
 
     Args:
-        k: number of top-scoring labels to consider as positive predictions per sample.
+        k: number of top-scoring labels to consider as positive predictions per sample. If ``k`` is greater
+            than the number of labels, it is clamped to the number of labels (i.e. every label is selected).
+            By default, 5.
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
-            form expected by the metric.
-        average: reduction option. Same semantics as :class:`~ignite.metrics.recall.Recall`
-            for multilabel inputs.
-        device: specifies which device updates are accumulated on.
-        skip_unrolling: specifies whether output should be unrolled before being fed to update method.
+            form expected by the metric. This can be useful if, for example, you have a multi-output model and
+            you want to compute the metric with respect to one of the outputs.
+        average: available options are
+
+            False
+              default option. Per label recall is returned.
+
+            None
+              like the ``False`` option.
+
+            'micro'
+              recall is computed counting stats of all labels altogether.
+
+              .. math::
+                  \text{Micro Recall} = \frac{\sum_{k=1}^C TP_k}{\sum_{k=1}^C TP_k+FN_k}
+
+              where :math:`C` is the number of labels.
+
+            'samples'
+              recall is computed on a per sample basis and then averaged across samples.
+
+              .. math::
+                  \text{Sample-averaged Recall} = \frac{\sum_{n=1}^N \frac{TP_n}{TP_n+FN_n}}{N}
+
+              where :math:`N` is the number of samples.
+
+            'weighted'
+              like macro recall but considers label imbalance. It computes recall for each label
+              then returns the average of them weighted by the support of labels (number of actual positive
+              samples in each label).
+
+              .. math::
+                  \text{Weighted Recall} = \frac{\sum_{k=1}^C P_k \cdot \text{Recall}_k}{\sum_{k=1}^C P_k}
+
+              where :math:`P_k` is the number of positive samples belonging to label :math:`k`.
+
+            macro
+              computes macro recall which is the unweighted average of the per-label recall.
+
+              .. math::
+                  \text{Macro Recall} = \frac{\sum_{k=1}^C \text{Recall}_k}{C}
+
+            True
+              like macro option.
+        device: specifies which device updates are accumulated on. Setting the metric's
+            device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
+            default, CPU.
+        skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
+            true for multi-output model, for example, if ``y_pred`` contains multi-output as ``(y_pred_a, y_pred_b)``
+            Alternatively, ``output_transform`` can be used to handle this.
+
+    Examples:
+
+        For more information on how metric works with :class:`~ignite.engine.engine.Engine`, visit :ref:`attach-engine`.
+
+        .. include:: defaults.rst
+            :start-after: :orphan:
+
+        The shapes must be ``(batch_size, num_labels, ...)``. ``y_pred`` holds prediction scores and ``y`` is binary.
+
+        .. testcode::
+
+            metric = TopKMultilabelRecall(k=2)
+            micro_metric = TopKMultilabelRecall(k=2, average='micro')
+            macro_metric = TopKMultilabelRecall(k=2, average=True)
+            weighted_metric = TopKMultilabelRecall(k=2, average='weighted')
+            samples_metric = TopKMultilabelRecall(k=2, average='samples')
+
+            metric.attach(default_evaluator, "recall")
+            micro_metric.attach(default_evaluator, "micro recall")
+            macro_metric.attach(default_evaluator, "macro recall")
+            weighted_metric.attach(default_evaluator, "weighted recall")
+            samples_metric.attach(default_evaluator, "samples recall")
+
+            y_true = torch.tensor([
+                [0, 1, 0, 1],
+                [1, 0, 0, 1],
+                [0, 0, 1, 0],
+                [1, 1, 0, 0],
+                [0, 1, 1, 0],
+            ])
+            y_pred = torch.tensor([
+                [0.1, 0.9, 0.2, 0.8],
+                [0.7, 0.3, 0.6, 0.4],
+                [0.2, 0.5, 0.6, 0.1],
+                [0.9, 0.85, 0.05, 0.1],
+                [0.3, 0.7, 0.75, 0.2],
+            ])
+            state = default_evaluator.run([[y_pred, y_true]])
+            print(f"Recall: {state.metrics['recall']}")
+            print(f"Micro Recall: {state.metrics['micro recall']}")
+            print(f"Macro Recall: {state.metrics['macro recall']}")
+            print(f"Weighted Recall: {state.metrics['weighted recall']}")
+            print(f"Samples Recall: {state.metrics['samples recall']}")
+
+        .. testoutput::
+
+            Recall: tensor([1.0000, 1.0000, 1.0000, 0.5000], dtype=torch.float64)
+            Micro Recall: 0.8888888888888888
+            Macro Recall: 0.875
+            Weighted Recall: 0.8888888888888888
+            Samples Recall: 0.9
+
+    .. versionadded:: 0.6.0
     """
 
     @reinit__is_reduced
@@ -170,7 +367,7 @@ class TopKMultilabelRecall(_BaseTopKMultilabelPrecisionRecall):
         elif self._average == "micro":
             self._denominator += y.sum()
             self._numerator += correct.sum()
-        else:
+        else:  # _average in [False, None, 'macro', 'weighted']
             self._denominator += y.sum(dim=0)
             self._numerator += correct.sum(dim=0)
 

--- a/ignite/metrics/top_k_multilabel_precision_recall.py
+++ b/ignite/metrics/top_k_multilabel_precision_recall.py
@@ -1,0 +1,180 @@
+from collections.abc import Callable, Sequence
+
+import torch
+
+from ignite.metrics.metric import reinit__is_reduced
+from ignite.metrics.precision import _BasePrecisionRecall
+
+__all__ = ["TopKMultilabelPrecision", "TopKMultilabelRecall"]
+
+
+class _BaseTopKMultilabelPrecisionRecall(_BasePrecisionRecall):
+    """Base class for top-k multilabel precision and recall metrics.
+
+    For each sample, the ``k`` labels with the highest prediction scores are
+    selected as positive predictions. Precision and recall are then computed per
+    label, treating each label independently across the accumulated samples.
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        output_transform: Callable = lambda x: x,
+        average: bool | str | None = False,
+        device: str | torch.device = torch.device("cpu"),
+        skip_unrolling: bool = False,
+    ) -> None:
+        if k < 1:
+            raise ValueError(f"Argument k should be a positive integer, given {k}.")
+
+        self._k = k
+        super().__init__(
+            output_transform=output_transform,
+            average=average,
+            is_multilabel=True,
+            device=device,
+            skip_unrolling=skip_unrolling,
+        )
+
+    def _check_type(self, output: Sequence[torch.Tensor]) -> None:
+        self._check_shape(output)
+        y_pred, y = output
+
+        if not (y.shape == y_pred.shape and y.ndimension() > 1 and y.shape[1] > 1):
+            raise ValueError(
+                "y and y_pred must have same shape of (batch_size, num_labels, ...) "
+                f"with num_labels > 1, but given {y.shape} vs {y_pred.shape}."
+            )
+
+        if not torch.equal(y, y**2):
+            raise ValueError("For multilabel cases, y must be comprised of 0's and 1's.")
+
+        if y_pred.dtype in (torch.int, torch.long):
+            raise TypeError(f"`y_pred` should be a float tensor with prediction scores, given {y_pred.dtype}.")
+
+        num_labels = y_pred.shape[1]
+        if self._type is None:
+            self._type = "multilabel"
+            self._num_classes = num_labels
+        elif self._type != "multilabel":
+            raise RuntimeError(f"Input data type has changed from {self._type} to multilabel.")
+        elif self._num_classes != num_labels:
+            raise ValueError(
+                f"Input data number of labels has changed from {self._num_classes} to {num_labels}."
+            )
+
+    def _prepare_output(self, output: Sequence[torch.Tensor]) -> Sequence[torch.Tensor]:
+        y_pred, y = output[0].detach(), output[1].detach()
+
+        num_labels = y_pred.size(1)
+        y_pred = torch.transpose(y_pred, 1, -1).reshape(-1, num_labels)
+        y = torch.transpose(y, 1, -1).reshape(-1, num_labels)
+
+        k = min(self._k, num_labels)
+        topk_indices = torch.topk(y_pred, k, dim=1).indices
+        y_pred_topk = torch.zeros_like(y_pred)
+        y_pred_topk.scatter_(1, topk_indices, 1.0)
+
+        y_pred_topk = y_pred_topk.to(dtype=self._double_dtype, device=self._device)
+        y = y.to(dtype=self._double_dtype, device=self._device)
+        correct = y * y_pred_topk
+
+        return y_pred_topk, y, correct
+
+
+class TopKMultilabelPrecision(_BaseTopKMultilabelPrecisionRecall):
+    r"""Calculates top-k precision for multilabel data.
+
+    For each sample, the ``k`` labels with the highest scores are treated as
+    positive predictions. Per-label precision is then computed as
+
+    .. math:: \text{Precision}_k = \frac{TP_k}{TP_k + FP_k}
+
+    where :math:`TP_k` and :math:`FP_k` are counted per label across samples.
+
+    - ``update`` must receive output of the form ``(y_pred, y)``.
+    - ``y_pred`` must be prediction scores of shape ``(batch_size, num_labels, ...)``.
+    - ``y`` must be a binary tensor of the same shape as ``y_pred``.
+
+    Args:
+        k: number of top-scoring labels to consider as positive predictions per sample.
+        output_transform: a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric.
+        average: reduction option. Same semantics as :class:`~ignite.metrics.precision.Precision`
+            for multilabel inputs.
+        device: specifies which device updates are accumulated on.
+        skip_unrolling: specifies whether output should be unrolled before being fed to update method.
+    """
+
+    @reinit__is_reduced
+    def update(self, output: Sequence[torch.Tensor]) -> None:
+        self._check_shape(output)
+        self._check_type(output)
+        y_pred, y, correct = self._prepare_output(output)
+
+        if self._average == "samples":
+            all_positives = y_pred.sum(dim=1)
+            true_positives = correct.sum(dim=1)
+            self._numerator += torch.sum(true_positives / (all_positives + self.eps))
+            self._denominator += y.size(0)
+        elif self._average == "micro":
+            self._denominator += y_pred.sum()
+            self._numerator += correct.sum()
+        else:
+            self._denominator += y_pred.sum(dim=0)
+            self._numerator += correct.sum(dim=0)
+
+            if self._average == "weighted":
+                self._weight += y.sum(dim=0)
+
+        self._updated = True
+
+
+class TopKMultilabelRecall(_BaseTopKMultilabelPrecisionRecall):
+    r"""Calculates top-k recall for multilabel data.
+
+    For each sample, the ``k`` labels with the highest scores are treated as
+    positive predictions. Per-label recall is then computed as
+
+    .. math:: \text{Recall}_k = \frac{TP_k}{TP_k + FN_k}
+
+    where :math:`TP_k` and :math:`FN_k` are counted per label across samples.
+
+    - ``update`` must receive output of the form ``(y_pred, y)``.
+    - ``y_pred`` must be prediction scores of shape ``(batch_size, num_labels, ...)``.
+    - ``y`` must be a binary tensor of the same shape as ``y_pred``.
+
+    Args:
+        k: number of top-scoring labels to consider as positive predictions per sample.
+        output_transform: a callable that is used to transform the
+            :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
+            form expected by the metric.
+        average: reduction option. Same semantics as :class:`~ignite.metrics.recall.Recall`
+            for multilabel inputs.
+        device: specifies which device updates are accumulated on.
+        skip_unrolling: specifies whether output should be unrolled before being fed to update method.
+    """
+
+    @reinit__is_reduced
+    def update(self, output: Sequence[torch.Tensor]) -> None:
+        self._check_shape(output)
+        self._check_type(output)
+        _, y, correct = self._prepare_output(output)
+
+        if self._average == "samples":
+            actual_positives = y.sum(dim=1)
+            true_positives = correct.sum(dim=1)
+            self._numerator += torch.sum(true_positives / (actual_positives + self.eps))
+            self._denominator += y.size(0)
+        elif self._average == "micro":
+            self._denominator += y.sum()
+            self._numerator += correct.sum()
+        else:
+            self._denominator += y.sum(dim=0)
+            self._numerator += correct.sum(dim=0)
+
+            if self._average == "weighted":
+                self._weight += y.sum(dim=0)
+
+        self._updated = True

--- a/ignite/metrics/top_k_multilabel_precision_recall.py
+++ b/ignite/metrics/top_k_multilabel_precision_recall.py
@@ -37,6 +37,7 @@ class _BaseTopKMultilabelPrecisionRecall(_BasePrecisionRecall):
         )
 
     def _check_type(self, output: Sequence[torch.Tensor]) -> None:
+        # Override the parent's method to accommodate for this metric inputting floats instead of binary labels
         y_pred, y = output
 
         if not torch.equal(y, y**2):

--- a/tests/ignite/metrics/test_top_k_multilabel_precision_recall.py
+++ b/tests/ignite/metrics/test_top_k_multilabel_precision_recall.py
@@ -214,7 +214,7 @@ def test_ties_in_scores(metric_cls, score_fn, average):
 
 @pytest.mark.parametrize("average", [False, "macro", "micro", "weighted", "samples"])
 def test_zero_positive_label(average):
-    # A label with no positive ground-truth samples: recall denominator is 0 
+    # A label with no positive ground-truth samples: recall denominator is 0
     y_pred = torch.rand(6, 4)
     y = torch.randint(0, 2, size=(6, 4))
     y[:, 1] = 0  # label 1 has no positives

--- a/tests/ignite/metrics/test_top_k_multilabel_precision_recall.py
+++ b/tests/ignite/metrics/test_top_k_multilabel_precision_recall.py
@@ -1,0 +1,336 @@
+import warnings
+
+import pytest
+import torch
+from sklearn.exceptions import UndefinedMetricWarning
+from sklearn.metrics import precision_score, recall_score
+
+import ignite.distributed as idist
+from ignite.engine import Engine
+from ignite.exceptions import NotComputableError
+from ignite.metrics import TopKMultilabelPrecision, TopKMultilabelRecall
+
+METRICS = [
+    pytest.param(TopKMultilabelPrecision, precision_score, id="precision"),
+    pytest.param(TopKMultilabelRecall, recall_score, id="recall"),
+]
+
+
+def ignite_average_to_scikit_average(average):
+    # All inputs here are multilabel.
+    if average in [None, "micro", "samples", "weighted", "macro"]:
+        return average
+    if average is False:
+        return None
+    if average is True:
+        return "macro"
+    raise ValueError(f"Wrong average parameter `{average}`")
+
+
+def reference_top_k_multilabel(score_fn, y_pred, y, k, average):
+    """Reference value computed by binarizing the top-k predictions then deferring to scikit-learn.
+
+    Uses the same reshape as the metric so that, per sample, y and the predicted top-k mask
+    stay aligned.
+    """
+    num_labels = y_pred.size(1)
+    yp = torch.transpose(y_pred, 1, -1).reshape(-1, num_labels)
+    yy = torch.transpose(y, 1, -1).reshape(-1, num_labels)
+
+    kk = min(k, num_labels)
+    topk_indices = torch.topk(yp, kk, dim=1).indices
+    mask = torch.zeros_like(yp)
+    mask.scatter_(1, topk_indices, 1.0)
+
+    np_y_pred = mask.cpu().numpy().astype(int)
+    np_y = yy.cpu().numpy().astype(int)
+    sk_average = ignite_average_to_scikit_average(average)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+        return score_fn(np_y, np_y_pred, average=sk_average, zero_division=0)
+
+
+@pytest.fixture(params=range(6))
+def test_data_multilabel(request):
+    # y_pred holds float prediction scores, y is binary; shapes (N, C), (N, C, L) and (N, C, H, W).
+    return [
+        (torch.rand(10, 5), torch.randint(0, 2, size=(10, 5)), 1),
+        (torch.rand(10, 4), torch.randint(0, 2, size=(10, 4)), 1),
+        (torch.rand(50, 5), torch.randint(0, 2, size=(50, 5)), 16),
+        (torch.rand(50, 4, 10), torch.randint(0, 2, size=(50, 4, 10)), 16),
+        (torch.rand(10, 5, 18, 16), torch.randint(0, 2, size=(10, 5, 18, 16)), 1),
+        (torch.rand(50, 4, 20, 23), torch.randint(0, 2, size=(50, 4, 20, 23)), 16),
+    ][request.param]
+
+
+@pytest.mark.parametrize("metric_cls, _", METRICS)
+def test_no_update(metric_cls, _):
+    metric = metric_cls(k=2)
+    with pytest.raises(
+        NotComputableError, match=rf"{metric_cls.__name__} must have at least one example before it can be computed"
+    ):
+        metric.compute()
+
+
+@pytest.mark.parametrize("metric_cls, _", METRICS)
+def test_invalid_k(metric_cls, _):
+    with pytest.raises(ValueError, match=r"Argument k should be a positive integer, given 0."):
+        metric_cls(k=0)
+    with pytest.raises(ValueError, match=r"Argument k should be a positive integer, given -1."):
+        metric_cls(k=-1)
+
+
+def test_invalid_average():
+    with pytest.raises(ValueError, match=r"Argument average should be None or a boolean or one of values"):
+        TopKMultilabelPrecision(k=2, average="something")
+
+
+@pytest.mark.parametrize("metric_cls, _", METRICS)
+def test_wrong_inputs(metric_cls, _):
+    metric = metric_cls(k=2)
+
+    with pytest.raises(ValueError, match=r"num_categories > 1"):
+        # 1D shapes are not valid multilabel inputs
+        metric.update((torch.rand(10), torch.randint(0, 2, size=(10,))))
+
+    with pytest.raises(ValueError, match=r"compatible shapes"):
+        # mismatched shapes
+        metric.update((torch.rand(10, 5), torch.randint(0, 2, size=(10, 4))))
+
+    with pytest.raises(ValueError, match=r"num_categories > 1"):
+        # num_labels must be > 1
+        metric.update((torch.rand(10, 1), torch.randint(0, 2, size=(10, 1))))
+
+    with pytest.raises(ValueError, match=r"y must be comprised of 0's and 1's"):
+        # y must be binary
+        metric.update((torch.rand(10, 5), torch.randint(0, 5, size=(10, 5))))
+
+    with pytest.raises(TypeError, match=r"`y_pred` should be a float tensor with prediction scores"):
+        # y_pred must contain float scores, not integer labels
+        metric.update((torch.randint(0, 2, size=(10, 5)), torch.randint(0, 2, size=(10, 5))))
+
+    with pytest.raises(ValueError, match=r"Input data number of labels has changed"):
+        # number of labels must stay constant across updates
+        metric.update((torch.rand(10, 5), torch.randint(0, 2, size=(10, 5))))
+        metric.update((torch.rand(10, 4), torch.randint(0, 2, size=(10, 4))))
+
+
+@pytest.mark.parametrize("metric_cls, _", METRICS)
+def test_incorrect_type(metric_cls, _):
+    metric = metric_cls(k=2)
+    metric.update((torch.rand(10, 5), torch.randint(0, 2, size=(10, 5))))
+    assert metric._updated is True
+
+    with pytest.raises(ValueError, match=r"Input data number of labels has changed"):
+        metric.update((torch.rand(10, 6), torch.randint(0, 2, size=(10, 6))))
+
+
+@pytest.mark.parametrize("metric_cls, score_fn", METRICS)
+@pytest.mark.parametrize("average", [None, False, "macro", "micro", "weighted", "samples"])
+@pytest.mark.parametrize("k", [1, 2, 5, 10])
+def test_multilabel_input(metric_cls, score_fn, average, k, available_device, test_data_multilabel):
+    metric = metric_cls(k=k, average=average, device=available_device)
+    assert metric._device == torch.device(available_device)
+    assert metric._updated is False
+
+    y_pred, y, batch_size = test_data_multilabel
+    metric.reset()
+
+    if batch_size > 1:
+        n_iters = y.shape[0] // batch_size + 1
+        for i in range(n_iters):
+            idx = i * batch_size
+            metric.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+    else:
+        metric.update((y_pred, y))
+
+    assert metric._type == "multilabel"
+    assert metric._updated is True
+
+    res = metric.compute()
+    res = res.cpu().numpy() if isinstance(res, torch.Tensor) else res
+    ref = reference_top_k_multilabel(score_fn, y_pred, y, k, average)
+    assert ref == pytest.approx(res)
+
+
+def test_hand_computed_label_wise_topk():
+    # Hand-verified example: for each sample the top-k highest-scoring
+    # labels become positive predictions, then precision/recall is reported per label.
+    y_pred = torch.tensor(
+        [
+            [0.9, 0.8, 0.1],
+            [0.2, 0.7, 0.6],
+            [0.7, 0.1, 0.6],
+            [0.1, 0.9, 0.5],
+        ]
+    )
+    y = torch.tensor(
+        [
+            [1, 0, 0],
+            [0, 1, 1],
+            [1, 0, 0],
+            [0, 1, 0],
+        ]
+    )
+
+    def precision(average):
+        m = TopKMultilabelPrecision(k=2, average=average)
+        m.update((y_pred, y))
+        return m.compute()
+
+    def recall(average):
+        m = TopKMultilabelRecall(k=2, average=average)
+        m.update((y_pred, y))
+        return m.compute()
+
+    assert precision(False).cpu().numpy() == pytest.approx([1.0, 2 / 3, 1 / 3])
+    assert precision("micro") == pytest.approx(5 / 8)
+    assert precision(True) == pytest.approx((1.0 + 2 / 3 + 1 / 3) / 3)
+    assert precision("weighted") == pytest.approx((2 * 1.0 + 2 * (2 / 3) + 1 * (1 / 3)) / 5)
+    assert precision("samples") == pytest.approx((0.5 + 1.0 + 0.5 + 0.5) / 4)
+
+    assert recall(False).cpu().numpy() == pytest.approx([1.0, 1.0, 1.0])
+    assert recall("micro") == pytest.approx(1.0)
+    assert recall(True) == pytest.approx(1.0)
+    assert recall("weighted") == pytest.approx(1.0)
+    assert recall("samples") == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("metric_cls, score_fn", METRICS)
+@pytest.mark.parametrize("average", [False, "macro", "micro", "weighted", "samples"])
+def test_ties_in_scores(metric_cls, score_fn, average):
+    # All-equal scores: top-k selection is arbitrary among ties, but the metric and the reference
+    # call the same torch.topk, so they must agree (and the metric must not crash).
+    y_pred = torch.full((8, 5), 0.5)
+    y = torch.randint(0, 2, size=(8, 5))
+    metric = metric_cls(k=2, average=average)
+    metric.update((y_pred, y))
+
+    res = metric.compute()
+    res = res.cpu().numpy() if isinstance(res, torch.Tensor) else res
+    ref = reference_top_k_multilabel(score_fn, y_pred, y, 2, average)
+    assert ref == pytest.approx(res)
+
+
+@pytest.mark.parametrize("average", [False, "macro", "micro", "weighted", "samples"])
+def test_zero_positive_label(average):
+    # A label with no positive ground-truth samples: recall denominator is 0 
+    y_pred = torch.rand(6, 4)
+    y = torch.randint(0, 2, size=(6, 4))
+    y[:, 1] = 0  # label 1 has no positives
+
+    metric = TopKMultilabelRecall(k=2, average=average)
+    metric.update((y_pred, y))
+    res = metric.compute()
+
+    if average is False:
+        assert res[1].item() == pytest.approx(0.0)
+
+    res = res.cpu().numpy() if isinstance(res, torch.Tensor) else res
+    ref = reference_top_k_multilabel(recall_score, y_pred, y, 2, average)
+    assert ref == pytest.approx(res)
+
+
+@pytest.mark.parametrize("metric_cls, score_fn", METRICS)
+@pytest.mark.parametrize("average", [False, "macro", "micro", "weighted", "samples"])
+def test_label_imbalance(metric_cls, score_fn, average):
+    # One common label and one rare label; per-label handling must still match the reference.
+    n = 200
+    y_pred = torch.rand(n, 4)
+    y = torch.zeros(n, 4, dtype=torch.long)
+    y[:, 0] = 1  # common label: almost always positive
+    y[0, 0] = 0
+    y[:, 3] = 0
+    y[0, 3] = 1  # rare label: a single positive
+
+    metric = metric_cls(k=2, average=average)
+    metric.update((y_pred, y))
+    res = metric.compute()
+    res = res.cpu().numpy() if isinstance(res, torch.Tensor) else res
+    ref = reference_top_k_multilabel(score_fn, y_pred, y, 2, average)
+    assert ref == pytest.approx(res)
+
+
+@pytest.mark.usefixtures("distributed")
+class TestDistributed:
+    @pytest.mark.parametrize("metric_cls, score_fn", METRICS)
+    @pytest.mark.parametrize("average", [False, "macro", "weighted", "micro"])
+    @pytest.mark.parametrize("n_epochs", [1, 2])
+    def test_integration_multilabel(self, metric_cls, score_fn, average, n_epochs):
+        rank = idist.get_rank()
+        torch.manual_seed(12 + rank)
+
+        n_iters = 60
+        batch_size = 16
+        n_labels = 7
+        k = 3
+
+        metric_devices = ["cpu"]
+        device = idist.device()
+        if device.type != "xla":
+            metric_devices.append(idist.device())
+
+        for metric_device in metric_devices:
+            y_true = torch.randint(0, 2, size=(n_iters * batch_size, n_labels, 6, 8)).to(device)
+            y_preds = torch.rand(n_iters * batch_size, n_labels, 6, 8).to(device)
+
+            def update(engine, i):
+                return (
+                    y_preds[i * batch_size : (i + 1) * batch_size, ...],
+                    y_true[i * batch_size : (i + 1) * batch_size, ...],
+                )
+
+            engine = Engine(update)
+
+            metric = metric_cls(k=k, average=average, device=metric_device)
+            metric.attach(engine, "metric")
+            assert metric._updated is False
+
+            data = list(range(n_iters))
+            engine.run(data=data, max_epochs=n_epochs)
+
+            y_preds = idist.all_gather(y_preds)
+            y_true = idist.all_gather(y_true)
+
+            assert "metric" in engine.state.metrics
+            assert metric._updated is True
+            res = engine.state.metrics["metric"]
+            if isinstance(res, torch.Tensor):
+                res = res.cpu().numpy()
+
+            assert metric._type == "multilabel"
+            ref = reference_top_k_multilabel(score_fn, y_preds.cpu(), y_true.cpu(), k, average)
+            assert ref == pytest.approx(res)
+
+    @pytest.mark.parametrize("metric_cls, _", METRICS)
+    @pytest.mark.parametrize("average", [False, "macro", "weighted", "micro", "samples"])
+    def test_accumulator_device(self, metric_cls, _, average):
+        metric_devices = [torch.device("cpu")]
+        device = idist.device()
+        if device.type != "xla":
+            metric_devices.append(idist.device())
+
+        for metric_device in metric_devices:
+            metric = metric_cls(k=2, average=average, device=metric_device)
+            assert metric._device == metric_device
+            assert metric._updated is False
+
+            y_pred = torch.rand(10, 4, 20, 23)
+            y = torch.randint(0, 2, size=(10, 4, 20, 23)).long()
+            metric.update((y_pred, y))
+
+            assert metric._updated is True
+            assert metric._numerator.device == metric_device, (
+                f"{type(metric._numerator.device)}:{metric._numerator.device} vs {type(metric_device)}:{metric_device}"
+            )
+
+            if average != "samples":
+                assert metric._denominator.device == metric_device, (
+                    f"{type(metric._denominator.device)}:{metric._denominator.device} vs "
+                    f"{type(metric_device)}:{metric_device}"
+                )
+
+            if average == "weighted":
+                assert metric._weight.device == metric_device, (
+                    f"{type(metric._weight.device)}:{metric._weight.device} vs {type(metric_device)}:{metric_device}"
+                )


### PR DESCRIPTION
Fixes #467 

## Description

Adds two new multilabel ranking metrics: `TopKMultilabelPrecision` and `TopKMultilabelRecall` to `ignite.metrics`.

For each sample, the `k` labels with the highest prediction scores are treated as positive predictions; precision and recall are then reported **per label** across the accumulated samples. This matches the metric described in the discussion (#466 -> #467 ), grounded in https://arxiv.org/pdf/1312.4894.pdf

## Notes:

-`y_pred` must be **float scores**.
- If `k` exceeds the number of labels, it is clamped to `num_labels`.
- Default k = 5

## Changes

- New module `ignite/metrics/top_k_multilabel_precision_recall.py`
- Export `TopKMultilabelPrecision` and `TopKMultilabelRecall` from `ignite.metrics`
- Add entries to `docs/source/metrics.rst`
- RST docstrings with `.. testcode::` / `.. testoutput::` examples
- Tests at `ignite/metrics/test_top_k_multilabel_precision_recall.py`

## Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
