### PR TITLE
feat: support broadcasting picklable objects in idist.broadcast

### DIFF
--- a/ignite/distributed/comp_models/base.py
+++ b/ignite/distributed/comp_models/base.py
@@ -106,29 +106,45 @@ class ComputationModel(metaclass=ABCMeta):
         return cast(int, size.item())
 
     @staticmethod
-    def _encode_input_data(x: torch.Tensor | float | str | Path | None, is_src: bool) -> list[int]:
+    def _input_type_tag(x: torch.Tensor | float | str | Path | Any) -> int:
+        # Which collective the input has to go through. Tags 0-3 are sent as tensors; tag 4 is
+        # anything else, which travels as a pickled object. `broadcast` classifies the input
+        # with this helper in both safe and non-safe mode so the two cannot drift apart.
+        if isinstance(x, torch.Tensor):
+            return 0
+        if isinstance(x, Number):
+            return 1
+        if isinstance(x, str):
+            return 2
+        if isinstance(x, Path):
+            # Keep a distinct tag so non-source ranks in safe mode can reconstruct
+            # Path placeholders and return Path values rather than strings.
+            return 3
+        return 4
+
+    @staticmethod
+    def _encode_input_data(x: torch.Tensor | float | str | Path | Any, is_src: bool) -> list[int]:
         encoded_msg = [-1] * 512
         if not is_src:
             # Discard input type if not source
             return encoded_msg
 
-        if isinstance(x, torch.Tensor):
-            shape = x.shape
-            dtype = str(x.dtype)
-            msg = [0, len(shape), *shape, len(dtype), *list(bytearray(dtype, "utf-8"))]
+        tag = ComputationModel._input_type_tag(x)
+        if tag == 0:
+            shape = cast(torch.Tensor, x).shape
+            dtype = str(cast(torch.Tensor, x).dtype)
+            msg = [tag, len(shape), *shape, len(dtype), *list(bytearray(dtype, "utf-8"))]
             encoded_msg[: len(msg)] = msg
-        elif isinstance(x, Number):
-            encoded_msg[0] = 1
-        elif isinstance(x, str):
-            encoded_msg[0] = 2
-        elif isinstance(x, Path):
-            # Keep a distinct tag so non-source ranks in safe mode can reconstruct
-            # Path placeholders and return Path values rather than strings.
-            encoded_msg[0] = 3
+        else:
+            # Nothing else needs encoding: the remaining tags either have a fixed placeholder
+            # or, for tag 4, carry their own type inside the pickled payload.
+            encoded_msg[0] = tag
         return encoded_msg
 
     @staticmethod
-    def _decode_as_placeholder(encoded_msg: list[int], device: torch.device) -> torch.Tensor | float | str | Path:
+    def _decode_as_placeholder(
+        encoded_msg: list[int], device: torch.device
+    ) -> torch.Tensor | float | str | Path | None:
         if encoded_msg[0] == 0:
             len_shape = encoded_msg[1]
             le = 2 + len_shape
@@ -143,22 +159,29 @@ class ComputationModel(metaclass=ABCMeta):
             return ""
         elif encoded_msg[0] == 3:
             return Path("")
+        elif encoded_msg[0] == 4:
+            # Object collectives receive into a plain None slot, no placeholder needed.
+            return None
         else:
             raise RuntimeError(f"Internal error: unhandled dtype {encoded_msg[0]}, encoded_msg={encoded_msg}")
 
     def _setup_placeholder(
-        self, x: torch.Tensor | float | str | Path | None, device: torch.device, is_src: bool
-    ) -> torch.Tensor | float | str | Path:
+        self, x: torch.Tensor | float | str | Path | Any, device: torch.device, is_src: bool
+    ) -> tuple[torch.Tensor | float | str | Path | Any, int]:
+        # Returns the placeholder along with the input type tag agreed on by every rank. The
+        # tag is what callers must branch on: once objects are in play a non-source rank
+        # cannot tell from its own value alone which collective the source is about to call.
         encoded_msg_per_rank = self._encode_input_data(x, is_src)
         encoded_msg_all_ranks = self._do_all_reduce(torch.tensor(encoded_msg_per_rank, device=device), op="MAX")
+
+        encoded_msg = encoded_msg_all_ranks.cpu().tolist()
 
         if is_src:
             if x is None:
                 raise RuntimeError("Internal error, x is None. Please, file an issue if you encounter this error.")
-            return x
+            return x, encoded_msg[0]
 
-        encoded_msg = encoded_msg_all_ranks.cpu().tolist()
-        return self._decode_as_placeholder(encoded_msg, device)
+        return self._decode_as_placeholder(encoded_msg, device), encoded_msg[0]
 
     @staticmethod
     def _decode_str(xs: torch.Tensor) -> list[str]:
@@ -240,11 +263,8 @@ class ComputationModel(metaclass=ABCMeta):
             raise ValueError("Argument ranks should be list of int")
 
     def broadcast(
-        self, tensor: torch.Tensor | float | str | Path | None, src: int = 0, safe_mode: bool = False
-    ) -> torch.Tensor | float | str | Path:
-        if not (isinstance(tensor, (torch.Tensor, Number, str, Path)) or tensor is None):
-            raise TypeError(f"Unhandled input type {type(tensor)}")
-
+        self, tensor: torch.Tensor | float | str | Path | Any, src: int = 0, safe_mode: bool = False
+    ) -> torch.Tensor | float | str | Path | Any:
         rank = self.get_rank()
         if tensor is None:
             if rank == src:
@@ -256,7 +276,17 @@ class ComputationModel(metaclass=ABCMeta):
         tensor_to_number = tensor_to_str = tensor_to_path = False
 
         if safe_mode:
-            tensor = self._setup_placeholder(tensor, device, rank == src)
+            tensor, input_type = self._setup_placeholder(tensor, device, rank == src)
+        else:
+            # Without safe mode there is no negotiation: every rank is required to pass the
+            # same input type, so each one can classify its own value and reach the same
+            # collective.
+            input_type = self._input_type_tag(tensor)
+
+        if input_type == 4:
+            # Picklable object: the payload carries its own type, so no placeholder is
+            # involved and `tensor` is legitimately None on non-source ranks.
+            return self._do_broadcast_object_list(tensor, src=src)
 
         if tensor is None:
             raise RuntimeError("Internal error, tensor is None. Please, file an issue if you encounter this error.")
@@ -301,6 +331,10 @@ class ComputationModel(metaclass=ABCMeta):
 
     @abstractmethod
     def _do_broadcast(self, tensor: torch.Tensor, src: int) -> torch.Tensor:
+        pass
+
+    @abstractmethod
+    def _do_broadcast_object_list(self, tensor: Any, src: int) -> Any:
         pass
 
     @abstractmethod
@@ -384,8 +418,8 @@ class _SerialModel(ComputationModel):
         return cast(list[float] | list[str] | list[Any], [tensor])
 
     def broadcast(
-        self, tensor: torch.Tensor | float | str | Path | None, src: int = 0, safe_mode: bool = False
-    ) -> torch.Tensor | float | str | Path:
+        self, tensor: torch.Tensor | float | str | Path | Any, src: int = 0, safe_mode: bool = False
+    ) -> torch.Tensor | float | str | Path | Any:
         if tensor is None:
             raise ValueError("Argument tensor should not be None")
         return tensor
@@ -403,6 +437,9 @@ class _SerialModel(ComputationModel):
         return ranks
 
     def _do_broadcast(self, tensor: torch.Tensor, src: int) -> torch.Tensor:
+        return tensor
+
+    def _do_broadcast_object_list(self, tensor: Any, src: int) -> Any:
         return tensor
 
     def barrier(self) -> None:

--- a/ignite/distributed/comp_models/horovod.py
+++ b/ignite/distributed/comp_models/horovod.py
@@ -232,6 +232,9 @@ if has_hvd_support:
         def _do_broadcast(self, tensor: torch.Tensor, src: int) -> torch.Tensor:
             return hvd.broadcast(tensor, root_rank=src)
 
+        def _do_broadcast_object_list(self, tensor: Any, src: int) -> Any:
+            return hvd.broadcast_object(tensor, root_rank=src)
+
         def barrier(self) -> None:
             # https://github.com/horovod/horovod/issues/159#issuecomment-424834603
             # hvd.allreduce(torch.tensor(0, device=self.device()), name="barrier")

--- a/ignite/distributed/comp_models/native.py
+++ b/ignite/distributed/comp_models/native.py
@@ -498,6 +498,11 @@ if has_native_dist_support:
             dist.broadcast(tensor, src=src)
             return tensor
 
+        def _do_broadcast_object_list(self, tensor: Any, src: int) -> Any:
+            object_list = [tensor]
+            dist.broadcast_object_list(object_list, src=src, device=self.device())
+            return object_list[0]
+
         def barrier(self) -> None:
             dist.barrier()
 

--- a/ignite/distributed/comp_models/xla.py
+++ b/ignite/distributed/comp_models/xla.py
@@ -166,6 +166,9 @@ if has_xla_support:
         def _do_new_group(self, ranks: list[int], **kwargs: Any) -> Any:
             return [ranks]
 
+        def _do_broadcast_object_list(self, tensor: Any, src: int) -> Any:
+            raise NotImplementedError("broadcast on object is not implemented for xla")
+
         def _do_broadcast(self, tensor: torch.Tensor, src: int) -> torch.Tensor:
             # from https://github.com/jysohn23/xla/blob/model-parallel-colab/Gather_Scatter_Broadcast_PyTorch_XLA.ipynb
             if src != self.get_rank():

--- a/ignite/distributed/utils.py
+++ b/ignite/distributed/utils.py
@@ -413,15 +413,22 @@ def all_gather(
     """Helper method to perform all gather operation.
 
     Args:
-        tensor: tensor or number or str to collect across participating processes. If tensor, it should have the
-            same shape across processes.
+        tensor: tensor, number, str or any picklable object to collect across participating processes.
+            If tensor, it should have the same shape across processes. Objects other than tensor, number
+            and str are collected with an object collective, which is not available on the ``xla`` backend.
         group: list of integer or the process group for each backend. If None, the default process group will be used.
 
     Returns:
         If input is a tensor, returns a torch.Tensor of shape ``(world_size * tensor.shape[0], tensor.shape[1], ...)``.
-        If input is a number, a torch.Tensor of shape ``(world_size, )`` is returned and finally a list of strings
-        is returned if input is a string. If current process does not belong to `group`, the very ``tensor`` is
-        returned.
+        If input is a number, a torch.Tensor of shape ``(world_size, )`` is returned, a list of strings is returned
+        if input is a string, and a list of objects of length ``world_size`` for any other picklable input.
+        If current process does not belong to `group`, the very ``tensor`` is returned.
+
+    .. warning::
+
+        Tensors nested inside a gathered object are pickled together with their device, so on the
+        receiving processes they point at the sending process' device. Move them yourself if the
+        result has to live on the local device.
 
     .. versionchanged:: 0.4.11
         added ``group``
@@ -433,12 +440,14 @@ def all_gather(
 
 
 def broadcast(
-    tensor: torch.Tensor | float | str | Path | None, src: int = 0, safe_mode: bool = False
-) -> torch.Tensor | float | str | Path:
+    tensor: torch.Tensor | float | str | Path | Any, src: int = 0, safe_mode: bool = False
+) -> torch.Tensor | float | str | Path | Any:
     """Helper method to perform broadcast operation.
 
     Args:
-        tensor: tensor, number, str or pathlib.Path to broadcast to participating processes.
+        tensor: tensor, number, str, pathlib.Path or any picklable object to broadcast to participating
+            processes. Objects other than tensor, number, str and pathlib.Path are sent with an object
+            collective, which is not available on the ``xla`` backend.
             Make sure to respect data type of torch tensor input for all processes, otherwise execution will crash.
             Can use None for non-source data with ``safe_mode=True``.
         src: source rank. Default, 0.
@@ -448,7 +457,13 @@ def broadcast(
             collectives before the broadcast, making it slower than without using this mode. Default, False.
 
     Returns:
-        torch.Tensor, string, pathlib.Path or number
+        torch.Tensor, string, pathlib.Path, number or any picklable object
+
+    .. warning::
+
+        Tensors nested inside a broadcast object are pickled together with their device, so on the
+        receiving processes they point at the source process' device. Move them yourself if the
+        result has to live on the local device.
 
     Examples:
         .. code-block:: python
@@ -481,10 +496,18 @@ def broadcast(
             y = idist.broadcast(y, src=0, safe_mode=True)
             assert isinstance(y, torch.Tensor)
 
+            # Broadcast a picklable object from rank 0, other ranks pass None
+            d = {"loss": 1.23, "counts": [1, 2, 3]} if idist.get_rank() == 0 else None
+            d = idist.broadcast(d, src=0, safe_mode=True)
+            # >>> d = {"loss": 1.23, "counts": [1, 2, 3]}
+
     .. versionadded:: 0.4.2
 
     .. versionchanged:: 0.4.5
         added ``safe_mode``
+
+    .. versionchanged:: 0.6.0
+        added support for any picklable object
     """
     if _need_to_sync and isinstance(_model, _SerialModel):
         sync(temporary=True)

--- a/tests/ignite/distributed/utils/__init__.py
+++ b/tests/ignite/distributed/utils/__init__.py
@@ -388,8 +388,22 @@ def _test_distrib_broadcast(device):
     _test(t, 123.4, safe_mode=True)
 
     if idist.get_world_size() > 1:
-        with pytest.raises(TypeError, match=r"Unhandled input type"):
-            idist.broadcast([0, 1, 2], src=0)
+        # Picklable objects go through an object collective, which xla does not provide.
+        if idist.backend() == "xla-tpu":
+            with pytest.raises(NotImplementedError, match=r"broadcast on object is not implemented for xla"):
+                idist.broadcast([0, 1, 2], src=0)
+        else:
+            _test([0, 1, 2], [-1, -1, -1], safe_mode=False)
+            _test([0, 1, 2], None, safe_mode=True)
+            _test({"a": 1, "b": [2.0, 3.0]}, None, safe_mode=True)
+
+            # containers holding tensors keep their structure and leaf types
+            for src in range(ws):
+                data = {"t": torch.tensor([1.0, 2.0]), "n": 3} if rank == src else None
+                res = idist.broadcast(data, src=src, safe_mode=True)
+                assert isinstance(res, dict)
+                assert (res["t"] == torch.tensor([1.0, 2.0])).all()
+                assert isinstance(res["n"], int) and res["n"] == 3
 
     if idist.get_world_size() > 1:
         msg = "Source data can not be None" if rank == 0 else "Argument safe_mode should be True"


### PR DESCRIPTION
Related to #1757, prerequisite for #3789. Follows @vfdev-5's suggestion in https://github.com/pytorch/ignite/pull/3789#issuecomment-5515841049.

Description:

`idist.broadcast` only handles `torch.Tensor`, numbers, `str` and `pathlib.Path`, and raises `TypeError` otherwise, while `idist.all_gather` already falls back to an object collective. This gives `broadcast` the same capability via `torch.distributed.broadcast_object_list`.

- `_do_broadcast_object_list` on `ComputationModel`: `dist.broadcast_object_list` for native, `hvd.broadcast_object` for horovod, `NotImplementedError` for xla (as with `_do_all_gather_object`)
- `ComputationModel.broadcast` dispatches to it for any input that is not a tensor/number/str/Path
- `Any` in the `idist.broadcast` typehint; `broadcast` and `all_gather` docstrings now document picklable-object support

`_setup_placeholder` now also returns the input type tag agreed on by every rank. An object input has no meaningful placeholder, so a non-source rank cannot decide from its own value which collective the source is about to call — it has to branch on the negotiated tag instead. Details in the code comments.

Behaviour change: `broadcast` no longer raises `TypeError("Unhandled input type")`. The test asserting that now asserts a successful object broadcast, except on xla where it asserts `NotImplementedError`.

Check list:

- [x] New tests are added (if a new feature is added)
- [x] New doc strings: description and/or example code are in RST format
- [x] Documentation is updated (if required)
