### PR TITLE
added lock file in git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ conda_build/
 pytest.ini
 
 .vscode/*
+
+# lock files
+*.lock


### PR DESCRIPTION
Adds lock files to to .gitignore, many people use modern package manager for python like uv, pixi etc. They generate lock files which sometimes gets commited by mistake.
