### PR TITLE
Preserve scalar precision in GeometricAverage

### DIFF
--- a/ignite/metrics/accumulation.py
+++ b/ignite/metrics/accumulation.py
@@ -298,7 +298,7 @@ class GeometricAverage(VariableAccumulation):
     ):
         def _geom_op(a: torch.Tensor, x: float | torch.Tensor) -> torch.Tensor:
             if not isinstance(x, torch.Tensor):
-                x = torch.tensor(x)
+                x = torch.tensor(x, dtype=a.dtype, device=a.device)
             x = torch.log(x)
             if x.ndim > 1:
                 x = x.sum(dim=0)

--- a/tests/ignite/metrics/test_accumulation.py
+++ b/tests/ignite/metrics/test_accumulation.py
@@ -520,3 +520,12 @@ def test_multinode_distrib_nccl_gpu(distributed_context_multi_node_nccl):
     _test_distrib_geom_average(device)
     _test_distrib_integration(device)
     _test_distrib_accumulator_device(device)
+
+
+@pytest.mark.parametrize("value", [1e-100, 1e100, 1.234567891234567])
+def test_geometric_average_preserves_python_scalar_precision(value):
+    scalar_metric = GeometricAverage()
+    tensor_metric = GeometricAverage()
+    scalar_metric.update(value)
+    tensor_metric.update(torch.tensor(value, dtype=torch.float64))
+    assert scalar_metric.compute() == pytest.approx(tensor_metric.compute(), rel=1e-12, abs=0)


### PR DESCRIPTION
Description:

`GeometricAverage.update(1e-100)` produces zero and `update(1e100)` produces infinity, even though its float64 accumulator can represent both. A scalar and an equivalent float64 tensor also disagree at ordinary magnitudes.

Construct scalar tensors on the accumulator device with its dtype before taking the logarithm.

Validation: 3 regression failures before the fix; `pytest tests/ignite/metrics/test_accumulation.py -m "not distributed" -q`: 12 passed, 5 skipped, 3 deselected on CPU. Distributed and GPU tests were not run. Ruff lint and format checks pass for changed files.

Check list:

- [x] Regression tests added.
- [x] No public API or documentation changes required.

Implementation and validation were performed with AI assistance.

Fixes #3839.
