### PR TITLE
Fix HSIC automatic bandwidth for constant inputs

### DIFF
--- a/ignite/metrics/hsic.py
+++ b/ignite/metrics/hsic.py
@@ -136,6 +136,7 @@ class HSIC(Metric):
         if self.sigma_x < 0:
             # vx = torch.quantile(dxx, 0.5)
             vx = torch.quantile(dxx, 0.5)
+            vx = vx.clamp_min(torch.finfo(vx.dtype).tiny)
         else:
             vx = self.sigma_x**2
         K = torch.exp(-0.5 * dxx / vx) * mask
@@ -147,6 +148,7 @@ class HSIC(Metric):
         vy: Tensor | float
         if self.sigma_y < 0:
             vy = torch.quantile(dyy, 0.5)
+            vy = vy.clamp_min(torch.finfo(vy.dtype).tiny)
         else:
             vy = self.sigma_y**2
         L = torch.exp(-0.5 * dyy / vy) * mask

--- a/tests/ignite/metrics/test_hsic.py
+++ b/tests/ignite/metrics/test_hsic.py
@@ -120,6 +120,23 @@ def test_accumulator_detached(available_device):
     assert not hsic._sum_of_hsic.requires_grad
 
 
+@pytest.mark.parametrize("constant_input", ["x", "y", "both"])
+def test_constant_input(constant_input):
+    torch.manual_seed(12)
+    x = torch.randn(10, 3)
+    y = torch.randn(10, 3)
+
+    if constant_input in ("x", "both"):
+        x.zero_()
+    if constant_input in ("y", "both"):
+        y.zero_()
+
+    hsic = HSIC()
+    hsic.update((x, y))
+
+    assert hsic.compute() == pytest.approx(0.0, abs=1e-6)
+
+
 @pytest.mark.usefixtures("distributed")
 class TestDistributed:
     @pytest.mark.parametrize("sigma_x", [-1.0, 1.0])


### PR DESCRIPTION
Fixes #3821

Description:

`HSIC` inferred a zero RBF bandwidth when either input was constant. Dividing the zero pairwise distances by that bandwidth produced `NaN`, which then propagated to the metric result.

Clamp only non-positive automatically inferred bandwidths to the smallest positive value for their dtype. Positive inferred bandwidths and explicitly supplied bandwidths are unchanged. This gives the limiting RBF kernel for constant inputs and keeps the HSIC estimate finite and near zero.

The regression covers constant `x`, constant `y`, and both inputs constant.

Validation:

- `pytest tests/ignite/metrics/test_hsic.py -q`: 47 passed, 99 skipped
- `ruff check ignite/metrics/hsic.py tests/ignite/metrics/test_hsic.py`: passed
- `ruff format --check ignite/metrics/hsic.py tests/ignite/metrics/test_hsic.py`: passed
- `git diff --check`: passed
- manual float32/float64 checks for batch sizes 4, 5, 10, and 32: finite and within 1e-6 of zero

AI assistance disclosure: OpenAI Codex assisted with diagnosis, implementation, duplicate searching, and test execution. The issue includes a standalone reproducer, and the focused test results above were run against this branch.

Check list:

- [x] New tests are added
- [x] No new doc strings are required
- [x] Documentation is not required for this correctness fix