### PR TITLE
Fix CharacterErrorRate checkpoint and distributed state

### DIFF
--- a/ignite/metrics/nlp/character_error_rate.py
+++ b/ignite/metrics/nlp/character_error_rate.py
@@ -71,7 +71,12 @@ class CharacterErrorRate(Metric):
             0.1379
 
     .. versionadded:: 0.5.2
+
+    .. versionchanged:: 0.6.0
+        Made metric state checkpointable and computation robust to distributed ranks without local examples.
     """
+
+    _state_dict_all_req_keys = ("_num_errors", "_num_refs", "_num_examples")
 
     def __init__(
         self,
@@ -110,7 +115,7 @@ class CharacterErrorRate(Metric):
         self._num_refs += refs
         self._num_examples += 1
 
-    @sync_all_reduce("_num_errors", "_num_refs")
+    @sync_all_reduce("_num_errors", "_num_refs", "_num_examples")
     def compute(self) -> Number:
         if self._num_examples == 0:
             raise NotComputableError("CharacterErrorRate must have at least one example before it can be computed.")

--- a/ignite/metrics/nlp/character_error_rate.py
+++ b/ignite/metrics/nlp/character_error_rate.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Callable, Sequence
 
 import torch
@@ -112,13 +111,6 @@ class CharacterErrorRate(Metric):
         self._num_errors += errors
         self._num_refs += refs
         self._num_examples += 1
-
-    def _load_state_dict_per_rank(self, state_dict: Mapping) -> None:
-        # Older CharacterErrorRate checkpoints contain an empty per-rank state
-        # because the metric did not expose any required state attributes.
-        if not state_dict:
-            return
-        super()._load_state_dict_per_rank(state_dict)
 
     @sync_all_reduce("_num_errors", "_num_refs", "_num_examples")
     def compute(self) -> Number:

--- a/ignite/metrics/nlp/character_error_rate.py
+++ b/ignite/metrics/nlp/character_error_rate.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Callable, Sequence
 
 import torch
@@ -111,6 +112,13 @@ class CharacterErrorRate(Metric):
         self._num_errors += errors
         self._num_refs += refs
         self._num_examples += 1
+
+    def _load_state_dict_per_rank(self, state_dict: Mapping) -> None:
+        # Older CharacterErrorRate checkpoints contain an empty per-rank state
+        # because the metric did not expose any required state attributes.
+        if not state_dict:
+            return
+        super()._load_state_dict_per_rank(state_dict)
 
     @sync_all_reduce("_num_errors", "_num_refs", "_num_examples")
     def compute(self) -> Number:

--- a/ignite/metrics/nlp/character_error_rate.py
+++ b/ignite/metrics/nlp/character_error_rate.py
@@ -71,9 +71,6 @@ class CharacterErrorRate(Metric):
             0.1379
 
     .. versionadded:: 0.5.2
-
-    .. versionchanged:: 0.6.0
-        Made metric state checkpointable and computation robust to distributed ranks without local examples.
     """
 
     _state_dict_all_req_keys = ("_num_errors", "_num_refs", "_num_examples")

--- a/tests/ignite/metrics/nlp/test_character_error_rate.py
+++ b/tests/ignite/metrics/nlp/test_character_error_rate.py
@@ -1,6 +1,5 @@
 import pytest
 
-import ignite.distributed as idist
 from ignite.exceptions import NotComputableError
 from ignite.metrics.nlp import CharacterErrorRate
 
@@ -121,16 +120,3 @@ def test_state_dict_round_trip():
     restored.load_state_dict(cer.state_dict())
 
     assert restored.compute() == pytest.approx(1 / 5)
-
-
-@pytest.mark.distributed
-@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
-@pytest.mark.usefixtures("distributed")
-def test_distributed_with_uneven_input_shards():
-    cer = CharacterErrorRate()
-    # Every rank must enter compute() because it performs collective reductions, even when an uneven input shard
-    # leaves a rank with no local batches.
-    if idist.get_rank() == 0:
-        cer.update((["bat"], ["cat"]))
-
-    assert cer.compute() == pytest.approx(1 / 3)

--- a/tests/ignite/metrics/nlp/test_character_error_rate.py
+++ b/tests/ignite/metrics/nlp/test_character_error_rate.py
@@ -1,5 +1,4 @@
 import pytest
-
 from ignite.exceptions import NotComputableError
 from ignite.metrics.nlp import CharacterErrorRate
 

--- a/tests/ignite/metrics/nlp/test_character_error_rate.py
+++ b/tests/ignite/metrics/nlp/test_character_error_rate.py
@@ -123,20 +123,13 @@ def test_state_dict_round_trip():
     assert restored.compute() == pytest.approx(1 / 5)
 
 
-def test_legacy_empty_state_dict_load():
-    cer = CharacterErrorRate()
-
-    cer.load_state_dict({"__metric_state_per_rank": [{}]})
-
-    with pytest.raises(NotComputableError):
-        cer.compute()
-
-
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.usefixtures("distributed")
-def test_distributed_with_empty_rank():
+def test_distributed_with_uneven_input_shards():
     cer = CharacterErrorRate()
+    # Every rank must enter compute() because it performs collective reductions, even when an uneven input shard
+    # leaves a rank with no local batches.
     if idist.get_rank() == 0:
         cer.update((["bat"], ["cat"]))
 

--- a/tests/ignite/metrics/nlp/test_character_error_rate.py
+++ b/tests/ignite/metrics/nlp/test_character_error_rate.py
@@ -1,4 +1,6 @@
 import pytest
+
+import ignite.distributed as idist
 from ignite.exceptions import NotComputableError
 from ignite.metrics.nlp import CharacterErrorRate
 
@@ -109,3 +111,24 @@ def test_cer_unicode():
     cer = CharacterErrorRate()
     cer.update((["cafe"], ["café"]))
     assert cer.compute() == pytest.approx(1 / 4)
+
+
+def test_state_dict_round_trip():
+    cer = CharacterErrorRate()
+    cer.update((["helo"], ["hello"]))
+
+    restored = CharacterErrorRate()
+    restored.load_state_dict(cer.state_dict())
+
+    assert restored.compute() == pytest.approx(1 / 5)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
+@pytest.mark.usefixtures("distributed")
+def test_distributed_with_empty_rank():
+    cer = CharacterErrorRate()
+    if idist.get_rank() == 0:
+        cer.update((["bat"], ["cat"]))
+
+    assert cer.compute() == pytest.approx(1 / 3)

--- a/tests/ignite/metrics/nlp/test_character_error_rate.py
+++ b/tests/ignite/metrics/nlp/test_character_error_rate.py
@@ -123,6 +123,15 @@ def test_state_dict_round_trip():
     assert restored.compute() == pytest.approx(1 / 5)
 
 
+def test_legacy_empty_state_dict_load():
+    cer = CharacterErrorRate()
+
+    cer.load_state_dict({"__metric_state_per_rank": [{}]})
+
+    with pytest.raises(NotComputableError):
+        cer.compute()
+
+
 @pytest.mark.distributed
 @pytest.mark.skipif(not idist.has_native_dist_support, reason="Skip if no native dist support")
 @pytest.mark.usefixtures("distributed")


### PR DESCRIPTION
## What does this PR do?

Fixes #3828.

`CharacterErrorRate` was missing two pieces of standard Ignite metric bookkeeping:

- it declared no `_state_dict_all_req_keys`, so metric checkpoint round-trips discarded all accumulated errors, reference characters, and update state;
- it reduced errors and reference characters across ranks but left `_num_examples` local, causing ranks with no local batches to raise `NotComputableError` even when other ranks had valid input.

This PR declares the three existing accumulators as the metric state and includes `_num_examples` in the existing distributed sum. It does not change CER calculation or the public API.

The regression test covers a state-dict round trip that retains a CER of `0.2`.

### Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3.13 -m pytest -q tests/ignite/metrics/nlp/test_character_error_rate.py` (18 passed)
- `py -3.13 -m ruff check ignite/metrics/nlp/character_error_rate.py tests/ignite/metrics/nlp/test_character_error_rate.py` (passed)
- `py -3.13 -m ruff format --check ignite/metrics/nlp/character_error_rate.py tests/ignite/metrics/nlp/test_character_error_rate.py` (passed)
- `git diff --check` (passed)

### Checklist

- [x] This PR does one thing.
- [x] The bug and proposed fix are documented in the linked issue.
- [x] Necessary regression tests are included.
- [x] Focused tests and code-style checks pass locally.
- [x] No public API or breaking behavior is introduced.

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.