### PR TITLE
feat: Add per_label parameter to Accuracy for per-label multilabel output

### DIFF
--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -167,11 +167,6 @@ class Accuracy(_BaseClassification):
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        per_label: if False (default), computes subset accuracy for multilabel data
-            (a sample is correct only if all labels match exactly), returning a single float.
-            If True, computes per-label accuracy for multilabel data, returning a tensor
-            of shape ``(num_labels,)`` where each element is the fraction of samples correctly
-            predicted for that label. Only applicable when ``is_multilabel=True``.
         is_multilabel: flag to use in multilabel case. By default, False.
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
@@ -179,6 +174,11 @@ class Accuracy(_BaseClassification):
         skip_unrolling: specifies whether output should be unrolled before being fed to update method. Should be
             true for multi-output model, for example, if ``y_pred`` contains multi-output as ``(y_pred_a, y_pred_b)``
             Alternatively, ``output_transform`` can be used to handle this.
+        per_label: if False (default), computes subset accuracy for multilabel data
+            (a sample is correct only if all labels match exactly), returning a single float.
+            If True, computes per-label accuracy for multilabel data, returning a tensor
+            of shape ``(num_labels,)`` where each element is the fraction of samples correctly
+            predicted for that label. Only applicable when ``is_multilabel=True``.
 
     Examples:
 
@@ -311,13 +311,11 @@ class Accuracy(_BaseClassification):
     def __init__(
         self,
         output_transform: Callable = lambda x: x,
-        per_label: bool = False,
         is_multilabel: bool = False,
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
+        per_label: bool = False,
     ):
-        if type(per_label) is not bool:
-            raise ValueError("Argument per_label should be boolean.")
         if per_label and not is_multilabel:
             raise ValueError("Argument per_label=True is only applicable with is_multilabel=True.")
         self._per_label = per_label
@@ -337,6 +335,7 @@ class Accuracy(_BaseClassification):
         self._check_type(output)
         y_pred, y = output[0].detach(), output[1].detach()
 
+        sum_dim: int | None = None
         if self._type == "binary":
             correct = torch.eq(y_pred.view(-1).to(y), y.view(-1))
         elif self._type == "multiclass":
@@ -349,22 +348,23 @@ class Accuracy(_BaseClassification):
             y_pred = torch.transpose(y_pred, 1, last_dim - 1).reshape(-1, num_classes)
             y = torch.transpose(y, 1, last_dim - 1).reshape(-1, num_classes)
             if self._per_label:
+                # Keep the label dimension so each column gets its own accuracy
                 correct = (y == y_pred.type_as(y)).float()
-                self._num_correct = self._num_correct + correct.sum(dim=0).to(self._device)
-                self._num_examples += correct.shape[0]
-                return
-            # Default: subset accuracy — entire label vector must match exactly
-            correct = torch.all(y == y_pred.type_as(y), dim=-1)
+                sum_dim = 0
+            else:
+                # Subset accuracy — entire label vector must match exactly
+                correct = torch.all(y == y_pred.type_as(y), dim=-1)
         else:
             raise ValueError(f"Unexpected type: {self._type}")
 
-        self._num_correct += torch.sum(correct).to(self._device)
+        # Non-in-place: on the first per-label update, this grows `_num_correct` from a
+        # 0-dim tensor to shape (num_labels,), which in-place `+=` cannot broadcast into.
+        self._num_correct = self._num_correct + torch.sum(correct, dim=sum_dim).to(self._device)
         self._num_examples += correct.shape[0]
 
     @sync_all_reduce("_num_examples", "_num_correct")
     def compute(self) -> float | torch.Tensor:
         if self._num_examples == 0:
             raise NotComputableError("Accuracy must have at least one example before it can be computed.")
-        if self._per_label:
-            return self._num_correct / self._num_examples
-        return self._num_correct.item() / self._num_examples
+        num_correct = self._num_correct if self._per_label else self._num_correct.item()
+        return num_correct / self._num_examples

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Sequence, Iterable
+from typing import cast
 
 import torch
 
@@ -349,7 +350,6 @@ class Accuracy(_BaseClassification):
             y_pred = torch.transpose(y_pred, 1, last_dim - 1).reshape(-1, num_classes)
             y = torch.transpose(y, 1, last_dim - 1).reshape(-1, num_classes)
             if self._average is False:
-                # Per-label elementwise accuracy: count correct predictions per label separately
                 correct = (y == y_pred.type_as(y)).float()
                 self._num_correct += correct.sum(dim=0).to(self._device)
                 self._num_examples += correct.shape[0]
@@ -368,4 +368,4 @@ class Accuracy(_BaseClassification):
             raise NotComputableError("Accuracy must have at least one example before it can be computed.")
         if self._average is False:
             return self._num_correct / self._num_examples
-        return self._num_correct.item() / self._num_examples
+        return cast(torch.Tensor, self._num_correct).item() / self._num_examples

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -167,6 +167,11 @@ class Accuracy(_BaseClassification):
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
+        average: if None (default), computes subset accuracy for multilabel data
+            (a sample is correct only if all labels match exactly), returning a single float.
+            If False, computes per-label accuracy for multilabel data, returning a tensor
+            of shape ``(num_labels,)`` where each element is the fraction of samples correctly
+            predicted for that label. Only applicable when ``is_multilabel=True``.
         is_multilabel: flag to use in multilabel case. By default, False.
         device: specifies which device updates are accumulated on. Setting the metric's
             device to be the same as your ``update`` arguments ensures the ``update`` method is non-blocking. By
@@ -246,6 +251,33 @@ class Accuracy(_BaseClassification):
 
             0.2
 
+        Multilabel case, per-label accuracy
+
+        .. testcode:: 5
+
+            metric = Accuracy(is_multilabel=True, average=False)
+            metric.attach(default_evaluator, "label_accuracy")
+            y_true = torch.tensor([
+                [0, 0, 1, 0, 1],
+                [1, 0, 1, 0, 0],
+                [0, 0, 0, 0, 1],
+                [1, 0, 0, 0, 1],
+                [0, 1, 1, 0, 1],
+            ])
+            y_pred = torch.tensor([
+                [1, 1, 0, 0, 0],
+                [1, 0, 1, 0, 0],
+                [1, 0, 0, 0, 0],
+                [1, 0, 1, 1, 1],
+                [1, 1, 0, 0, 1],
+            ])
+            state = default_evaluator.run([[y_pred, y_true]])
+            print(state.metrics["label_accuracy"])
+
+        .. testoutput:: 5
+
+            tensor([0.4000, 0.8000, 0.4000, 0.8000, 0.6000])
+
         In binary and multilabel cases, the elements of `y` and `y_pred` should have 0 or 1 values. Thresholding of
         predictions can be done as below:
 
@@ -269,6 +301,9 @@ class Accuracy(_BaseClassification):
 
     .. versionchanged:: 0.5.1
         ``skip_unrolling`` argument is added.
+
+    .. versionchanged:: 0.6.0
+        ``average`` argument is added.
     """
 
     _state_dict_all_req_keys = ("_num_correct", "_num_examples")
@@ -276,17 +311,23 @@ class Accuracy(_BaseClassification):
     def __init__(
         self,
         output_transform: Callable = lambda x: x,
+        average: bool | None = None,
         is_multilabel: bool = False,
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
+        if average is not None and average is not False:
+            raise ValueError("Argument average should be None or False.")
+        if average is False and not is_multilabel:
+            raise ValueError("Argument average=False is only applicable with is_multilabel=True.")
+        self._average = average
         super().__init__(
             output_transform=output_transform, is_multilabel=is_multilabel, device=device, skip_unrolling=skip_unrolling
         )
 
     @reinit__is_reduced
     def reset(self) -> None:
-        self._num_correct = torch.tensor(0, device=self._device)
+        self._num_correct: int | torch.Tensor = 0
         self._num_examples = 0
         super().reset()
 
@@ -307,6 +348,13 @@ class Accuracy(_BaseClassification):
             last_dim = y_pred.ndimension()
             y_pred = torch.transpose(y_pred, 1, last_dim - 1).reshape(-1, num_classes)
             y = torch.transpose(y, 1, last_dim - 1).reshape(-1, num_classes)
+            if self._average is False:
+                # Per-label elementwise accuracy: count correct predictions per label separately
+                correct = (y == y_pred.type_as(y)).float()
+                self._num_correct += correct.sum(dim=0).to(self._device)
+                self._num_examples += correct.shape[0]
+                return
+            # Default: subset accuracy — entire label vector must match exactly
             correct = torch.all(y == y_pred.type_as(y), dim=-1)
         else:
             raise ValueError(f"Unexpected type: {self._type}")
@@ -315,7 +363,9 @@ class Accuracy(_BaseClassification):
         self._num_examples += correct.shape[0]
 
     @sync_all_reduce("_num_examples", "_num_correct")
-    def compute(self) -> float:
+    def compute(self) -> float | torch.Tensor:
         if self._num_examples == 0:
             raise NotComputableError("Accuracy must have at least one example before it can be computed.")
+        if self._average is False:
+            return self._num_correct / self._num_examples
         return self._num_correct.item() / self._num_examples

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -168,7 +168,7 @@ class Accuracy(_BaseClassification):
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        average: if None (default), computes subset accuracy for multilabel data
+        subset_accuracy: if True (default), computes subset accuracy for multilabel data
             (a sample is correct only if all labels match exactly), returning a single float.
             If False, computes per-label accuracy for multilabel data, returning a tensor
             of shape ``(num_labels,)`` where each element is the fraction of samples correctly
@@ -256,7 +256,7 @@ class Accuracy(_BaseClassification):
 
         .. testcode:: 5
 
-            metric = Accuracy(is_multilabel=True, average=False)
+            metric = Accuracy(is_multilabel=True, subset_accuracy=False)
             metric.attach(default_evaluator, "label_accuracy")
             y_true = torch.tensor([
                 [0, 0, 1, 0, 1],
@@ -304,7 +304,7 @@ class Accuracy(_BaseClassification):
         ``skip_unrolling`` argument is added.
 
     .. versionchanged:: 0.6.0
-        ``average`` argument is added.
+        ``subset_accuracy`` argument is added.
     """
 
     _state_dict_all_req_keys = ("_num_correct", "_num_examples")
@@ -312,16 +312,16 @@ class Accuracy(_BaseClassification):
     def __init__(
         self,
         output_transform: Callable = lambda x: x,
-        average: bool | None = None,
+        subset_accuracy: bool = True,
         is_multilabel: bool = False,
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
-        if average is not None and average is not False:
-            raise ValueError("Argument average should be None or False.")
-        if average is False and not is_multilabel:
-            raise ValueError("Argument average=False is only applicable with is_multilabel=True.")
-        self._average = average
+        if type(subset_accuracy) is not bool:
+            raise ValueError("Argument subset_accuracy should be boolean.")
+        if not subset_accuracy and not is_multilabel:
+            raise ValueError("Argument subset_accuracy=False is only applicable with is_multilabel=True.")
+        self._subset_accuracy = subset_accuracy
         super().__init__(
             output_transform=output_transform, is_multilabel=is_multilabel, device=device, skip_unrolling=skip_unrolling
         )
@@ -349,7 +349,7 @@ class Accuracy(_BaseClassification):
             last_dim = y_pred.ndimension()
             y_pred = torch.transpose(y_pred, 1, last_dim - 1).reshape(-1, num_classes)
             y = torch.transpose(y, 1, last_dim - 1).reshape(-1, num_classes)
-            if self._average is False:
+            if not self._subset_accuracy:
                 correct = (y == y_pred.type_as(y)).float()
                 self._num_correct += correct.sum(dim=0).to(self._device)
                 self._num_examples += correct.shape[0]
@@ -366,6 +366,6 @@ class Accuracy(_BaseClassification):
     def compute(self) -> float | torch.Tensor:
         if self._num_examples == 0:
             raise NotComputableError("Accuracy must have at least one example before it can be computed.")
-        if self._average is False:
+        if not self._subset_accuracy:
             return self._num_correct / self._num_examples
         return cast(torch.Tensor, self._num_correct).item() / self._num_examples

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -168,9 +168,9 @@ class Accuracy(_BaseClassification):
             :class:`~ignite.engine.engine.Engine`'s ``process_function``'s output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        subset_accuracy: if True (default), computes subset accuracy for multilabel data
+        per_label: if False (default), computes subset accuracy for multilabel data
             (a sample is correct only if all labels match exactly), returning a single float.
-            If False, computes per-label accuracy for multilabel data, returning a tensor
+            If True, computes per-label accuracy for multilabel data, returning a tensor
             of shape ``(num_labels,)`` where each element is the fraction of samples correctly
             predicted for that label. Only applicable when ``is_multilabel=True``.
         is_multilabel: flag to use in multilabel case. By default, False.
@@ -256,7 +256,7 @@ class Accuracy(_BaseClassification):
 
         .. testcode:: 5
 
-            metric = Accuracy(is_multilabel=True, subset_accuracy=False)
+            metric = Accuracy(is_multilabel=True, per_label=True)
             metric.attach(default_evaluator, "label_accuracy")
             y_true = torch.tensor([
                 [0, 0, 1, 0, 1],
@@ -304,7 +304,7 @@ class Accuracy(_BaseClassification):
         ``skip_unrolling`` argument is added.
 
     .. versionchanged:: 0.6.0
-        ``subset_accuracy`` argument is added.
+        ``per_label`` argument is added.
     """
 
     _state_dict_all_req_keys = ("_num_correct", "_num_examples")
@@ -312,16 +312,16 @@ class Accuracy(_BaseClassification):
     def __init__(
         self,
         output_transform: Callable = lambda x: x,
-        subset_accuracy: bool = True,
+        per_label: bool = False,
         is_multilabel: bool = False,
         device: str | torch.device = torch.device("cpu"),
         skip_unrolling: bool = False,
     ):
-        if type(subset_accuracy) is not bool:
-            raise ValueError("Argument subset_accuracy should be boolean.")
-        if not subset_accuracy and not is_multilabel:
-            raise ValueError("Argument subset_accuracy=False is only applicable with is_multilabel=True.")
-        self._subset_accuracy = subset_accuracy
+        if type(per_label) is not bool:
+            raise ValueError("Argument per_label should be boolean.")
+        if per_label and not is_multilabel:
+            raise ValueError("Argument per_label=True is only applicable with is_multilabel=True.")
+        self._per_label = per_label
         super().__init__(
             output_transform=output_transform, is_multilabel=is_multilabel, device=device, skip_unrolling=skip_unrolling
         )
@@ -349,7 +349,7 @@ class Accuracy(_BaseClassification):
             last_dim = y_pred.ndimension()
             y_pred = torch.transpose(y_pred, 1, last_dim - 1).reshape(-1, num_classes)
             y = torch.transpose(y, 1, last_dim - 1).reshape(-1, num_classes)
-            if not self._subset_accuracy:
+            if self._per_label:
                 correct = (y == y_pred.type_as(y)).float()
                 self._num_correct += correct.sum(dim=0).to(self._device)
                 self._num_examples += correct.shape[0]
@@ -366,6 +366,6 @@ class Accuracy(_BaseClassification):
     def compute(self) -> float | torch.Tensor:
         if self._num_examples == 0:
             raise NotComputableError("Accuracy must have at least one example before it can be computed.")
-        if not self._subset_accuracy:
+        if self._per_label:
             return self._num_correct / self._num_examples
         return cast(torch.Tensor, self._num_correct).item() / self._num_examples

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable, Sequence, Iterable
-from typing import cast
 
 import torch
 
@@ -328,7 +327,7 @@ class Accuracy(_BaseClassification):
 
     @reinit__is_reduced
     def reset(self) -> None:
-        self._num_correct: int | torch.Tensor = 0
+        self._num_correct = torch.tensor(0, device=self._device)
         self._num_examples = 0
         super().reset()
 
@@ -351,7 +350,7 @@ class Accuracy(_BaseClassification):
             y = torch.transpose(y, 1, last_dim - 1).reshape(-1, num_classes)
             if self._per_label:
                 correct = (y == y_pred.type_as(y)).float()
-                self._num_correct += correct.sum(dim=0).to(self._device)
+                self._num_correct = self._num_correct + correct.sum(dim=0).to(self._device)
                 self._num_examples += correct.shape[0]
                 return
             # Default: subset accuracy — entire label vector must match exactly
@@ -368,4 +367,4 @@ class Accuracy(_BaseClassification):
             raise NotComputableError("Accuracy must have at least one example before it can be computed.")
         if self._per_label:
             return self._num_correct / self._num_examples
-        return cast(torch.Tensor, self._num_correct).item() / self._num_examples
+        return self._num_correct.item() / self._num_examples

--- a/ignite/metrics/accuracy.py
+++ b/ignite/metrics/accuracy.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Sequence, Iterable
+from typing import cast
 
 import torch
 
@@ -325,7 +326,7 @@ class Accuracy(_BaseClassification):
 
     @reinit__is_reduced
     def reset(self) -> None:
-        self._num_correct = torch.tensor(0, device=self._device)
+        self._num_correct: int | torch.Tensor = 0
         self._num_examples = 0
         super().reset()
 
@@ -357,14 +358,12 @@ class Accuracy(_BaseClassification):
         else:
             raise ValueError(f"Unexpected type: {self._type}")
 
-        # Non-in-place: on the first per-label update, this grows `_num_correct` from a
-        # 0-dim tensor to shape (num_labels,), which in-place `+=` cannot broadcast into.
-        self._num_correct = self._num_correct + torch.sum(correct, dim=sum_dim).to(self._device)
+        self._num_correct += torch.sum(correct, dim=sum_dim).to(self._device)
         self._num_examples += correct.shape[0]
 
     @sync_all_reduce("_num_examples", "_num_correct")
     def compute(self) -> float | torch.Tensor:
         if self._num_examples == 0:
             raise NotComputableError("Accuracy must have at least one example before it can be computed.")
-        num_correct = self._num_correct if self._per_label else self._num_correct.item()
+        num_correct = self._num_correct if self._per_label else cast(torch.Tensor, self._num_correct).item()
         return num_correct / self._num_examples

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -154,6 +154,18 @@ def test_multilabel_wrong_inputs():
         acc.update((torch.randint(0, 2, size=(10, 1)), torch.randint(0, 2, size=(10, 1)).long()))
 
 
+def test_average_parameter():
+    with pytest.raises(ValueError, match=r"Argument average should be None or False"):
+        Accuracy(average="macro")
+
+    with pytest.raises(ValueError, match=r"Argument average=False is only applicable with is_multilabel=True"):
+        Accuracy(average=False)
+
+    # both should be fine
+    Accuracy(average=None)
+    Accuracy(average=False, is_multilabel=True)
+
+
 @pytest.mark.parametrize("n_times", range(3))
 def test_multilabel_input(n_times, available_device, test_data_multilabel):
     acc = Accuracy(is_multilabel=True, device=available_device)
@@ -176,6 +188,110 @@ def test_multilabel_input(n_times, available_device, test_data_multilabel):
     assert accuracy_score(np_y, np_y_pred) == pytest.approx(acc.compute())
 
 
+def test_multilabel_input_average_false():
+    y_true = torch.tensor(
+        [
+            [0, 0, 1, 0, 1],
+            [1, 0, 1, 0, 0],
+            [0, 0, 0, 0, 1],
+            [1, 0, 0, 0, 1],
+            [0, 1, 1, 0, 1],
+        ]
+    )
+    y_pred = torch.tensor(
+        [
+            [1, 1, 0, 0, 0],
+            [1, 0, 1, 0, 0],
+            [1, 0, 0, 0, 0],
+            [1, 0, 1, 1, 1],
+            [1, 1, 0, 0, 1],
+        ]
+    )
+
+    acc = Accuracy(is_multilabel=True, average=False)
+    acc.update((y_pred, y_true))
+    result = acc.compute()
+
+    assert isinstance(result, torch.Tensor)
+    assert result.shape == (5,)
+
+    expected = (y_true == y_pred).float().mean(dim=0)
+    assert torch.allclose(result, expected)
+    assert torch.allclose(result, torch.tensor([0.4, 0.8, 0.4, 0.8, 0.6]))
+
+
+def test_multilabel_input_average_false_all_correct():
+    y_true = torch.randint(0, 2, size=(8, 3))
+    y_pred = y_true.clone()
+
+    acc = Accuracy(is_multilabel=True, average=False)
+    acc.update((y_pred, y_true))
+    assert torch.allclose(acc.compute(), torch.ones(3))
+
+
+def test_multilabel_input_average_false_all_wrong():
+    y_true = torch.tensor([[0, 1, 0]] * 8)
+    y_pred = torch.tensor([[1, 0, 1]] * 8)
+
+    acc = Accuracy(is_multilabel=True, average=False)
+    acc.update((y_pred, y_true))
+    assert torch.allclose(acc.compute(), torch.zeros(3))
+
+
+def test_multilabel_input_average_false_label_with_no_positives():
+    # label at index 1 has no positive samples in y_true
+    y_true = torch.tensor(
+        [
+            [1, 0, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [0, 0, 0],
+        ]
+    )
+    y_pred = torch.tensor(
+        [
+            [1, 0, 0],
+            [0, 1, 1],
+            [1, 0, 0],
+            [0, 0, 1],
+        ]
+    )
+
+    acc = Accuracy(is_multilabel=True, average=False)
+    acc.update((y_pred, y_true))
+    result = acc.compute()
+
+    expected = (y_true == y_pred).float().mean(dim=0)
+    assert torch.allclose(result, expected)
+    assert torch.isfinite(result).all()
+
+
+@pytest.mark.parametrize("n_times", range(3))
+def test_multilabel_input_average_false_batched(n_times, available_device, test_data_multilabel):
+    acc = Accuracy(is_multilabel=True, average=False, device=available_device)
+    assert acc._device == torch.device(available_device)
+
+    y_pred, y, batch_size = test_data_multilabel
+    if batch_size > 1:
+        n_iters = y.shape[0] // batch_size + 1
+        for i in range(n_iters):
+            idx = i * batch_size
+            acc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
+    else:
+        acc.update((y_pred, y))
+
+    np_y_pred = to_numpy_multilabel(y_pred)
+    np_y = to_numpy_multilabel(y)
+    num_labels = np_y.shape[1]
+
+    result = acc.compute()
+    assert isinstance(result, torch.Tensor)
+    assert result.shape == (num_labels,)
+
+    expected = (np_y == np_y_pred).mean(axis=0)
+    assert result.cpu().numpy().tolist() == pytest.approx(expected.tolist())
+
+
 def test_incorrect_type():
     acc = Accuracy()
 
@@ -190,6 +306,39 @@ def test_incorrect_type():
 
     with pytest.raises(RuntimeError):
         acc.update((y_pred, y))
+
+
+@pytest.mark.parametrize("n_epochs", [1, 2])
+def test_engine_integration_multilabel_average_false(n_epochs):
+    # Regression test: reset() must correctly re-initialize the per-label accumulator
+    # at the start of every epoch, not just the first one.
+    n_iters = 10
+    batch_size = 16
+    n_classes = 5
+
+    y_true = torch.randint(0, 2, size=(n_iters * batch_size, n_classes))
+    y_preds = torch.randint(0, 2, size=(n_iters * batch_size, n_classes))
+
+    def update(engine, i):
+        return (
+            y_preds[i * batch_size : (i + 1) * batch_size, :],
+            y_true[i * batch_size : (i + 1) * batch_size, :],
+        )
+
+    engine = Engine(update)
+    acc = Accuracy(is_multilabel=True, average=False)
+    acc.attach(engine, "acc")
+
+    data = list(range(n_iters))
+    engine.run(data=data, max_epochs=n_epochs)
+
+    assert "acc" in engine.state.metrics
+    res = engine.state.metrics["acc"]
+    assert isinstance(res, torch.Tensor)
+    assert res.shape == (n_classes,)
+
+    expected = (y_true == y_preds).float().mean(dim=0)
+    assert torch.allclose(res, expected)
 
 
 @pytest.mark.usefixtures("distributed")
@@ -400,6 +549,58 @@ class TestDistributed:
 
             assert pytest.approx(res) == true_res
 
+    @pytest.mark.parametrize("n_epochs", [1, 2])
+    def test_integration_multilabel_average_false(self, n_epochs):
+        rank = idist.get_rank()
+        torch.manual_seed(12 + rank)
+
+        n_iters = 80
+        batch_size = 16
+        n_classes = 10
+
+        metric_devices = [torch.device("cpu")]
+        device = idist.device()
+        if device.type != "xla":
+            metric_devices.append(device)
+
+        for metric_device in metric_devices:
+            metric_device = torch.device(metric_device)
+
+            y_true = torch.randint(0, 2, size=(n_iters * batch_size, n_classes, 8, 10)).to(device)
+            y_preds = torch.randint(0, 2, size=(n_iters * batch_size, n_classes, 8, 10)).to(device)
+
+            def update(engine, i):
+                return (
+                    y_preds[i * batch_size : (i + 1) * batch_size, ...],
+                    y_true[i * batch_size : (i + 1) * batch_size, ...],
+                )
+
+            engine = Engine(update)
+
+            acc = Accuracy(is_multilabel=True, average=False, device=metric_device)
+            acc.attach(engine, "acc")
+
+            data = list(range(n_iters))
+            engine.run(data=data, max_epochs=n_epochs)
+
+            y_true = idist.all_gather(y_true)
+            y_preds = idist.all_gather(y_preds)
+
+            assert acc._num_correct.device == metric_device, (
+                f"{type(acc._num_correct.device)}:{acc._num_correct.device} vs {type(metric_device)}:{metric_device}"
+            )
+
+            assert "acc" in engine.state.metrics
+            res = engine.state.metrics["acc"]
+            assert isinstance(res, torch.Tensor)
+            assert res.shape == (n_classes,)
+
+            np_y_true = to_numpy_multilabel(y_true)
+            np_y_preds = to_numpy_multilabel(y_preds)
+            expected = (np_y_true == np_y_preds).mean(axis=0)
+
+            assert res.cpu().numpy().tolist() == pytest.approx(expected.tolist())
+
     def test_accumulator_device(self):
         metric_devices = [torch.device("cpu")]
         device = idist.device()
@@ -409,9 +610,9 @@ class TestDistributed:
         for metric_device in metric_devices:
             acc = Accuracy(device=metric_device)
             assert acc._device == metric_device
-            assert acc._num_correct.device == metric_device, (
-                f"{type(acc._num_correct.device)}:{acc._num_correct.device} vs {type(metric_device)}:{metric_device}"
-            )
+            # Since the shape of the accumulated amount isn't known before the first update
+            # call, the internal variable isn't a tensor on the right device yet (it's a
+            # plain int 0 right after reset()).
 
             y_pred = torch.randint(0, 2, size=(10,), device=device, dtype=torch.long)
             y = torch.randint(0, 2, size=(10,), device=device, dtype=torch.long)

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -507,7 +507,9 @@ class TestDistributed:
         for metric_device in metric_devices:
             acc = Accuracy(device=metric_device)
             assert acc._device == metric_device
-            assert acc._num_correct.device == metric_device
+            # Since the shape of the accumulated amount isn't known before the first update
+            # call, the internal variable isn't a tensor on the right device yet (it's a
+            # plain int 0 right after reset()).
 
             y_pred = torch.randint(0, 2, size=(10,), device=device, dtype=torch.long)
             y = torch.randint(0, 2, size=(10,), device=device, dtype=torch.long)

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -161,10 +161,6 @@ def test_per_label_parameter():
     with pytest.raises(ValueError, match=r"Argument per_label=True is only applicable with is_multilabel=True"):
         Accuracy(per_label=True)
 
-    # both should be fine
-    Accuracy(per_label=False)
-    Accuracy(per_label=True, is_multilabel=True)
-
 
 @pytest.mark.parametrize("n_times", range(3))
 def test_multilabel_input(n_times, available_device, test_data_multilabel):
@@ -215,67 +211,19 @@ def test_multilabel_input_per_label():
     assert isinstance(result, torch.Tensor)
     assert result.shape == (5,)
 
-    expected = (y_true == y_pred).float().mean(dim=0)
-    assert torch.allclose(result, expected)
     assert torch.allclose(result, torch.tensor([0.4, 0.8, 0.4, 0.8, 0.6]))
 
 
-@pytest.mark.parametrize(
-    "y_true, y_pred",
-    [
-        pytest.param(
-            torch.tensor([[1, 0, 1], [0, 1, 0], [1, 1, 0], [0, 0, 1]]),
-            torch.tensor([[1, 0, 1], [0, 1, 0], [1, 1, 0], [0, 0, 1]]),
-            id="all_correct",
-        ),
-        pytest.param(
-            torch.tensor([[0, 1, 0]] * 8),
-            torch.tensor([[1, 0, 1]] * 8),
-            id="all_wrong",
-        ),
-        pytest.param(
-            # label at index 1 has no positive samples in y_true
-            torch.tensor([[1, 0, 0], [0, 0, 1], [1, 0, 1], [0, 0, 0]]),
-            torch.tensor([[1, 0, 0], [0, 1, 1], [1, 0, 0], [0, 0, 1]]),
-            id="label_with_no_positives",
-        ),
-    ],
-)
-def test_multilabel_input_per_label_edge_cases(y_true, y_pred):
-    acc = Accuracy(is_multilabel=True, per_label=True)
-    acc.update((y_pred, y_true))
-    result = acc.compute()
-
-    expected = (y_true == y_pred).float().mean(dim=0)
-    assert isinstance(result, torch.Tensor)
-    assert torch.allclose(result, expected)
-    assert torch.isfinite(result).all()
-
-
-@pytest.mark.parametrize("n_times", range(3))
-def test_multilabel_input_per_label_batched(n_times, available_device, test_data_multilabel):
+def test_multilabel_input_per_label_batched(available_device):
+    y_true = torch.tensor([[0, 1, 0], [1, 0, 1], [1, 1, 0], [0, 0, 1]])
+    y_pred = torch.tensor([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 0, 1]])
     acc = Accuracy(is_multilabel=True, per_label=True, device=available_device)
-    assert acc._device == torch.device(available_device)
 
-    y_pred, y, batch_size = test_data_multilabel
-    if batch_size > 1:
-        n_iters = y.shape[0] // batch_size + 1
-        for i in range(n_iters):
-            idx = i * batch_size
-            acc.update((y_pred[idx : idx + batch_size], y[idx : idx + batch_size]))
-    else:
-        acc.update((y_pred, y))
+    acc.update((y_pred[:2], y_true[:2]))
+    acc.update((y_pred[2:], y_true[2:]))
 
-    np_y_pred = to_numpy_multilabel(y_pred)
-    np_y = to_numpy_multilabel(y)
-    num_labels = np_y.shape[1]
-
-    result = acc.compute()
-    assert isinstance(result, torch.Tensor)
-    assert result.shape == (num_labels,)
-
-    expected = (np_y == np_y_pred).mean(axis=0)
-    assert result.cpu().numpy().tolist() == pytest.approx(expected.tolist())
+    expected = (y_true == y_pred).float().mean(dim=0).to(available_device)
+    assert torch.allclose(acc.compute(), expected)
 
 
 def test_incorrect_type():
@@ -502,8 +450,7 @@ class TestDistributed:
 
             assert pytest.approx(res) == true_res
 
-    @pytest.mark.parametrize("n_epochs", [1, 2])
-    def test_integration_multilabel_per_label(self, n_epochs):
+    def test_integration_multilabel_per_label(self):
         rank = idist.get_rank()
         torch.manual_seed(12 + rank)
 
@@ -534,7 +481,7 @@ class TestDistributed:
             acc.attach(engine, "acc")
 
             data = list(range(n_iters))
-            engine.run(data=data, max_epochs=n_epochs)
+            engine.run(data=data, max_epochs=2)
 
             y_true = idist.all_gather(y_true)
             y_preds = idist.all_gather(y_preds)
@@ -563,9 +510,7 @@ class TestDistributed:
         for metric_device in metric_devices:
             acc = Accuracy(device=metric_device)
             assert acc._device == metric_device
-            # Since the shape of the accumulated amount isn't known before the first update
-            # call, the internal variable isn't a tensor on the right device yet (it's a
-            # plain int 0 right after reset()).
+            assert acc._num_correct.device == metric_device
 
             y_pred = torch.randint(0, 2, size=(10,), device=device, dtype=torch.long)
             y = torch.randint(0, 2, size=(10,), device=device, dtype=torch.long)

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -155,9 +155,6 @@ def test_multilabel_wrong_inputs():
 
 
 def test_per_label_parameter():
-    with pytest.raises(ValueError, match=r"Argument per_label should be boolean"):
-        Accuracy(per_label="macro")
-
     with pytest.raises(ValueError, match=r"Argument per_label=True is only applicable with is_multilabel=True"):
         Accuracy(per_label=True)
 

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -154,16 +154,16 @@ def test_multilabel_wrong_inputs():
         acc.update((torch.randint(0, 2, size=(10, 1)), torch.randint(0, 2, size=(10, 1)).long()))
 
 
-def test_subset_accuracy_parameter():
-    with pytest.raises(ValueError, match=r"Argument subset_accuracy should be boolean"):
-        Accuracy(subset_accuracy="macro")
+def test_per_label_parameter():
+    with pytest.raises(ValueError, match=r"Argument per_label should be boolean"):
+        Accuracy(per_label="macro")
 
-    with pytest.raises(ValueError, match=r"Argument subset_accuracy=False is only applicable with is_multilabel=True"):
-        Accuracy(subset_accuracy=False)
+    with pytest.raises(ValueError, match=r"Argument per_label=True is only applicable with is_multilabel=True"):
+        Accuracy(per_label=True)
 
     # both should be fine
-    Accuracy(subset_accuracy=True)
-    Accuracy(subset_accuracy=False, is_multilabel=True)
+    Accuracy(per_label=False)
+    Accuracy(per_label=True, is_multilabel=True)
 
 
 @pytest.mark.parametrize("n_times", range(3))
@@ -188,7 +188,7 @@ def test_multilabel_input(n_times, available_device, test_data_multilabel):
     assert accuracy_score(np_y, np_y_pred) == pytest.approx(acc.compute())
 
 
-def test_multilabel_input_subset_accuracy_false():
+def test_multilabel_input_per_label():
     y_true = torch.tensor(
         [
             [0, 0, 1, 0, 1],
@@ -208,7 +208,7 @@ def test_multilabel_input_subset_accuracy_false():
         ]
     )
 
-    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
+    acc = Accuracy(is_multilabel=True, per_label=True)
     acc.update((y_pred, y_true))
     result = acc.compute()
 
@@ -220,55 +220,41 @@ def test_multilabel_input_subset_accuracy_false():
     assert torch.allclose(result, torch.tensor([0.4, 0.8, 0.4, 0.8, 0.6]))
 
 
-def test_multilabel_input_subset_accuracy_false_all_correct():
-    y_true = torch.randint(0, 2, size=(8, 3))
-    y_pred = y_true.clone()
-
-    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
-    acc.update((y_pred, y_true))
-    assert torch.allclose(acc.compute(), torch.ones(3))
-
-
-def test_multilabel_input_subset_accuracy_false_all_wrong():
-    y_true = torch.tensor([[0, 1, 0]] * 8)
-    y_pred = torch.tensor([[1, 0, 1]] * 8)
-
-    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
-    acc.update((y_pred, y_true))
-    assert torch.allclose(acc.compute(), torch.zeros(3))
-
-
-def test_multilabel_input_subset_accuracy_false_label_with_no_positives():
-    # label at index 1 has no positive samples in y_true
-    y_true = torch.tensor(
-        [
-            [1, 0, 0],
-            [0, 0, 1],
-            [1, 0, 1],
-            [0, 0, 0],
-        ]
-    )
-    y_pred = torch.tensor(
-        [
-            [1, 0, 0],
-            [0, 1, 1],
-            [1, 0, 0],
-            [0, 0, 1],
-        ]
-    )
-
-    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
+@pytest.mark.parametrize(
+    "y_true, y_pred",
+    [
+        pytest.param(
+            torch.tensor([[1, 0, 1], [0, 1, 0], [1, 1, 0], [0, 0, 1]]),
+            torch.tensor([[1, 0, 1], [0, 1, 0], [1, 1, 0], [0, 0, 1]]),
+            id="all_correct",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 0]] * 8),
+            torch.tensor([[1, 0, 1]] * 8),
+            id="all_wrong",
+        ),
+        pytest.param(
+            # label at index 1 has no positive samples in y_true
+            torch.tensor([[1, 0, 0], [0, 0, 1], [1, 0, 1], [0, 0, 0]]),
+            torch.tensor([[1, 0, 0], [0, 1, 1], [1, 0, 0], [0, 0, 1]]),
+            id="label_with_no_positives",
+        ),
+    ],
+)
+def test_multilabel_input_per_label_edge_cases(y_true, y_pred):
+    acc = Accuracy(is_multilabel=True, per_label=True)
     acc.update((y_pred, y_true))
     result = acc.compute()
 
     expected = (y_true == y_pred).float().mean(dim=0)
+    assert isinstance(result, torch.Tensor)
     assert torch.allclose(result, expected)
     assert torch.isfinite(result).all()
 
 
 @pytest.mark.parametrize("n_times", range(3))
-def test_multilabel_input_subset_accuracy_false_batched(n_times, available_device, test_data_multilabel):
-    acc = Accuracy(is_multilabel=True, subset_accuracy=False, device=available_device)
+def test_multilabel_input_per_label_batched(n_times, available_device, test_data_multilabel):
+    acc = Accuracy(is_multilabel=True, per_label=True, device=available_device)
     assert acc._device == torch.device(available_device)
 
     y_pred, y, batch_size = test_data_multilabel
@@ -306,39 +292,6 @@ def test_incorrect_type():
 
     with pytest.raises(RuntimeError):
         acc.update((y_pred, y))
-
-
-@pytest.mark.parametrize("n_epochs", [1, 2])
-def test_engine_integration_multilabel_subset_accuracy_false(n_epochs):
-    # Regression test: reset() must correctly re-initialize the per-label accumulator
-    # at the start of every epoch, not just the first one.
-    n_iters = 10
-    batch_size = 16
-    n_classes = 5
-
-    y_true = torch.randint(0, 2, size=(n_iters * batch_size, n_classes))
-    y_preds = torch.randint(0, 2, size=(n_iters * batch_size, n_classes))
-
-    def update(engine, i):
-        return (
-            y_preds[i * batch_size : (i + 1) * batch_size, :],
-            y_true[i * batch_size : (i + 1) * batch_size, :],
-        )
-
-    engine = Engine(update)
-    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
-    acc.attach(engine, "acc")
-
-    data = list(range(n_iters))
-    engine.run(data=data, max_epochs=n_epochs)
-
-    assert "acc" in engine.state.metrics
-    res = engine.state.metrics["acc"]
-    assert isinstance(res, torch.Tensor)
-    assert res.shape == (n_classes,)
-
-    expected = (y_true == y_preds).float().mean(dim=0)
-    assert torch.allclose(res, expected)
 
 
 @pytest.mark.usefixtures("distributed")
@@ -550,7 +503,7 @@ class TestDistributed:
             assert pytest.approx(res) == true_res
 
     @pytest.mark.parametrize("n_epochs", [1, 2])
-    def test_integration_multilabel_subset_accuracy_false(self, n_epochs):
+    def test_integration_multilabel_per_label(self, n_epochs):
         rank = idist.get_rank()
         torch.manual_seed(12 + rank)
 
@@ -577,7 +530,7 @@ class TestDistributed:
 
             engine = Engine(update)
 
-            acc = Accuracy(is_multilabel=True, subset_accuracy=False, device=metric_device)
+            acc = Accuracy(is_multilabel=True, per_label=True, device=metric_device)
             acc.attach(engine, "acc")
 
             data = list(range(n_iters))

--- a/tests/ignite/metrics/test_accuracy.py
+++ b/tests/ignite/metrics/test_accuracy.py
@@ -154,16 +154,16 @@ def test_multilabel_wrong_inputs():
         acc.update((torch.randint(0, 2, size=(10, 1)), torch.randint(0, 2, size=(10, 1)).long()))
 
 
-def test_average_parameter():
-    with pytest.raises(ValueError, match=r"Argument average should be None or False"):
-        Accuracy(average="macro")
+def test_subset_accuracy_parameter():
+    with pytest.raises(ValueError, match=r"Argument subset_accuracy should be boolean"):
+        Accuracy(subset_accuracy="macro")
 
-    with pytest.raises(ValueError, match=r"Argument average=False is only applicable with is_multilabel=True"):
-        Accuracy(average=False)
+    with pytest.raises(ValueError, match=r"Argument subset_accuracy=False is only applicable with is_multilabel=True"):
+        Accuracy(subset_accuracy=False)
 
     # both should be fine
-    Accuracy(average=None)
-    Accuracy(average=False, is_multilabel=True)
+    Accuracy(subset_accuracy=True)
+    Accuracy(subset_accuracy=False, is_multilabel=True)
 
 
 @pytest.mark.parametrize("n_times", range(3))
@@ -188,7 +188,7 @@ def test_multilabel_input(n_times, available_device, test_data_multilabel):
     assert accuracy_score(np_y, np_y_pred) == pytest.approx(acc.compute())
 
 
-def test_multilabel_input_average_false():
+def test_multilabel_input_subset_accuracy_false():
     y_true = torch.tensor(
         [
             [0, 0, 1, 0, 1],
@@ -208,7 +208,7 @@ def test_multilabel_input_average_false():
         ]
     )
 
-    acc = Accuracy(is_multilabel=True, average=False)
+    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
     acc.update((y_pred, y_true))
     result = acc.compute()
 
@@ -220,25 +220,25 @@ def test_multilabel_input_average_false():
     assert torch.allclose(result, torch.tensor([0.4, 0.8, 0.4, 0.8, 0.6]))
 
 
-def test_multilabel_input_average_false_all_correct():
+def test_multilabel_input_subset_accuracy_false_all_correct():
     y_true = torch.randint(0, 2, size=(8, 3))
     y_pred = y_true.clone()
 
-    acc = Accuracy(is_multilabel=True, average=False)
+    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
     acc.update((y_pred, y_true))
     assert torch.allclose(acc.compute(), torch.ones(3))
 
 
-def test_multilabel_input_average_false_all_wrong():
+def test_multilabel_input_subset_accuracy_false_all_wrong():
     y_true = torch.tensor([[0, 1, 0]] * 8)
     y_pred = torch.tensor([[1, 0, 1]] * 8)
 
-    acc = Accuracy(is_multilabel=True, average=False)
+    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
     acc.update((y_pred, y_true))
     assert torch.allclose(acc.compute(), torch.zeros(3))
 
 
-def test_multilabel_input_average_false_label_with_no_positives():
+def test_multilabel_input_subset_accuracy_false_label_with_no_positives():
     # label at index 1 has no positive samples in y_true
     y_true = torch.tensor(
         [
@@ -257,7 +257,7 @@ def test_multilabel_input_average_false_label_with_no_positives():
         ]
     )
 
-    acc = Accuracy(is_multilabel=True, average=False)
+    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
     acc.update((y_pred, y_true))
     result = acc.compute()
 
@@ -267,8 +267,8 @@ def test_multilabel_input_average_false_label_with_no_positives():
 
 
 @pytest.mark.parametrize("n_times", range(3))
-def test_multilabel_input_average_false_batched(n_times, available_device, test_data_multilabel):
-    acc = Accuracy(is_multilabel=True, average=False, device=available_device)
+def test_multilabel_input_subset_accuracy_false_batched(n_times, available_device, test_data_multilabel):
+    acc = Accuracy(is_multilabel=True, subset_accuracy=False, device=available_device)
     assert acc._device == torch.device(available_device)
 
     y_pred, y, batch_size = test_data_multilabel
@@ -309,7 +309,7 @@ def test_incorrect_type():
 
 
 @pytest.mark.parametrize("n_epochs", [1, 2])
-def test_engine_integration_multilabel_average_false(n_epochs):
+def test_engine_integration_multilabel_subset_accuracy_false(n_epochs):
     # Regression test: reset() must correctly re-initialize the per-label accumulator
     # at the start of every epoch, not just the first one.
     n_iters = 10
@@ -326,7 +326,7 @@ def test_engine_integration_multilabel_average_false(n_epochs):
         )
 
     engine = Engine(update)
-    acc = Accuracy(is_multilabel=True, average=False)
+    acc = Accuracy(is_multilabel=True, subset_accuracy=False)
     acc.attach(engine, "acc")
 
     data = list(range(n_iters))
@@ -550,7 +550,7 @@ class TestDistributed:
             assert pytest.approx(res) == true_res
 
     @pytest.mark.parametrize("n_epochs", [1, 2])
-    def test_integration_multilabel_average_false(self, n_epochs):
+    def test_integration_multilabel_subset_accuracy_false(self, n_epochs):
         rank = idist.get_rank()
         torch.manual_seed(12 + rank)
 
@@ -577,7 +577,7 @@ class TestDistributed:
 
             engine = Engine(update)
 
-            acc = Accuracy(is_multilabel=True, average=False, device=metric_device)
+            acc = Accuracy(is_multilabel=True, subset_accuracy=False, device=metric_device)
             acc.attach(engine, "acc")
 
             data = list(range(n_iters))

--- a/tests/ignite/metrics/test_running_average.py
+++ b/tests/ignite/metrics/test_running_average.py
@@ -121,9 +121,7 @@ def test_integration_batchwise(usage):
     acc_metric.load_state_dict(metric_state)
     assert acc_metric._value == saved__value
     assert acc_metric.src._num_examples == saved_src__num_examples
-    # `_num_correct` may be a plain int (right after reset(), before any update()) or a tensor,
-    # depending on whether `src` was updated since its last reset — compare in a type-agnostic way.
-    assert torch.equal(torch.as_tensor(acc_metric.src._num_correct), torch.as_tensor(saved_src__num_correct))
+    assert (acc_metric.src._num_correct == saved_src__num_correct).all()
 
     metric_state = avg_output.state_dict()
     saved__value = avg_output._value

--- a/tests/ignite/metrics/test_running_average.py
+++ b/tests/ignite/metrics/test_running_average.py
@@ -121,7 +121,9 @@ def test_integration_batchwise(usage):
     acc_metric.load_state_dict(metric_state)
     assert acc_metric._value == saved__value
     assert acc_metric.src._num_examples == saved_src__num_examples
-    assert (acc_metric.src._num_correct == saved_src__num_correct).all()
+    # `_num_correct` may be a plain int (right after reset(), before any update()) or a tensor,
+    # depending on whether `src` was updated since its last reset — compare in a type-agnostic way.
+    assert torch.equal(torch.as_tensor(acc_metric.src._num_correct), torch.as_tensor(saved_src__num_correct))
 
     metric_state = avg_output.state_dict()
     saved__value = avg_output._value


### PR DESCRIPTION
Fixes #513

Description:
Adds a `per_label` parameter to `Accuracy` for multilabel classification. When `per_label=True` and `is_multilabel=True`, `compute()` returns a per-label accuracy tensor of shape `(num_labels,)` using elementwise comparison, instead of the default subset accuracy scalar. Default behavior (`per_label=False`) is unchanged.

Prior attempts (PR #516, PR #542) stalled in 2019 over API design — both proposed a `labelwise=True` boolean flag, which was rejected. This PR went through a few naming iterations during review (`average` → `subset_accuracy` → `per_label`) before landing on `per_label`, since it avoids clashing with `Precision`/`Recall`'s existing `average='micro'/'macro'` semantics and its True/False polarity matches what it returns.

`per_label` is the last keyword argument in `__init__` to preserve positional-argument backward compatibility.

Also updates two pre-existing tests (`test_accuracy.py::test_accumulator_device`, `test_running_average.py::test_integration_batchwise`) that assumed `_num_correct` is always a tensor right after `reset()` — it's now a plain `int` until the first `update()`, matching the `int | torch.Tensor` pattern `Precision`/`Recall` already use for `_numerator`/`_denominator`.

Check list:

- [ x ] New tests are added (if a new feature is added)
- [ x ] New doc strings: description and/or example code are in RST format
- [ x ] Documentation is updated (if required)
