### PR TITLE
fix(handlers): EMAHandler warmup now respects custom name parameter

### DIFF
--- a/ignite/handlers/ema_handler.py
+++ b/ignite/handlers/ema_handler.py
@@ -248,7 +248,7 @@ class EMAHandler:
             setattr(engine.state, name, self.momentum)
 
         if self._momentum_lambda_obj is not None:
-            self.momentum_scheduler = LambdaStateScheduler(self._momentum_lambda_obj, param_name="ema_momentum")
+            self.momentum_scheduler = LambdaStateScheduler(self._momentum_lambda_obj, param_name=name)
 
             # first update the momentum and then update the EMA model
             self.momentum_scheduler.attach(engine, event)


### PR DESCRIPTION
When `EMAHandler.attach()` is called with a custom `name` parameter (e.g. `"gen_ema_momentum"` for a GAN generator), the momentum warmup scheduler is hardcoded to write to `engine.state.ema_momentum` instead of `engine.state.{name}`.

`_update_ema_model` reads momentum from `engine.state.{name}` (line 192), so with a custom name the scheduler updates the wrong attribute and warmup has no effect -- the EMA model always uses the initial (un-warmed-up) momentum.

The docstring example at line 135 even documents using custom names like `"gen_ema_momentum"` and `"dis_ema_momentum"` for GAN training -- if warmup were used with those handlers, it would silently break.

## Fix

One line: change `param_name="ema_momentum"` to `param_name=name` on line 251.
