### PR TITLE
fix: fixed the scipy version to mitigate FID errors in the tests.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ pytest-xdist
 setuptools
 fairlearn
 # Test contrib dependencies
-scipy
+scipy<=1.17.0
 pytorch_fid
 tqdm
 scikit-learn

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ pytest-xdist
 setuptools
 fairlearn
 # Test contrib dependencies
+# pytorch_fid library passes disp=False to scipy.linalg.sqrtm, disp parameter was removed in scipy 1.18.0
 scipy<=1.17.0
 pytorch_fid
 tqdm


### PR DESCRIPTION
Summary
Pins scipy<=1.17.0 in requirements-dev.txt to fix failing unit tests caused by scipy.linalg.sqrtm removing the disp
parameter in
SciPy 1.18.0 .

Problem
In SciPy 1.16.0 , the disp parameter in scipy.linalg.sqrtm was deprecated, and it was completely removed in SciPy 1.18.0 .
However, the pytorch-fid library (which we use in test_fid.py to validate our FID metric implementation) still passes
disp=False to scipy.linalg.sqrtm .

When running tests with SciPy 1.18.0 or newer, this mismatch results in a TypeError: sqrtm() got an unexpected keyword
argument 'disp' , causing our test suite (specifically FID metric unit tests) to fail.

Solution
Since pytorch-fid is a third-party dependency used primarily for validation in our dev/test environment, we restrict the scipy dependency in requirements-dev.txt to <=1.17.0 . This ensures that the test suite continues to run successfully on environments using the pinned SciPy version.