### PR TITLE
Change the upper bound to <3.15 for the required python version to enable support for 3.14.x

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -187,5 +187,8 @@ jobs:
       - name: Run CIFAR10 with Ray Tune and Ignite
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
+          echo "Downloading CIFAR20 archive from Zenodo..."
+          mkdir -p data
+          curl -L --retry 3 --retry-delay 10 -o data/cifar-10-python.tar.gz "https://zenodo.org/records/10089977/files/cifar-10-python.tar.gz?download=1"
           uv pip install -r examples/cifar10_raytune/requirements.txt
           python examples/cifar10_raytune/main.py --num_epochs 1 --num_trials 1 --cpus_per_trial 1 --gpus_per_trial 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Run CIFAR10 with Ray Tune and Ignite
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          echo "Downloading CIFAR20 archive from Zenodo..."
+          echo "Downloading CIFAR10 archive from Zenodo..."
           mkdir -p data
           curl -L --retry 3 --retry-delay 10 -o data/cifar-10-python.tar.gz "https://zenodo.org/records/10089977/files/cifar-10-python.tar.gz?download=1"
           uv pip install -r examples/cifar10_raytune/requirements.txt

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         pytorch-channel: [pytorch, pytorch-nightly]
         include:
           # includes a single build on windows

--- a/examples/super_resolution/main.py
+++ b/examples/super_resolution/main.py
@@ -147,7 +147,9 @@ basic_profiler.attach(trainer)
 
 ProgressBar().attach(trainer, output_transform=lambda x: {"loss": x})
 
-trainer.run(training_data_loader, opt.n_epochs, epoch_length=epoch_length)
 
-results = basic_profiler.get_results()
-basic_profiler.print_results(results)
+if __name__ == "__main__":
+    trainer.run(training_data_loader, opt.n_epochs, epoch_length=epoch_length)
+
+    results = basic_profiler.get_results()
+    basic_profiler.print_results(results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.10,<=3.14"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "torch>=2.2,<3",
     "packaging"


### PR DESCRIPTION
Fixes #3803 

Description:

Changes the upper bound to <3.15 for the required python version to enable support for 3.14.x. See #3803 for description.

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
