### PR TITLE
Fix ClearML task closure issue

### DIFF
--- a/ignite/handlers/clearml_logger.py
+++ b/ignite/handlers/clearml_logger.py
@@ -218,6 +218,8 @@ class ClearMLLogger(BaseLogger):
 
     def close(self) -> None:
         self.clearml_logger.flush()
+        if self._task:
+            self._task.close()
 
     def _create_output_handler(self, *args: Any, **kwargs: Any) -> "OutputHandler":
         return OutputHandler(*args, **kwargs)


### PR DESCRIPTION
This pull request adds a small but important resource management improvement to the `ignite/handlers/clearml_logger.py` file. Now, when the `close()` method is called, it also closes the underlying `_task` if it exists, ensuring resources are properly released.

Resource management improvement:

* Updated the `close()` method to call `self._task.close()` if `_task` is set, preventing potential resource leaks.Fixes #{issue number}

Description:

Check list:

- [ ] New tests are added (if a new feature is added)
- [ ] New doc strings: description and/or example code are in RST format
- [ ] Documentation is updated (if required)
