### PR TITLE
Use monotonic time for training time limits

### DIFF
--- a/ignite/handlers/time_limit.py
+++ b/ignite/handlers/time_limit.py
@@ -34,11 +34,11 @@ class TimeLimit:
             raise ValueError("Argument limit_sec should be a positive integer.")
 
         self.limit_sec = limit_sec
-        self.start_time = time.time()
+        self.start_time = time.monotonic()
         self.logger = setup_logger(__name__ + "." + self.__class__.__name__)
 
     def __call__(self, engine: Engine) -> None:
-        elapsed_time = time.time() - self.start_time
+        elapsed_time = time.monotonic() - self.start_time
         if elapsed_time > self.limit_sec:
             self.logger.info(f"Reached the time limit: {self.limit_sec} sec. Stop training")
             engine.terminate()

--- a/tests/ignite/handlers/test_time_limit.py
+++ b/tests/ignite/handlers/test_time_limit.py
@@ -1,9 +1,28 @@
 import time
+from types import SimpleNamespace
 
 import pytest
 
 from ignite.engine import Engine, Events
 from ignite.handlers import TimeLimit
+
+
+@pytest.mark.parametrize("wall_elapsed, elapsed, terminated", [(1000, 2, False), (-1000, 11, True)])
+def test_time_limit_ignores_wall_clock_adjustments(monkeypatch, wall_elapsed, elapsed, terminated):
+    import ignite.handlers.time_limit as module
+
+    clocks = {"wall": 10000, "elapsed": 20}
+    monkeypatch.setattr(
+        module, "time", SimpleNamespace(time=lambda: clocks["wall"], monotonic=lambda: clocks["elapsed"])
+    )
+    handler = TimeLimit(limit_sec=10)
+    trainer = Engine(lambda engine, batch: batch)
+    clocks["wall"] += wall_elapsed
+    clocks["elapsed"] += elapsed
+
+    handler(trainer)
+
+    assert trainer.should_terminate is terminated
 
 
 def test_arg_validation():


### PR DESCRIPTION
Description:

TimeLimit measures elapsed time using the wall clock. A clock synchronization or manual clock change can prematurely stop training or extend a configured training limit.

Use time.monotonic for the start and elapsed measurements. Add engine-level regressions for forward and backward wall-clock changes.

Validation: 2 regression failures before the fix; all 5 tests in `tests/ignite/handlers/test_time_limit.py` pass on CPU afterward. Ruff lint and format checks pass for changed files.

Check list:

- [x] Regression tests added.
- [x] No public API or documentation changes required.

Implementation and validation were performed with AI assistance.

Fixes #3841.
