### PR TITLE
refactor: convert .format() to f-strings (fixes #2224)

### DIFF
--- a/ignite/handlers/param_scheduler.py
+++ b/ignite/handlers/param_scheduler.py
@@ -897,7 +897,7 @@ class _CosineAnnealingWarmRestarts:
                 self._lr_scheduler.T_i = self._lr_scheduler.T_i * T_mult
         else:
             if epoch < 0:
-                raise ValueError("Expected non-negative epoch, but got {}".format(epoch))
+                raise ValueError(f"Expected non-negative epoch, but got {epoch}")
             if epoch >= self._lr_scheduler.T_0:
                 if T_mult == 1:
                     self._lr_scheduler.T_cur = epoch % self._lr_scheduler.T_0

--- a/ignite/handlers/time_limit.py
+++ b/ignite/handlers/time_limit.py
@@ -40,5 +40,5 @@ class TimeLimit:
     def __call__(self, engine: Engine) -> None:
         elapsed_time = time.time() - self.start_time
         if elapsed_time > self.limit_sec:
-            self.logger.info("Reached the time limit: {} sec. Stop training".format(self.limit_sec))
+            self.logger.info(f"Reached the time limit: {self.limit_sec} sec. Stop training")
             engine.terminate()

--- a/ignite/metrics/gan/fid.py
+++ b/ignite/metrics/gan/fid.py
@@ -42,7 +42,7 @@ def fid_score(
     if np.iscomplexobj(covmean):
         if not np.allclose(np.diagonal(covmean).imag, 0, atol=1e-3):
             m = np.max(np.abs(covmean.imag))
-            raise ValueError("Imaginary component {}".format(m))
+            raise ValueError(f"Imaginary component {m}")
         covmean = covmean.real
 
     tr_covmean = np.trace(covmean)


### PR DESCRIPTION
This PR replaces the legacy .format() string formatting with modern f-strings in handlers and metrics as requested in issue #2224.