### PR TITLE
Keep finite Python numbers from terminating training

### DIFF
--- a/ignite/handlers/terminate_on_nan.py
+++ b/ignite/handlers/terminate_on_nan.py
@@ -41,7 +41,8 @@ class TerminateOnNan:
 
         def raise_error(x: float | torch.Tensor) -> None:
             if isinstance(x, numbers.Number):
-                x = torch.tensor(x)
+                dtype = torch.float64 if isinstance(x, numbers.Real) else torch.complex128
+                x = torch.tensor(x, dtype=dtype)
 
             if isinstance(x, torch.Tensor) and not bool(torch.isfinite(x).all()):
                 raise RuntimeError("Infinite or NaN tensor found.")

--- a/tests/ignite/handlers/test_terminate_on_nan.py
+++ b/tests/ignite/handlers/test_terminate_on_nan.py
@@ -10,6 +10,10 @@ from ignite.handlers import TerminateOnNan
     "state_output,should_terminate",
     [
         (1.0, False),
+        (1e100, False),
+        (-1e100, False),
+        (complex(1e100, 1e100), False),
+        ({"loss": 1e100}, False),
         (torch.tensor(123.45), False),
         (torch.asin(torch.tensor([1.0, 2.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])), True),
         (torch.asin(torch.randn(4, 4)), True),


### PR DESCRIPTION
Description:

Calling TerminateOnNan with a finite Python value such as `1e100` terminates the engine. The implicit float32 tensor conversion overflows before the finiteness check. Nested outputs and large finite complex values are affected as well.

Convert real Python numbers to float64 and complex numbers to complex128 before checking them. Tensor inputs retain their existing dtype.

Validation: 4 regression failures before the fix; all 18 tests in `tests/ignite/handlers/test_terminate_on_nan.py` pass on CPU afterward. Ruff lint and format checks pass for changed files.

Check list:

- [x] Regression tests added.
- [x] No public API or documentation changes required.

Implementation and validation were performed with AI assistance.

Fixes #3837.
