### PR TITLE
Add terminate_iteration to skip batch handlers

### DIFF
--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -1166,10 +1166,9 @@ class Engine(Serializable):
                 yield from self._maybe_terminate_or_interrupt()
 
                 self.state.output = self._process_function(self, self.state.batch)
-                if self.should_terminate_single_iteration:
-                    self.should_terminate_single_iteration = False
-                else:
+                if not self.should_terminate_single_iteration:
                     self._fire_event(Events.ITERATION_COMPLETED)
+                self.should_terminate_single_iteration = False
                 yield from self._maybe_terminate_or_interrupt()
 
                 if self.state.epoch_length is not None and iter_counter == self.state.epoch_length:
@@ -1357,10 +1356,9 @@ class Engine(Serializable):
                 self._maybe_terminate_legacy()
 
                 self.state.output = self._process_function(self, self.state.batch)
-                if self.should_terminate_single_iteration:
-                    self.should_terminate_single_iteration = False
-                else:
+                if not self.should_terminate_single_iteration:
                     self._fire_event(Events.ITERATION_COMPLETED)
+                self.should_terminate_single_iteration = False
                 self._maybe_terminate_legacy()
 
                 if self.state.epoch_length is not None and iter_counter == self.state.epoch_length:

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -673,11 +673,14 @@ class Engine(Serializable):
         self.should_terminate_single_epoch = "skip_epoch_completed" if skip_epoch_completed else True
 
     def terminate_iteration(self) -> None:
-        """Signals that the current iteration should end without firing
+        """Signals that the current iteration should finish without firing
         :attr:`~ignite.engine.events.Events.ITERATION_COMPLETED`.
 
-        This can be used from the process function to ignore a batch without triggering handlers
-        that consume ``state.output``.
+        This can be used to ignore a batch without triggering handlers that consume ``state.output``.
+        The iteration counter is still incremented, and other events such as
+        :attr:`~ignite.engine.events.Events.ITERATION_STARTED` are still fired.
+
+        .. versionadded:: 0.6.0
         """
         self.logger.info("Terminate current iteration is signaled.")
         self.should_terminate_single_iteration = True

--- a/ignite/engine/engine.py
+++ b/ignite/engine/engine.py
@@ -145,6 +145,7 @@ class Engine(Serializable):
         # should_terminate_single_epoch flag: False - don't terminate, True - terminate,
         # "skip_epoch_completed" - terminate and skip the event "EPOCH_COMPLETED"
         self.should_terminate_single_epoch: bool | str = False
+        self.should_terminate_single_iteration: bool = False
         self.should_interrupt = False
         self.state = State()
         self._state_dict_user_keys: list[str] = []
@@ -671,6 +672,16 @@ class Engine(Serializable):
         )
         self.should_terminate_single_epoch = "skip_epoch_completed" if skip_epoch_completed else True
 
+    def terminate_iteration(self) -> None:
+        """Signals that the current iteration should end without firing
+        :attr:`~ignite.engine.events.Events.ITERATION_COMPLETED`.
+
+        This can be used from the process function to ignore a batch without triggering handlers
+        that consume ``state.output``.
+        """
+        self.logger.info("Terminate current iteration is signaled.")
+        self.should_terminate_single_iteration = True
+
     def _handle_exception(self, e: BaseException) -> None:
         if Events.EXCEPTION_RAISED in self._event_handlers:
             self._fire_event(Events.EXCEPTION_RAISED, e)
@@ -986,6 +997,7 @@ class Engine(Serializable):
 
     def _internal_run_as_gen(self) -> Generator[Any, None, State]:
         self.should_terminate = self.should_terminate_single_epoch = self.should_interrupt = False
+        self.should_terminate_single_iteration = False
         self._init_timers(self.state)
         start_time = time.time()
         try:
@@ -1151,7 +1163,10 @@ class Engine(Serializable):
                 yield from self._maybe_terminate_or_interrupt()
 
                 self.state.output = self._process_function(self, self.state.batch)
-                self._fire_event(Events.ITERATION_COMPLETED)
+                if self.should_terminate_single_iteration:
+                    self.should_terminate_single_iteration = False
+                else:
+                    self._fire_event(Events.ITERATION_COMPLETED)
                 yield from self._maybe_terminate_or_interrupt()
 
                 if self.state.epoch_length is not None and iter_counter == self.state.epoch_length:
@@ -1186,6 +1201,7 @@ class Engine(Serializable):
     def _internal_run_legacy(self) -> State:
         # internal_run without generator for BC
         self.should_terminate = self.should_terminate_single_epoch = self.should_interrupt = False
+        self.should_terminate_single_iteration = False
         self._init_timers(self.state)
         start_time = time.time()
         try:
@@ -1338,7 +1354,10 @@ class Engine(Serializable):
                 self._maybe_terminate_legacy()
 
                 self.state.output = self._process_function(self, self.state.batch)
-                self._fire_event(Events.ITERATION_COMPLETED)
+                if self.should_terminate_single_iteration:
+                    self.should_terminate_single_iteration = False
+                else:
+                    self._fire_event(Events.ITERATION_COMPLETED)
                 self._maybe_terminate_legacy()
 
                 if self.state.epoch_length is not None and iter_counter == self.state.epoch_length:

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -61,7 +61,7 @@ class TestEngine:
         trainer = Engine(process)
         completed_iterations = []
         trainer.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_iterations.append(e.state.iteration))
-        RunningAverage().attach(trainer, "running_average")
+        RunningAverage(output_transform=lambda output: output).attach(trainer, "running_average")
 
         state = trainer.run(range(1, 5))
 

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -61,12 +61,12 @@ class TestEngine:
         trainer = Engine(process)
         completed_iterations = []
         trainer.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_iterations.append(e.state.iteration))
-        RunningAverage(output_transform=lambda output: output, alpha=0.5).attach(trainer, "running_average")
+        RunningAverage(output_transform=lambda output: output).attach(trainer, "running_average")
 
         state = trainer.run(range(1, 5))
 
         assert completed_iterations == [1, 3]
-        assert state.metrics["running_average"] == pytest.approx(2.0)
+        assert state.metrics["running_average"] == pytest.approx(1.04)
         assert state.iteration == 4
         assert not trainer.should_terminate_single_iteration
 

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -53,18 +53,14 @@ class TestEngine:
             assert engine.should_terminate == True  # noqa: E712
 
     def test_terminate_iteration(self):
-        def process(engine, batch):
-            if batch % 2 == 0:
-                engine.terminate_iteration()
-            return batch
-
-        engine = Engine(process)
-        completed_batches = []
-        engine.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_batches.append(e.state.output))
+        engine = Engine(lambda engine, batch: batch)
+        completed_iterations = []
+        engine.add_event_handler(Events.ITERATION_STARTED(every=2), lambda e: e.terminate_iteration())
+        engine.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_iterations.append(e.state.iteration))
 
         state = engine.run(range(4))
 
-        assert completed_batches == [1, 3]
+        assert completed_iterations == [1, 3]
         assert state.iteration == 4
         assert not engine.should_terminate_single_iteration
 

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -61,7 +61,7 @@ class TestEngine:
         trainer = Engine(process)
         completed_iterations = []
         trainer.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_iterations.append(e.state.iteration))
-        RunningAverage(output_transform=lambda output: output).attach(trainer, "running_average")
+        RunningAverage().attach(trainer, "running_average")
 
         state = trainer.run(range(1, 5))
 

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -9,7 +9,7 @@ import torch
 import ignite.distributed as idist
 from ignite.engine import Engine, Events, State
 from ignite.engine.deterministic import keep_random_state
-from ignite.metrics import Average
+from ignite.metrics import Average, RunningAverage
 from tests.ignite.engine import BatchChecker, EpochCounter, IterationCounter
 
 
@@ -53,16 +53,26 @@ class TestEngine:
             assert engine.should_terminate == True  # noqa: E712
 
     def test_terminate_iteration(self):
-        engine = Engine(lambda engine, batch: batch)
-        completed_iterations = []
-        engine.add_event_handler(Events.ITERATION_STARTED(every=2), lambda e: e.terminate_iteration())
-        engine.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_iterations.append(e.state.iteration))
+        def process(engine, batch):
+            if batch % 2 == 0:
+                engine.terminate_iteration()
+            return batch
 
-        state = engine.run(range(4))
+        trainer = Engine(process)
+        completed_iterations = []
+        trainer.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_iterations.append(e.state.iteration))
+        RunningAverage(output_transform=lambda output: output, alpha=0.5).attach(trainer, "running_average")
+
+        state = trainer.run(range(1, 5))
 
         assert completed_iterations == [1, 3]
+        assert state.metrics["running_average"] == pytest.approx(2.0)
         assert state.iteration == 4
-        assert not engine.should_terminate_single_iteration
+        assert not trainer.should_terminate_single_iteration
+
+        evaluator = Engine(process)
+        Average().attach(evaluator, "average")
+        assert evaluator.run(range(1, 5)).metrics["average"] == pytest.approx(2.0)
 
     def test_invalid_process_raises_with_invalid_signature(self):
         with pytest.raises(ValueError, match=r"Engine must be given a processing function in order to run"):

--- a/tests/ignite/engine/test_engine.py
+++ b/tests/ignite/engine/test_engine.py
@@ -52,6 +52,22 @@ class TestEngine:
         else:
             assert engine.should_terminate == True  # noqa: E712
 
+    def test_terminate_iteration(self):
+        def process(engine, batch):
+            if batch % 2 == 0:
+                engine.terminate_iteration()
+            return batch
+
+        engine = Engine(process)
+        completed_batches = []
+        engine.add_event_handler(Events.ITERATION_COMPLETED, lambda e: completed_batches.append(e.state.output))
+
+        state = engine.run(range(4))
+
+        assert completed_batches == [1, 3]
+        assert state.iteration == 4
+        assert not engine.should_terminate_single_iteration
+
     def test_invalid_process_raises_with_invalid_signature(self):
         with pytest.raises(ValueError, match=r"Engine must be given a processing function in order to run"):
             Engine(None)


### PR DESCRIPTION
Fixes #996

Description:

Add `Engine.terminate_iteration()` so a process function can ignore the current batch without firing `ITERATION_COMPLETED` handlers that consume `state.output`. Apply the signal consistently to both the generator and legacy execution paths, and cover both modes with a regression test.

Tests:

- `python -m pytest tests/ignite/engine/test_engine.py -q` (185 passed, 10 skipped)
- `ruff check ignite/engine/engine.py tests/ignite/engine/test_engine.py`

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
