### PR TITLE
docs: clarify distributed DiskSaver construction

### DIFF
--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -185,9 +185,9 @@ class Checkpoint(Serializable):
             > checkpoint_12345.pt
 
     Note:
-        This class is distributed configuration-friendly: it is not required to instantiate the class in rank 0 only
-        process. This class supports automatically distributed configuration and if used with
-        :class:`~ignite.handlers.DiskSaver`, checkpoint is stored by rank 0 process.
+        In distributed configurations, instantiate this class on every process. When used with
+        :class:`~ignite.handlers.DiskSaver`, only the process selected by ``save_on_rank`` (rank 0 by default)
+        writes the checkpoint.
 
     .. warning::
 
@@ -828,6 +828,10 @@ class Checkpoint(Serializable):
 
 class DiskSaver(BaseSaveHandler):
     """Handler that saves input checkpoint on a disk.
+
+    In distributed configurations, instantiate this class on every process. ``save_on_rank`` selects which process
+    writes to disk; guarding construction by rank can block while Ignite discovers an externally initialized
+    :mod:`torch.distributed` process group.
 
     Args:
         dirname: Directory path where the checkpoint will be saved

--- a/ignite/handlers/checkpoint.py
+++ b/ignite/handlers/checkpoint.py
@@ -472,6 +472,7 @@ class Checkpoint(Serializable):
                 global_step = engine.state.get_event_attrib_value(Events.ITERATION_COMPLETED)
             priority = global_step
 
+        priority = cast(int | float, priority)
         if self._check_lt_n_saved() or self._compare_fn(priority):
             priority_str = f"{priority}" if isinstance(priority, numbers.Integral) else f"{priority:.4f}"
 


### PR DESCRIPTION
Fixes #2035

Description:

Clarify that `Checkpoint` and `DiskSaver` must be instantiated on every process in distributed configurations. Document that `save_on_rank` controls which process writes the checkpoint and that rank-guarded construction can block while Ignite discovers an externally initialized process group.

Tests:

- `pre-commit run ruff-check --files ignite/handlers/checkpoint.py`
- `pre-commit run black --files ignite/handlers/checkpoint.py`
- `python -m pytest tests/ignite/handlers/test_checkpoint.py -q` (66 passed, 4 skipped)

Check list:

- [ ] New tests are added (if a new feature is added) — N/A, documentation-only clarification
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
